### PR TITLE
Stricter click events

### DIFF
--- a/.changeset/little-shirts-play.md
+++ b/.changeset/little-shirts-play.md
@@ -1,0 +1,7 @@
+---
+'@threlte/core': patch
+---
+
+Validate click events to make sure the last pointerdown event hit the same instance as the click
+event did. This heuristic more closely resembles how the DOM works, and prevents accidental clicks
+while e.g. using OrbitControls or otherwise dragging on the canvas.

--- a/.changeset/ten-garlics-repair.md
+++ b/.changeset/ten-garlics-repair.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': patch
+---
+
+Add click event to interactivity example

--- a/apps/docs/src/routes/concepts/interactivity.md
+++ b/apps/docs/src/routes/concepts/interactivity.md
@@ -4,7 +4,7 @@ title: Interactivity
 
 # Interactivity
 
-[Open the interactivity example in a Svelte REPL](https://svelte.dev/repl/c2b74dcf88ec4b4681b664e202c54274?version=3.46.2)
+[Open the interactivity example in a Svelte REPL](https://svelte.dev/repl/612bfb61f8f84e299fe5083e4767b1e1?version=3.46.2)
 
 Listen to events of a `<Mesh>` and a `<MeshInstance>` as if it would be a regular DOM element:
 

--- a/packages/core/src/lib/lib/interactivity.ts
+++ b/packages/core/src/lib/lib/interactivity.ts
@@ -76,10 +76,13 @@ export const useEventRaycast = (
     setPointerFromEvent(ctx, e)
 
     const closestIntersection = getClosestIntersection(rootCtx, pointer, camera)
-    if (eventType === 'pointerdown') {
-      pointerDownOn = closestIntersection
-        ? { object: closestIntersection.object, instanceId: closestIntersection.instanceId }
-        : null
+    if (eventType === 'pointerdown' && closestIntersection) {
+      // Remember which object was pressed in order to validate the next click event
+      const { object, instanceId } = closestIntersection
+      pointerDownOn = { object, instanceId }
+    } else if (['click', 'pointerup', 'pointerdown'].includes(eventType)) {
+      // Clear pointerDownOn when pointer is released or when pointerdown hits nothing
+      pointerDownOn = null
     }
 
     if (!closestIntersection) return

--- a/packages/core/src/lib/lib/interactivity.ts
+++ b/packages/core/src/lib/lib/interactivity.ts
@@ -1,13 +1,6 @@
 import { onDestroy } from 'svelte'
 import { get } from 'svelte/store'
-import {
-  MOUSE,
-  type Camera,
-  type Event,
-  type Intersection,
-  type Object3D,
-  type Vector2
-} from 'three'
+import type { Camera, Event, Intersection, Object3D, Vector2 } from 'three'
 import type {
   ThrelteContext,
   ThreltePointerEventMap,
@@ -83,7 +76,7 @@ export const useEventRaycast = (
     setPointerFromEvent(ctx, e)
 
     const closestIntersection = getClosestIntersection(rootCtx, pointer, camera)
-    if (eventType === 'pointerdown' && e.button === MOUSE.LEFT) {
+    if (eventType === 'pointerdown') {
       pointerDownOn = closestIntersection
         ? { object: closestIntersection.object, instanceId: closestIntersection.instanceId }
         : null

--- a/packages/core/src/lib/types/types.ts
+++ b/packages/core/src/lib/types/types.ts
@@ -54,6 +54,7 @@ export type ThrelteRootContext = {
   raycastableObjects: Set<Object3D>
   raycaster: Raycaster
   lastIntersection: Intersection<Object3D<Event>> | null
+  lastPressIntersection: Intersection<Object3D<Event>> | null
 }
 
 export type ThrelteContext = {

--- a/packages/core/src/lib/types/types.ts
+++ b/packages/core/src/lib/types/types.ts
@@ -54,7 +54,6 @@ export type ThrelteRootContext = {
   raycastableObjects: Set<Object3D>
   raycaster: Raycaster
   lastIntersection: Intersection<Object3D<Event>> | null
-  lastPressIntersection: Intersection<Object3D<Event>> | null
 }
 
 export type ThrelteContext = {


### PR DESCRIPTION
Validate `click` events to make sure the last `pointerdown` event hit the same instance as the `click` event did. This heuristic more closely resembles how the DOM works, and prevents accidental clicks while e.g. using `OrbitControls` or otherwise dragging on the canvas.