### PR TITLE
Feature/chooseable camera frustrum

### DIFF
--- a/src/lib/cameras/OrthographicCamera.svelte
+++ b/src/lib/cameras/OrthographicCamera.svelte
@@ -43,10 +43,10 @@
   $: if (useCamera) setCamera(camera)
 
   $: {
-    camera.left = $size.width / -2
-    camera.right = $size.width / 2
-    camera.top = $size.height / 2
-    camera.bottom = $size.height / -2
+    camera.left = left || $size.width / -2
+    camera.right = right || $size.width / 2
+    camera.top = top || $size.height / 2
+    camera.bottom = bottom || $size.height / -2
     camera.updateProjectionMatrix()
     invalidate('OrthographicCamera: onResize')
   }
@@ -55,10 +55,6 @@
     if (near !== undefined) camera.near = near
     if (far !== undefined) camera.far = far
     if (zoom !== undefined) camera.zoom = zoom
-    if (left !== undefined) camera.left = left
-    if (right !== undefined) camera.right = right
-    if (bottom !== undefined) camera.bottom = bottom
-    if (top !== undefined) camera.top = top
     camera.updateProjectionMatrix()
     invalidate('OrthographicCamera: props changed')
   }

--- a/src/lib/cameras/OrthographicCamera.svelte
+++ b/src/lib/cameras/OrthographicCamera.svelte
@@ -23,15 +23,19 @@
   export let near: OrthographicCameraProperties['near'] = undefined
   export let far: OrthographicCameraProperties['far'] = undefined
   export let zoom: OrthographicCameraProperties['zoom'] = undefined
+  export let left: OrthographicCameraProperties['left'] = undefined
+  export let right: OrthographicCameraProperties['right'] = undefined
+  export let top: OrthographicCameraProperties['top'] = undefined
+  export let bottom: OrthographicCameraProperties['bottom'] = undefined
 
   const { size, invalidate } = useThrelte()
   const { setCamera } = useThrelteRoot()
 
   export const camera = new ThreeOrthographicCamera(
-    $size.width / -2,
-    $size.width / 2,
-    $size.height / 2,
-    $size.height / -2,
+    left || $size.width / -2,
+    right || $size.width / 2,
+    top || $size.height / 2,
+    bottom || $size.height / -2,
     near,
     far
   )
@@ -51,6 +55,10 @@
     if (near !== undefined) camera.near = near
     if (far !== undefined) camera.far = far
     if (zoom !== undefined) camera.zoom = zoom
+    if (left !== undefined) camera.left = left
+    if (right !== undefined) camera.right = right
+    if (bottom !== undefined) camera.bottom = bottom
+    if (top !== undefined) camera.top = top
     camera.updateProjectionMatrix()
     invalidate('OrthographicCamera: props changed')
   }

--- a/src/lib/types/components.ts
+++ b/src/lib/types/components.ts
@@ -73,6 +73,10 @@ export type OrthographicCameraProperties = Omit<CameraInstanceProperties, 'camer
   near?: number
   far?: number
   zoom?: number
+  left?: number
+  right?: number
+  top?: number
+  bottom?: number
 }
 
 export type PerspectiveCameraProperties = Omit<CameraInstanceProperties, 'camera'> & {


### PR DESCRIPTION
related to #34

providing frustrum props to set a custom view. Not using them means resizing to parent Container size as default

    <OrthographicCamera
      position={{ z: 50, x: 50, y: 50 }}
      lookAt={{ x: 0, y: 0, z: 0 }}
      left={-50}
      right={50}
      top={50}
      bottom={-50}
    />