### PR TITLE
Add links to related external docs

### DIFF
--- a/.changeset/rich-wasps-relate.md
+++ b/.changeset/rich-wasps-relate.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': patch
+---
+
+Add links to related external docs

--- a/apps/docs/src/kit-docs/ModuleSummary.svelte
+++ b/apps/docs/src/kit-docs/ModuleSummary.svelte
@@ -10,6 +10,7 @@
 	export let type: string
 	export let needsContext: boolean = false
 	export let divider: 'true' | 'false' = 'true'
+	export let relatedDocs: { name: string; url: string }[] = []
 
 	let importStatement = `import { ${name} } from '@threlte/${from}'`
 
@@ -58,6 +59,18 @@
 			<span>Package</span>
 		</p>
 		<NpmIcon class="col-span-12 992:col-span-10 !p-0" href={packageUrl}>View Package</NpmIcon>
+		{#if relatedDocs.length > 0}
+			<p
+				class="col-span-12 992:col-span-2 !my-0 text-sm 992:text-base !mb-2 992:!mb-0 flex items-center"
+			>
+				<span>Related Docs</span>
+			</p>
+			<div class="col-span-12 992:col-span-10 !p-0">
+				{#each relatedDocs as link}
+					<a href={link.url}>{link.name}</a>
+				{/each}
+			</div>
+		{/if}
 	</div>
 </div>
 

--- a/apps/docs/src/routes/core/ambient-light.md
+++ b/apps/docs/src/routes/core/ambient-light.md
@@ -2,7 +2,7 @@
 title: AmbientLight
 ---
 
-!!!module_summary title=AmbientLight|name=AmbientLight|sourcePath=lights/AmbientLight.svelte|from=core|type=component
+!!!module_summary title=AmbientLight|name=AmbientLight|sourcePath=lights/AmbientLight.svelte|from=core|type=component|relatedDocs={[{name:"three.js AmbientLight reference",url:"https://threejs.org/docs/#api/en/lights/AmbientLight"}]}
 This light globally illuminates all objects in the scene equally.
 This light cannot be used to cast shadows as it does not have a direction.
 !!!

--- a/apps/docs/src/routes/core/audio-instance.md
+++ b/apps/docs/src/routes/core/audio-instance.md
@@ -2,7 +2,7 @@
 title: AudioInstance
 ---
 
-!!!module_summary title=AudioInstance|sourcePath=instances/AudioInstance.svelte|name=AudioInstance|from=core|type=component
+!!!module_summary title=AudioInstance|sourcePath=instances/AudioInstance.svelte|name=AudioInstance|from=core|type=component|relatedDocs={[{name:"three.js Audio reference",url:"https://threejs.org/docs/#api/en/audio/Audio"}]}
 This component lets you use any manually instantiated object that extends `THREE.Audio` in threlte.
 !!!
 

--- a/apps/docs/src/routes/core/audio-listener.md
+++ b/apps/docs/src/routes/core/audio-listener.md
@@ -2,7 +2,7 @@
 title: AudioListener
 ---
 
-!!!module_summary title=AudioListener|sourcePath=audio/AudioListener.svelte|name=AudioListener|from=core|type=component
+!!!module_summary title=AudioListener|sourcePath=audio/AudioListener.svelte|name=AudioListener|from=core|type=component|relatedDocs={[{name:"three.js AudioListener reference",url:"https://threejs.org/docs/#api/en/audio/AudioListener"}]}
 The `<AudioListener>` represents a virtual listener of the all positional and non-positional audio effects in the scene.
 An application usually creates a single `<AudioListener>` component. It is a mandatory component for audio components like `<Audio>` and `<PositionalAudio>`.
 In most cases, the listener component is a child of the camera, so the 3D transformation of the camera represents the 3D transformation of the listener.

--- a/apps/docs/src/routes/core/audio.md
+++ b/apps/docs/src/routes/core/audio.md
@@ -2,7 +2,7 @@
 title: Audio
 ---
 
-!!!module_summary title=Audio|sourcePath=audio/Audio.svelte|name=Audio|from=core|type=component
+!!!module_summary title=Audio|sourcePath=audio/Audio.svelte|name=Audio|from=core|type=component|relatedDocs={[{name:"three.js Audio reference",url:"https://threejs.org/docs/#api/en/audio/Audio"}]}
 Create a non-positional (global) audio object.
 This uses the [Web Audio API](https://developer.mozilla.org/en-US/Web/API/Web_Audio_API).
 

--- a/apps/docs/src/routes/core/camera-instance.md
+++ b/apps/docs/src/routes/core/camera-instance.md
@@ -2,7 +2,7 @@
 title: CameraInstance
 ---
 
-!!!module_summary title=CameraInstance|sourcePath=instances/CameraInstance.svelte|name=CameraInstance|from=core|type=component
+!!!module_summary title=CameraInstance|sourcePath=instances/CameraInstance.svelte|name=CameraInstance|from=core|type=component|relatedDocs={[{name:"three.js Camera reference",url:"https://threejs.org/docs/#api/en/cameras/Camera"}]}
 This component lets you use any manually instantiated object that extends `THREE.Camera` in threlte.
 !!!
 

--- a/apps/docs/src/routes/core/directional-light.md
+++ b/apps/docs/src/routes/core/directional-light.md
@@ -2,7 +2,7 @@
 title: DirectionalLight
 ---
 
-!!!module_summary title=DirectionalLight|sourcePath=lights/DirectionalLight.svelte|name=DirectionalLight|from=core|type=component
+!!!module_summary title=DirectionalLight|sourcePath=lights/DirectionalLight.svelte|name=DirectionalLight|from=core|type=component|relatedDocs={[{name:"three.js DirectionalLight reference",url:"https://threejs.org/docs/#api/en/lights/DirectionalLight"}]}
 The `<DirectionalLight>` component accepts a property `target` which acts like the property `lookAt`: Provide either a `Position` (`{ x: 5, z: 3 }`) or another Object3D instance. In the latter case the `DirectionalLight` will track the provided object. This is especially useful if you want to move the area that the shadow is applied to.
 
 See the three.js [DirectionalLight documentation](https://threejs.org/index.html?q=direct#api/en/lights/DirectionalLight) for details.

--- a/apps/docs/src/routes/core/fog-exp-2.md
+++ b/apps/docs/src/routes/core/fog-exp-2.md
@@ -2,7 +2,7 @@
 title: FogExp2
 ---
 
-!!!module_summary title=FogExp2|sourcePath=misc/FogExp2.svelte|name=FogExp2|from=core|type=component
+!!!module_summary title=FogExp2|sourcePath=misc/FogExp2.svelte|name=FogExp2|from=core|type=component|relatedDocs={[{name:"three.js FogExp2 reference",url:"https://threejs.org/docs/api/en/scenes/FogExp2.html"}]}
 A `<FogExp2>` adds itself to the scene directly. The placement in the hierarchy is therefore unimportant as long as it's inside the `<Canvas>` component.
 !!!
 

--- a/apps/docs/src/routes/core/fog.md
+++ b/apps/docs/src/routes/core/fog.md
@@ -2,7 +2,7 @@
 title: Fog
 ---
 
-!!!module_summary title=Fog|sourcePath=misc/Fog.svelte|name=Fog|from=core|type=component
+!!!module_summary title=Fog|sourcePath=misc/Fog.svelte|name=Fog|from=core|type=component|relatedDocs={[{name:"three.js Fog reference",url:"https://threejs.org/docs/api/en/scenes/Fog.html"}]}
 A `<Fog>` adds itself to the scene directly. The placement in the hierarchy is therefore unimportant as long as it's inside the `<Canvas>` component.
 !!!
 

--- a/apps/docs/src/routes/core/group.md
+++ b/apps/docs/src/routes/core/group.md
@@ -2,7 +2,7 @@
 title: Group
 ---
 
-!!!module_summary title=Group|sourcePath=objects/Group.svelte|name=Group|from=core|type=component
+!!!module_summary title=Group|sourcePath=objects/Group.svelte|name=Group|from=core|type=component|relatedDocs={[{name:"three.js Group reference",url:"https://threejs.org/docs/#api/en/objects/Group"}]}
 This is almost identical to an [`<Object3D>`](/core/object3d). Its purpose is to make working with groups of objects syntactically clearer.
 !!!
 

--- a/apps/docs/src/routes/core/hemisphere-light.md
+++ b/apps/docs/src/routes/core/hemisphere-light.md
@@ -2,7 +2,7 @@
 title: HemisphereLight
 ---
 
-!!!module_summary title=HemisphereLight|sourcePath=lights/HemisphereLight.svelte|name=HemisphereLight|from=core|type=component
+!!!module_summary title=HemisphereLight|sourcePath=lights/HemisphereLight.svelte|name=HemisphereLight|from=core|type=component|relatedDocs={[{name:"three.js HemisphereLight reference",url:"https://threejs.org/docs/#api/en/lights/HemisphereLight"}]}
 A light source positioned directly above the scene, with color fading from the sky color to the ground color.
 This light cannot be used to cast shadows.
 !!!

--- a/apps/docs/src/routes/core/instance.md
+++ b/apps/docs/src/routes/core/instance.md
@@ -2,7 +2,7 @@
 title: Instance
 ---
 
-!!!module_summary title=Instance|sourcePath=objects/Instance.svelte|name=Instance|from=core|type=component
+!!!module_summary title=Instance|sourcePath=objects/Instance.svelte|name=Instance|from=core|type=component|relatedDocs={[{name:"three.js InstancedMesh reference",url:"https://threejs.org/docs/#api/en/objects/InstancedMesh"}]}
 Every `<Instance>` component nested in an [`<InstancedMesh>`](/core/instanced-mesh) component resembles one instance. An `<Instance>` can therefore only be used as a child component to a `<InstancedMesh>` component. The `<Instance>` component can be transformed and colorized individually:
 
 ```svelte

--- a/apps/docs/src/routes/core/instanced-mesh.md
+++ b/apps/docs/src/routes/core/instanced-mesh.md
@@ -6,7 +6,7 @@ title: InstancedMesh
 import Wrapper from '$examples/instanced-mesh/Wrapper.svelte'
 </script>
 
-!!!module_summary title=InstancedMesh|sourcePath=objects/InstancedMesh.svelte|name=InstancedMesh|from=core|type=component|divider=false
+!!!module_summary title=InstancedMesh|sourcePath=objects/InstancedMesh.svelte|name=InstancedMesh|from=core|type=component|divider=false|relatedDocs={[{name:"three.js InstancedMesh reference",url:"https://threejs.org/docs/#api/en/objects/InstancedMesh"}]}
 The `<InstancedMesh>` is a special version of [`<Mesh>`](/core/mesh) with instanced rendering support. Use `<InstancedMesh>` if you have to render a large number of objects with the same geometry and material but with different world transformations and colors. The usage of `<InstancedMesh>` will help you to reduce the number of draw calls and thus improve the overall rendering performance in your application.
 
 <ExampleWrapper>

--- a/apps/docs/src/routes/core/layers.md
+++ b/apps/docs/src/routes/core/layers.md
@@ -2,7 +2,7 @@
 title: Layers
 ---
 
-!!!module_summary title=Layers|sourcePath=misc/Layers.svelte|name=Layers|from=core|type=component
+!!!module_summary title=Layers|sourcePath=misc/Layers.svelte|name=Layers|from=core|type=component|relatedDocs={[{name:"three.js Layers reference",url:"https://threejs.org/docs/api/en/core/Layers.html"}]}
 [Layers](https://threejs.org/#api/en/core/Layers) are one of many ways to manage the visibility of objects in three.js.
 The `<Layers>` component assigns all child components the layer memberships you pass to it. Any object that is a member of the same layers the camera is on, is visible.
 !!!

--- a/apps/docs/src/routes/core/light-instance.md
+++ b/apps/docs/src/routes/core/light-instance.md
@@ -2,7 +2,7 @@
 title: LightInstance
 ---
 
-!!!module_summary title=LightInstance|sourcePath=instances/LightInstance.svelte|name=LightInstance|from=core|type=component
+!!!module_summary title=LightInstance|sourcePath=instances/LightInstance.svelte|name=LightInstance|from=core|type=component|relatedDocs={[{name:"three.js Light reference",url:"https://threejs.org/docs/#api/en/lights/Light"}]}
 This component lets you use any manually instantiated object that extends `THREE.Light` in threlte.
 !!!
 

--- a/apps/docs/src/routes/core/line-instance.md
+++ b/apps/docs/src/routes/core/line-instance.md
@@ -2,7 +2,7 @@
 title: LineInstance
 ---
 
-!!!module_summary title=LineInstance|sourcePath=instances/LineInstance.svelte|name=LineInstance|from=core|type=component
+!!!module_summary title=LineInstance|sourcePath=instances/LineInstance.svelte|name=LineInstance|from=core|type=component|relatedDocs={[{name:"three.js Line reference",url:"https://threejs.org/docs/#api/en/objects/Line"}]}
 This component lets you use any manually instantiated object that extends `THREE.Line` in threlte.
 !!!
 

--- a/apps/docs/src/routes/core/line-segments.md
+++ b/apps/docs/src/routes/core/line-segments.md
@@ -6,7 +6,7 @@ title: LineSegments
 import Wrapper from '$examples/line-segments/Wrapper.svelte'
 </script>
 
-!!!module_summary title=LineSegments|sourcePath=objects/LineSegments.svelte|name=LineSegments|from=core|type=component
+!!!module_summary title=LineSegments|sourcePath=objects/LineSegments.svelte|name=LineSegments|from=core|type=component|relatedDocs={[{name:"three.js LineSegments reference",url:"https://threejs.org/docs/#api/en/objects/LineSegments"}]}
 
 Draw lines using `THREE.LineSegments`.
 

--- a/apps/docs/src/routes/core/line.md
+++ b/apps/docs/src/routes/core/line.md
@@ -6,7 +6,7 @@ title: Line
 import Wrapper from '$examples/line/Wrapper.svelte'
 </script>
 
-!!!module_summary title=Line|sourcePath=objects/Line.svelte|name=Line|from=core|type=component
+!!!module_summary title=Line|sourcePath=objects/Line.svelte|name=Line|from=core|type=component|relatedDocs={[{name:"three.js Line reference",url:"https://threejs.org/docs/#api/en/objects/Line"}]}
 
 Draw Lines using `THREE.Line`. Due to limitations of the OpenGL Core Profile with the `THREE.WebGLRenderer` on most platforms the line width will always be `1` regardless of the value `lineWidth` of the used Material.
 

--- a/apps/docs/src/routes/core/mesh-instance.md
+++ b/apps/docs/src/routes/core/mesh-instance.md
@@ -2,7 +2,7 @@
 title: MeshInstance
 ---
 
-!!!module_summary title=MeshInstance|sourcePath=instances/MeshInstance.svelte|name=MeshInstance|from=core|type=component
+!!!module_summary title=MeshInstance|sourcePath=instances/MeshInstance.svelte|name=MeshInstance|from=core|type=component|relatedDocs={[{name:"three.js Mesh reference",url:"https://threejs.org/docs/#api/en/objects/Mesh"}]}
 This component lets you use any manually instantiated object that extends `THREE.Mesh` in threlte.
 !!!
 

--- a/apps/docs/src/routes/core/mesh.md
+++ b/apps/docs/src/routes/core/mesh.md
@@ -2,7 +2,7 @@
 title: Mesh
 ---
 
-!!!module_summary title=Mesh|sourcePath=objects/Mesh.svelte|name=Mesh|from=core|type=component
+!!!module_summary title=Mesh|sourcePath=objects/Mesh.svelte|name=Mesh|from=core|type=component|relatedDocs={[{name:"three.js Mesh reference",url:"https://threejs.org/docs/#api/en/objects/Mesh"}]}
 This component represents triangular polygon mesh based objects.
 !!!
 

--- a/apps/docs/src/routes/core/object3d-instance.md
+++ b/apps/docs/src/routes/core/object3d-instance.md
@@ -2,7 +2,7 @@
 title: Object3DInstance
 ---
 
-!!!module_summary title=Object3DInstance|sourcePath=instances/Object3DInstance.svelte|name=Object3DInstance|from=core|type=component
+!!!module_summary title=Object3DInstance|sourcePath=instances/Object3DInstance.svelte|name=Object3DInstance|from=core|type=component|relatedDocs={[{name:"three.js Object3D reference",url:"https://threejs.org/docs/api/en/core/Object3D.html"}]}
 This component lets you use any manually instantiated object that extends `THREE.Object3D` in threlte.
 !!!
 

--- a/apps/docs/src/routes/core/object3d.md
+++ b/apps/docs/src/routes/core/object3d.md
@@ -2,7 +2,7 @@
 title: Object3D
 ---
 
-!!!module_summary title=Object3D|sourcePath=objects/Object3D.svelte|name=Object3D|from=core|type=component
+!!!module_summary title=Object3D|sourcePath=objects/Object3D.svelte|name=Object3D|from=core|type=component|relatedDocs={[{name:"three.js Object3D reference",url:"https://threejs.org/docs/#api/en/core/Object3D"}]}
 !!!
 
 ### Example

--- a/apps/docs/src/routes/core/orbit-controls.md
+++ b/apps/docs/src/routes/core/orbit-controls.md
@@ -2,7 +2,7 @@
 title: OrbitControls
 ---
 
-!!!module_summary title=OrbitControls|sourcePath=controls/OrbitControls.svelte|name=OrbitControls|from=core|type=component
+!!!module_summary title=OrbitControls|sourcePath=controls/OrbitControls.svelte|name=OrbitControls|from=core|type=component|relatedDocs={[{name:"three.js OrbitControls reference",url:"https://threejs.org/docs/#examples/en/controls/OrbitControls"}]}
 `<OrbitControls>` allow the camera to orbit around a target.
 
 The component `<OrbitControls>` must be a direct child of a camera component and will mount itself to that camera.

--- a/apps/docs/src/routes/core/orthographic-camera.md
+++ b/apps/docs/src/routes/core/orthographic-camera.md
@@ -2,7 +2,7 @@
 title: OrthographicCamera
 ---
 
-!!!module_summary title=OrthographicCamera|sourcePath=cameras/OrthographicCamera.svelte|name=OrthographicCamera|from=core|type=component
+!!!module_summary title=OrthographicCamera|sourcePath=cameras/OrthographicCamera.svelte|name=OrthographicCamera|from=core|type=component|relatedDocs={[{name:"three.js OrthographicCamera reference",url:"https://threejs.org/docs/#api/en/cameras/OrthographicCamera"}]}
 A camera that uses orthographic projection.
 
 In this projection mode, an object's size in the rendered image stays constant regardless of its distance from the camera.

--- a/apps/docs/src/routes/core/pass.md
+++ b/apps/docs/src/routes/core/pass.md
@@ -2,7 +2,7 @@
 title: Pass
 ---
 
-!!!module_summary title=Pass|sourcePath=effects/Pass.svelte|name=Pass|from=core|type=component
+!!!module_summary title=Pass|sourcePath=effects/Pass.svelte|name=Pass|from=core|type=component|relatedDocs={[{name:"three.js post-processing tutorial",url:"https://threejs.org/docs/#manual/en/introduction/How-to-use-post-processing"}]}
 By default, threlte will render using the regular WebGLRenderer. If any Pass is added to the scene, the `EffectComposer` will take over the rendering. A default `RenderPass` is added automatically and rendered before any `<Pass>`.
 !!!
 

--- a/apps/docs/src/routes/core/perspective-camera.md
+++ b/apps/docs/src/routes/core/perspective-camera.md
@@ -2,7 +2,7 @@
 title: PerspectiveCamera
 ---
 
-!!!module_summary title=PerspectiveCamera|sourcePath=cameras/PerspectiveCamera.svelte|name=PerspectiveCamera|from=core|type=component
+!!!module_summary title=PerspectiveCamera|sourcePath=cameras/PerspectiveCamera.svelte|name=PerspectiveCamera|from=core|type=component|relatedDocs={[{name:"three.js PerspectiveCamera reference",url:"https://threejs.org/docs/#api/en/cameras/PerspectiveCamera"}]}
 A camera that uses perspective projection.
 
 This projection mode is designed to mimic the way the human eye sees. It is the most common projection mode used for rendering a 3D scene.

--- a/apps/docs/src/routes/core/point-light.md
+++ b/apps/docs/src/routes/core/point-light.md
@@ -2,7 +2,7 @@
 title: PointLight
 ---
 
-!!!module_summary title=PointLight|sourcePath=lights/PointLight.svelte|name=PointLight|from=core|type=component
+!!!module_summary title=PointLight|sourcePath=lights/PointLight.svelte|name=PointLight|from=core|type=component|relatedDocs={[{name:"three.js PointLight reference",url:"https://threejs.org/docs/#api/en/lights/PointLight"}]}
 A light that gets emitted from a single point in all directions. A common use case for this is to replicate the light emitted from a bare lightbulb.
 
 This light can cast shadows.

--- a/apps/docs/src/routes/core/positional-audio-helper.md
+++ b/apps/docs/src/routes/core/positional-audio-helper.md
@@ -2,7 +2,7 @@
 title: PositionalAudioHelper
 ---
 
-!!!module_summary title=PositionalAudioHelper|sourcePath=helpers/PositionalAudioHelper.svelte|name=PositionalAudioHelper|from=core|type=component
+!!!module_summary title=PositionalAudioHelper|sourcePath=helpers/PositionalAudioHelper.svelte|name=PositionalAudioHelper|from=core|type=component|relatedDocs={[{name:"three.js PositionalAudioHelper reference",url:"https://threejs.org/docs/examples/en/helpers/PositionalAudioHelper.html"}]}
 This helper displays the directional cone of a [`<PositionalAudio>`](/core/positional-audio) component and needs to be a direct child it.
 !!!
 

--- a/apps/docs/src/routes/core/positional-audio.md
+++ b/apps/docs/src/routes/core/positional-audio.md
@@ -6,7 +6,7 @@ title: PositionalAudio
 import Wrapper from '$examples/audio/Wrapper.svelte'
 </script>
 
-!!!module_summary title=PositionalAudio|sourcePath=audio/PositionalAudio.svelte|name=PositionalAudio|from=core|type=component
+!!!module_summary title=PositionalAudio|sourcePath=audio/PositionalAudio.svelte|name=PositionalAudio|from=core|type=component|relatedDocs={[{name:"three.js PositionalAudio reference",url:"https://threejs.org/docs/#api/en/audio/PositionalAudio"}]}
 Creates a positional audio entity.
 This uses the [Web Audio API](https://developer.mozilla.org/en-US/Web/API/Web_Audio_API).
 

--- a/apps/docs/src/routes/core/spot-light.md
+++ b/apps/docs/src/routes/core/spot-light.md
@@ -2,7 +2,7 @@
 title: SpotLight
 ---
 
-!!!module_summary title=SpotLight|sourcePath=lights/SpotLight.svelte|name=SpotLight|from=core|type=component
+!!!module_summary title=SpotLight|sourcePath=lights/SpotLight.svelte|name=SpotLight|from=core|type=component|relatedDocs={[{name:"three.js SpotLight reference",url:"https://threejs.org/docs/#api/en/lights/SpotLight"}]}
 This light gets emitted from a single point in one direction, along a cone that increases in size the further from the light it gets.
 
 This light can cast shadows.

--- a/apps/docs/src/routes/core/transform-controls.md
+++ b/apps/docs/src/routes/core/transform-controls.md
@@ -6,7 +6,7 @@ title: TransformControls
 import Wrapper from '$examples/transform-controls/Wrapper.svelte'
 </script>
 
-!!!module_summary title=TransformControls|sourcePath=controls/TransformControls.svelte|name=TransformControls|from=core|type=component
+!!!module_summary title=TransformControls|sourcePath=controls/TransformControls.svelte|name=TransformControls|from=core|type=component|relatedDocs={[{name:"three.js TransformControls reference",url:"https://threejs.org/docs/#examples/en/controls/TransformControls"}]}
 This component can be used to transform objects in 3D space by adapting a similar interaction model of DCC tools like Blender. Unlike other controls, it is not intended to transform the scenes camera.
 
 The component `<TransformControls>` needs to be a direct child of the component to be transformed.

--- a/apps/docs/src/routes/extras/edges.md
+++ b/apps/docs/src/routes/extras/edges.md
@@ -6,7 +6,7 @@ title: Edges
 import Wrapper from '$examples/edges/Wrapper.svelte'
 </script>
 
-!!!module_summary title=Edges|sourcePath=/components/Edges/Edges.svelte|name=Edges|from=extras|type=component
+!!!module_summary title=Edges|sourcePath=/components/Edges/Edges.svelte|name=Edges|from=extras|type=component|relatedDocs={[{name:"three.js EdgesGeometry reference",url:"https://threejs.org/docs/api/en/geometries/EdgesGeometry.html"}]}
 
 Abstracts `THREE.EdgesGeometry`. This component automatically pulls the geometry from its parent.
 

--- a/apps/docs/src/routes/extras/gltf.md
+++ b/apps/docs/src/routes/extras/gltf.md
@@ -6,7 +6,7 @@ title: GLTF
 import Wrapper from '$examples/gltf/Wrapper.svelte'
 </script>
 
-!!!module_summary title=GLTF|sourcePath=/components/GLTF/GLTF.svelte|name=GLTF|from=extras|type=component
+!!!module_summary title=GLTF|sourcePath=/components/GLTF/GLTF.svelte|name=GLTF|from=extras|type=component|relatedDocs={[{name:"three.js GLTFLoader reference",url:"https://threejs.org/docs/examples/en/loaders/GLTFLoader.html"}]}
 To use DRACO compression, provide a path to the DRACO decoder.
 To use KTX2 compressed textures, provide a path to the KTX2 transcoder.
 

--- a/apps/docs/src/routes/extras/text.md
+++ b/apps/docs/src/routes/extras/text.md
@@ -2,7 +2,7 @@
 title: Text
 ---
 
-!!!module_summary title=Text|sourcePath=/components/Text/Text.svelte|name=Text|from=extras|type=component
+!!!module_summary title=Text|sourcePath=/components/Text/Text.svelte|name=Text|from=extras|type=component|relatedDocs={[{name:"troika-three-text reference",url:"https://protectwise.github.io/troika/troika-three-text/"}]}
 The `<Text>` component uses [troika-three-text](https://github.com/protectwise/troika/tree/master/packages/troika-three-text) to render text.
 !!!
 

--- a/apps/docs/src/routes/extras/use-gltf.md
+++ b/apps/docs/src/routes/extras/use-gltf.md
@@ -6,7 +6,7 @@ title: useGltf
 import Wrapper from '$examples/use-gltf/Wrapper.svelte'
 </script>
 
-!!!module_summary title=useGltf|sourcePath=/hooks/useGltf.ts|name=useGltf|from=extras|type=hook
+!!!module_summary title=useGltf|sourcePath=/hooks/useGltf.ts|name=useGltf|from=extras|type=hook|relatedDocs={[{name:"three.js GLTFLoader reference",url:"https://threejs.org/docs/examples/en/loaders/GLTFLoader.html"}]}
 A Hook to load glTF files and use separate object nodes and materials of it.
 
 Use the component [`<GLTF>`](/extras/gltf) if you want to use a model in its entirety.

--- a/apps/docs/src/routes/extras/use-progress.md
+++ b/apps/docs/src/routes/extras/use-progress.md
@@ -6,7 +6,7 @@ title: useProgress
 import Wrapper from '$examples/use-progress/Wrapper.svelte'
 </script>
 
-!!!module_summary title=useProgress|sourcePath=/hooks/useProgress.ts|name=useProgress|from=extras|type=hook
+!!!module_summary title=useProgress|sourcePath=/hooks/useProgress.ts|name=useProgress|from=extras|type=hook|relatedDocs={[{name:"three.js DefaultLoadingManager reference",url:"https://threejs.org/docs/api/en/loaders/managers/DefaultLoadingManager.html"}]}
 Convenience hook that wraps `THREE.DefaultLoadingManager`.
 
 <ExampleWrapper>


### PR DESCRIPTION
Adds a prop to the ModuleSummary component that allows linking out to related documentation, for example to the three.js concepts that most threlte components abstract over. Also adds some more or less obvious candidates for links to existing documentation.