### PR TITLE
Automatic disposal of three.js objects

### DIFF
--- a/.changeset/chilled-plums-double.md
+++ b/.changeset/chilled-plums-double.md
@@ -1,0 +1,6 @@
+---
+'@threlte/core': minor
+'@threlte/extras': minor
+---
+
+Added a new property "userData" which is useful to debug, add custom properties and filter objects

--- a/.changeset/chilled-shirts-cough.md
+++ b/.changeset/chilled-shirts-cough.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': minor
+---
+
+Added automatic disposal of three.js objects. See documentation for more info.

--- a/.changeset/strange-taxis-shop.md
+++ b/.changeset/strange-taxis-shop.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': minor
+---
+
+Added component <Disposables> to easily create a disposal strategy

--- a/apps/docs/src/examples/rapier/rigid-body/Particle.svelte
+++ b/apps/docs/src/examples/rapier/rigid-body/Particle.svelte
@@ -14,5 +14,5 @@
 
 <RigidBody type={'dynamic'} {position} {rotation}>
 	<Collider shape={'cuboid'} args={[0.125, 0.125, 0.125]} />
-	<Mesh castShadow receiveShadow {geometry} {material} />
+	<Mesh dispose={false} castShadow receiveShadow {geometry} {material} />
 </RigidBody>

--- a/apps/docs/src/routes/concepts/disposal.md
+++ b/apps/docs/src/routes/concepts/disposal.md
@@ -1,0 +1,84 @@
+---
+title: Disposal
+---
+
+# Disposal
+
+Freeing resources is a [manual chore in three.js](https://threejs.org/docs/index.html#manual/en/introduction/How-to-dispose-of-objects), but Svelte is aware of component lifecycles, hence Threlte will attempt to free resources for you by calling `dispose`, if present, on all unmounted objects and recursively on all properties that can be disposed.
+
+```svelte
+<script>
+	import { Mesh, useTexture } from '@threlte/core'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+
+	const map = useTexture('/some/texture')
+	const material = new MeshStandardMaterial({	map })
+</script>
+
+<!--
+	The geometry, material and the associated texture will
+	be disposed as soon as the <Mesh> component unmounts.
+-->
+<Mesh
+	geometry={new BoxBufferGeometry(1, 1, 1)}
+	{material}
+/>
+```
+
+:::admonition type="info"
+Be aware that calling `dispose` on a three.js buffer, material or geometry is merely deallocating it from the GPU memory. If an object is used after it's disposed it will be allocated again, resulting in a performance drop for a single frame. It will **not produce a runtime error**.
+:::
+
+You can switch off automatic disposal by placing `dispose={false}` onto components, it is now valid for the entire tree.
+
+```svelte
+<script>
+	import { Mesh, useTexture } from '@threlte/core'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+
+	const map = useTexture('/some/texture')
+	const material = new MeshStandardMaterial({	map })
+</script>
+
+<!-- will not be disposed -->
+<Mesh
+	dispose={false}
+	geometry={new BoxBufferGeometry(1, 1, 1)}
+	{material}
+>
+	<!-- will also not be disposed -->
+	<Mesh
+		geometry={new BoxBufferGeometry(2, 2, 2)}
+		{material}
+	>
+		<!-- will be disposed -->
+		<Mesh
+			dispose
+			geometry={new BoxBufferGeometry(2, 2, 2)}
+			material={new MeshStandardMaterial()}
+		/>
+	</Mesh>
+</Mesh>
+```
+
+Sometimes it's useful to manage the disposal of objects yourself. This is especially true of objects are shared across separately mounted component trees. Use the component [`<Disposables>`](/extras/disposables) to automatically opt-out of automatic disposal and provide objects that should be disposed on unmounting of the component.
+
+```svelte
+<script>
+	import { Mesh, useTexture } from '@threlte/core'
+	import { Disposables } from '@threlte/extras'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+
+	const map = useTexture('/some/texture')
+	const material = new MeshStandardMaterial({	map })
+	const geometry = new BoxBufferGeometry(1, 1, 1)
+</script>
+
+<Disposables disposables={[map, geometry, material]}>
+	<Mesh {geometry} {material} position={{ x: 2 }}>
+		<Mesh {geometry} {material} position={{ y: 2 }}>
+			<Mesh {geometry} {material} position={{ x: 2 }} />
+		</Mesh>
+	</Mesh>
+<Disposables/>
+```

--- a/apps/docs/src/routes/core/ambient-light.md
+++ b/apps/docs/src/routes/core/ambient-light.md
@@ -32,6 +32,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 ```

--- a/apps/docs/src/routes/core/ambient-light.md
+++ b/apps/docs/src/routes/core/ambient-light.md
@@ -31,6 +31,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 ```

--- a/apps/docs/src/routes/core/audio-instance.md
+++ b/apps/docs/src/routes/core/audio-instance.md
@@ -41,6 +41,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 autoplay: boolean | undefined = undefined
 detune: number | undefined = undefined
 source: string | AudioBuffer | HTMLMediaElement | AudioBufferSourceNode | MediaStream | undefined = undefined

--- a/apps/docs/src/routes/core/audio-instance.md
+++ b/apps/docs/src/routes/core/audio-instance.md
@@ -40,6 +40,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 autoplay: boolean | undefined = undefined
 detune: number | undefined = undefined
 source: string | AudioBuffer | HTMLMediaElement | AudioBufferSourceNode | MediaStream | undefined = undefined

--- a/apps/docs/src/routes/core/audio-listener.md
+++ b/apps/docs/src/routes/core/audio-listener.md
@@ -54,6 +54,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 id: string | undefined = undefined
 masterVolume: number | undefined = undefined
 ```

--- a/apps/docs/src/routes/core/audio-listener.md
+++ b/apps/docs/src/routes/core/audio-listener.md
@@ -55,6 +55,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 id: string | undefined = undefined
 masterVolume: number | undefined = undefined
 ```

--- a/apps/docs/src/routes/core/audio.md
+++ b/apps/docs/src/routes/core/audio.md
@@ -41,6 +41,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 autoplay: boolean | undefined = undefined
 detune: number | undefined = undefined
 source: string | AudioBuffer | HTMLMediaElement | AudioBufferSourceNode | MediaStream | undefined = undefined

--- a/apps/docs/src/routes/core/audio.md
+++ b/apps/docs/src/routes/core/audio.md
@@ -42,6 +42,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 autoplay: boolean | undefined = undefined
 detune: number | undefined = undefined
 source: string | AudioBuffer | HTMLMediaElement | AudioBufferSourceNode | MediaStream | undefined = undefined

--- a/apps/docs/src/routes/core/camera-instance.md
+++ b/apps/docs/src/routes/core/camera-instance.md
@@ -38,6 +38,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 ```
 
 ### Bindings <!-- omit in toc -->

--- a/apps/docs/src/routes/core/camera-instance.md
+++ b/apps/docs/src/routes/core/camera-instance.md
@@ -37,6 +37,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 ```
 
 ### Bindings <!-- omit in toc -->

--- a/apps/docs/src/routes/core/directional-light.md
+++ b/apps/docs/src/routes/core/directional-light.md
@@ -30,6 +30,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 target: Position | THREE.Object3D | undefined = undefined

--- a/apps/docs/src/routes/core/directional-light.md
+++ b/apps/docs/src/routes/core/directional-light.md
@@ -31,6 +31,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 target: Position | THREE.Object3D | undefined = undefined

--- a/apps/docs/src/routes/core/disposable-object.md
+++ b/apps/docs/src/routes/core/disposable-object.md
@@ -1,0 +1,80 @@
+---
+title: DisposableObject
+---
+
+!!!module_summary title=DisposableObject|sourcePath=internal/DisposableObject.svelte|name=DisposableObject|from=core|type=component
+
+Depending on the provided property `dispose` and the parent components dispose strategy, this component will call `dispose` on the provided `object` and all properties of `object` that have a method `dispose`.
+
+!!!
+
+### Basic Example
+
+Automatically disposes the geometry.
+
+```svelte
+<script>
+	import { DisposableObject } from '@threlte/core'
+	import { BoxBufferGeometry } from 'three'
+
+	const cube = new BoxBufferGeometry(1, 1, 1)
+</script>
+
+<DisposableObject object={cube} />
+```
+
+Automatically disposes the material and associated textures.
+
+```svelte
+<script>
+	import { DisposableObject, useTexture } from '@threlte/core'
+	import { MeshStandardMaterial } from 'three'
+
+	const textures = useTexture({
+		map: '/map.jpg',
+		normalMap: '/normalMap.jpg',
+	})
+	const material = new MeshStandardMaterial({ ...textures })
+</script>
+
+<DisposableObject object={material} />
+```
+
+Opt out of disposal, this is valid for the whole following tree.
+
+```svelte
+<script>
+	import { DisposableObject } from '@threlte/core'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+
+	const cube = new BoxBufferGeometry(1, 1, 1)
+	const material = new MeshStandardMaterial()
+	const texture = useTexture('/texture.jpg',)
+</script>
+
+<!-- the material is not being disposed -->
+<DisposableObject dispose={false} object={material}>
+
+	<!--
+		the geometry is also not being disposed: as the
+		flag "dispose" is not provided, it's inheriting
+		the dispose strategy from the upstream parent.
+	-->
+	<DisposableObject object={cube} />
+
+	<!--
+		The texture will be disposed:
+		the flag "dispose" is provided.
+	-->
+	<DisposableObject dispose object={texture} />
+
+</DisposableObject />
+```
+
+### Properties
+
+```ts
+// optional
+dispose: boolean = true // internally uses "undefined" as default value, de-facto the default value is "true"
+object: Object3D | undefined = undefined
+```

--- a/apps/docs/src/routes/core/group.md
+++ b/apps/docs/src/routes/core/group.md
@@ -35,6 +35,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 ```
 
 ### Bindings

--- a/apps/docs/src/routes/core/group.md
+++ b/apps/docs/src/routes/core/group.md
@@ -34,6 +34,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 ```
 
 ### Bindings

--- a/apps/docs/src/routes/core/hemisphere-light.md
+++ b/apps/docs/src/routes/core/hemisphere-light.md
@@ -32,6 +32,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 intensity: number | undefined = undefined
 skyColor: THREE.ColorRepresentation | undefined = undefined
 groundColor: THREE.ColorRepresentation | undefined = undefined

--- a/apps/docs/src/routes/core/hemisphere-light.md
+++ b/apps/docs/src/routes/core/hemisphere-light.md
@@ -31,6 +31,7 @@ castShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 intensity: number | undefined = undefined
 skyColor: THREE.ColorRepresentation | undefined = undefined
 groundColor: THREE.ColorRepresentation | undefined = undefined

--- a/apps/docs/src/routes/core/instanced-mesh.md
+++ b/apps/docs/src/routes/core/instanced-mesh.md
@@ -142,6 +142,7 @@ castShadow: boolean | undefined = undefined
 receiveShadow: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/instanced-mesh.md
+++ b/apps/docs/src/routes/core/instanced-mesh.md
@@ -143,6 +143,7 @@ receiveShadow: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/light-instance.md
+++ b/apps/docs/src/routes/core/light-instance.md
@@ -42,6 +42,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 ```

--- a/apps/docs/src/routes/core/light-instance.md
+++ b/apps/docs/src/routes/core/light-instance.md
@@ -41,6 +41,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 ```

--- a/apps/docs/src/routes/core/line-2.md
+++ b/apps/docs/src/routes/core/line-2.md
@@ -61,6 +61,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line-2.md
+++ b/apps/docs/src/routes/core/line-2.md
@@ -60,6 +60,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line-instance.md
+++ b/apps/docs/src/routes/core/line-instance.md
@@ -45,6 +45,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line-instance.md
+++ b/apps/docs/src/routes/core/line-instance.md
@@ -46,6 +46,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line-segments.md
+++ b/apps/docs/src/routes/core/line-segments.md
@@ -52,6 +52,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line-segments.md
+++ b/apps/docs/src/routes/core/line-segments.md
@@ -53,6 +53,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line.md
+++ b/apps/docs/src/routes/core/line.md
@@ -62,6 +62,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/line.md
+++ b/apps/docs/src/routes/core/line.md
@@ -61,6 +61,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/mesh-instance.md
+++ b/apps/docs/src/routes/core/mesh-instance.md
@@ -43,6 +43,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 ```
 
 ### Bindings <!-- omit in toc -->

--- a/apps/docs/src/routes/core/mesh-instance.md
+++ b/apps/docs/src/routes/core/mesh-instance.md
@@ -44,6 +44,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 ```
 
 ### Bindings <!-- omit in toc -->

--- a/apps/docs/src/routes/core/mesh.md
+++ b/apps/docs/src/routes/core/mesh.md
@@ -39,6 +39,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/mesh.md
+++ b/apps/docs/src/routes/core/mesh.md
@@ -40,6 +40,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/core/object3d-instance.md
+++ b/apps/docs/src/routes/core/object3d-instance.md
@@ -36,6 +36,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 ```
 
 ### Bindings <!-- omit in toc -->

--- a/apps/docs/src/routes/core/object3d-instance.md
+++ b/apps/docs/src/routes/core/object3d-instance.md
@@ -37,6 +37,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 ```
 
 ### Bindings <!-- omit in toc -->

--- a/apps/docs/src/routes/core/object3d.md
+++ b/apps/docs/src/routes/core/object3d.md
@@ -35,6 +35,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 ```
 
 ### Bindings

--- a/apps/docs/src/routes/core/object3d.md
+++ b/apps/docs/src/routes/core/object3d.md
@@ -34,6 +34,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 ```
 
 ### Bindings

--- a/apps/docs/src/routes/core/orthographic-camera.md
+++ b/apps/docs/src/routes/core/orthographic-camera.md
@@ -35,6 +35,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 useCamera: boolean = true
 near: number = undefined
 far: number = undefined

--- a/apps/docs/src/routes/core/orthographic-camera.md
+++ b/apps/docs/src/routes/core/orthographic-camera.md
@@ -34,6 +34,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 useCamera: boolean = true
 near: number = undefined
 far: number = undefined

--- a/apps/docs/src/routes/core/perspective-camera.md
+++ b/apps/docs/src/routes/core/perspective-camera.md
@@ -33,6 +33,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 useCamera: boolean = true
 near: number = undefined
 far: number = undefined

--- a/apps/docs/src/routes/core/perspective-camera.md
+++ b/apps/docs/src/routes/core/perspective-camera.md
@@ -32,6 +32,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 useCamera: boolean = true
 near: number = undefined
 far: number = undefined

--- a/apps/docs/src/routes/core/point-light.md
+++ b/apps/docs/src/routes/core/point-light.md
@@ -31,6 +31,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 distance: number | undefined = undefined

--- a/apps/docs/src/routes/core/point-light.md
+++ b/apps/docs/src/routes/core/point-light.md
@@ -32,6 +32,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 distance: number | undefined = undefined

--- a/apps/docs/src/routes/core/positional-audio.md
+++ b/apps/docs/src/routes/core/positional-audio.md
@@ -66,6 +66,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 autoplay: boolean | undefined = undefined
 detune: number | undefined = undefined
 source: string | AudioBuffer | HTMLMediaElement | AudioBufferSourceNode | MediaStream | undefined = undefined

--- a/apps/docs/src/routes/core/positional-audio.md
+++ b/apps/docs/src/routes/core/positional-audio.md
@@ -65,6 +65,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 autoplay: boolean | undefined = undefined
 detune: number | undefined = undefined
 source: string | AudioBuffer | HTMLMediaElement | AudioBufferSourceNode | MediaStream | undefined = undefined

--- a/apps/docs/src/routes/core/spot-light.md
+++ b/apps/docs/src/routes/core/spot-light.md
@@ -33,6 +33,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 angle: number | undefined = undefined

--- a/apps/docs/src/routes/core/spot-light.md
+++ b/apps/docs/src/routes/core/spot-light.md
@@ -34,6 +34,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 color: THREE.ColorRepresentation | undefined = undefined
 intensity: number | undefined = undefined
 angle: number | undefined = undefined

--- a/apps/docs/src/routes/extras/disposables.md
+++ b/apps/docs/src/routes/extras/disposables.md
@@ -1,0 +1,48 @@
+---
+title: Disposables
+---
+
+!!!module_summary title=Disposables|sourcePath=/components/Disposables/Disposables.svelte|name=Disposables|from=extras|type=component
+
+This component switches of the automatic disposal of three.js objects for all child components (direct or indirect). The property `disposables` accepts three.js objects like meshes, material, textures and geometries that upon unmounting of the component will be **deeply disposed**.
+
+!!!
+
+### Example
+
+The meshes can be mounted and unmounted *without* the map, material and geometry being disposed. If the component `<Disposables>` is being unmounted, map, material and geometry will be disposed.
+
+```svelte
+<script>
+	import { Mesh, useTexture } from '@threlte/core'
+	import { Disposables } from '@threlte/extras'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+
+	const texture = useTexture('/some/texture')
+	const material = new MeshStandardMaterial({	map: texture })
+	const geometry = new BoxBufferGeometry(1, 1, 1)
+</script>
+
+<!--
+	*Theoretically* the texture would not need to be part of the property
+	"disposables" as it's a property of "material" and therefore gets
+	 disposed anyway. Leaving it in for the sake of completeness.
+-->
+<Disposables disposables={[texture, geometry, material]}>
+	<Mesh {geometry} {material} position={{ x: 2 }}>
+		<Mesh {geometry} {material} position={{ y: 2 }}>
+			<Mesh {geometry} {material} position={{ x: 2 }} />
+		</Mesh>
+	</Mesh>
+<Disposables/>
+```
+
+### Properties
+
+```ts
+// required
+disposables: ({
+		dispose?: () => void),
+		type?: string
+	} & Record<string, any>)[]
+```

--- a/apps/docs/src/routes/extras/edges.md
+++ b/apps/docs/src/routes/extras/edges.md
@@ -56,6 +56,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/extras/edges.md
+++ b/apps/docs/src/routes/extras/edges.md
@@ -57,6 +57,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 ```

--- a/apps/docs/src/routes/extras/float.md
+++ b/apps/docs/src/routes/extras/float.md
@@ -56,6 +56,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 viewportAware: boolean = false
 ```
 

--- a/apps/docs/src/routes/extras/float.md
+++ b/apps/docs/src/routes/extras/float.md
@@ -55,6 +55,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 viewportAware: boolean = false
 ```
 

--- a/apps/docs/src/routes/extras/gltf.md
+++ b/apps/docs/src/routes/extras/gltf.md
@@ -72,6 +72,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 dracoDecoderPath: string | undefined = undefined
 ktxTranscoderPath: string | undefined = undefined
 ignorePointer: boolean = false

--- a/apps/docs/src/routes/extras/text.md
+++ b/apps/docs/src/routes/extras/text.md
@@ -32,6 +32,7 @@ receiveShadow: boolean | undefined = undefined
 frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
+dispose: boolean | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 

--- a/apps/docs/src/routes/extras/text.md
+++ b/apps/docs/src/routes/extras/text.md
@@ -33,6 +33,7 @@ frustumCulled: boolean | undefined = undefined
 renderOrder: number | undefined = undefined
 visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
+userData: Record<string, any> | undefined = undefined
 interactive: boolean = false
 ignorePointer: boolean = false
 

--- a/apps/docs/src/routes/navigation.ts
+++ b/apps/docs/src/routes/navigation.ts
@@ -36,6 +36,10 @@ export const sidebar = {
 			{
 				title: 'Miscellaneous',
 				slug: '/concepts/miscellaneous'
+			},
+			{
+				title: 'Disposal',
+				slug: '/concepts/disposal'
 			}
 		],
 		'@threlte/core': [
@@ -236,6 +240,10 @@ export const sidebar = {
 				slug: '/core/layerable-object'
 			},
 			{
+				title: 'DisposableObject',
+				slug: '/core/disposable-object'
+			},
+			{
 				title: 'Hooks',
 				slug: ''
 			},
@@ -312,6 +320,10 @@ export const sidebar = {
 			{
 				title: 'Float',
 				slug: '/extras/float'
+			},
+			{
+				title: 'Disposables',
+				slug: '/extras/disposables'
 			}
 		],
 		'@threlte/rapier': [

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -59,7 +59,7 @@
   const { getCtx, renderCtx } = contexts
 
   // context bindings
-  export const { ctx, rootCtx, audioCtx } = contexts
+  export const { ctx, rootCtx, audioCtx, disposalCtx } = contexts
 
   setDefaultCameraAspectOnSizeChange(ctx)
 
@@ -91,7 +91,7 @@
     initialized = true
   })
 
-  useFrameloop(ctx, rootCtx, renderCtx)
+  useFrameloop(ctx, rootCtx, renderCtx, disposalCtx)
 
   const { onClick, onContextMenu, onPointerDown, onPointerMove, onPointerUp } = useEventRaycast(
     ctx,

--- a/packages/core/src/lib/audio/Audio.svelte
+++ b/packages/core/src/lib/audio/Audio.svelte
@@ -15,6 +15,8 @@
   export let frustumCulled: AudioProperties['frustumCulled'] = undefined
   export let renderOrder: AudioProperties['renderOrder'] = undefined
   export let visible: AudioProperties['visible'] = undefined
+  export let userData: AudioProperties['userData'] = undefined
+  export let dispose: AudioProperties['dispose'] = undefined
 
   export let autoplay: AudioProperties['autoplay'] = undefined
   export let detune: AudioProperties['detune'] = undefined
@@ -50,6 +52,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {castShadow}
   {receiveShadow}
   {viewportAware}

--- a/packages/core/src/lib/audio/AudioListener.svelte
+++ b/packages/core/src/lib/audio/AudioListener.svelte
@@ -16,6 +16,8 @@
   export let frustumCulled: AudioListenerProperties['frustumCulled'] = undefined
   export let renderOrder: AudioListenerProperties['renderOrder'] = undefined
   export let visible: AudioListenerProperties['visible'] = undefined
+  export let userData: AudioListenerProperties['userData'] = undefined
+  export let dispose: AudioListenerProperties['dispose'] = undefined
 
   export let id: AudioListenerProperties['id'] = undefined
   export let masterVolume: AudioListenerProperties['masterVolume'] = undefined
@@ -45,6 +47,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {castShadow}
   {receiveShadow}
   {viewportAware}

--- a/packages/core/src/lib/audio/PositionalAudio.svelte
+++ b/packages/core/src/lib/audio/PositionalAudio.svelte
@@ -15,6 +15,8 @@
   export let frustumCulled: PositionalAudioProperties['frustumCulled'] = undefined
   export let renderOrder: PositionalAudioProperties['renderOrder'] = undefined
   export let visible: PositionalAudioProperties['visible'] = undefined
+  export let userData: PositionalAudioProperties['userData'] = undefined
+  export let dispose: PositionalAudioProperties['dispose'] = undefined
 
   export let autoplay: PositionalAudioProperties['autoplay'] = undefined
   export let detune: PositionalAudioProperties['detune'] = undefined
@@ -71,6 +73,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {castShadow}
   {receiveShadow}
   {viewportAware}

--- a/packages/core/src/lib/cameras/OrthographicCamera.svelte
+++ b/packages/core/src/lib/cameras/OrthographicCamera.svelte
@@ -17,6 +17,8 @@
   export let frustumCulled: OrthographicCameraProperties['frustumCulled'] = undefined
   export let renderOrder: OrthographicCameraProperties['renderOrder'] = undefined
   export let visible: OrthographicCameraProperties['visible'] = undefined
+  export let userData: OrthographicCameraProperties['userData'] = undefined
+  export let dispose: OrthographicCameraProperties['dispose'] = undefined
   export let useCamera: OrthographicCameraProperties['useCamera'] = true
 
   // OrthographicCamera
@@ -66,6 +68,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/cameras/PerspectiveCamera.svelte
+++ b/packages/core/src/lib/cameras/PerspectiveCamera.svelte
@@ -14,6 +14,8 @@
   export let frustumCulled: PerspectiveCameraProperties['frustumCulled'] = undefined
   export let renderOrder: PerspectiveCameraProperties['renderOrder'] = undefined
   export let visible: PerspectiveCameraProperties['visible'] = undefined
+  export let userData: PerspectiveCameraProperties['userData'] = undefined
+  export let dispose: PerspectiveCameraProperties['dispose'] = undefined
   export let viewportAware: PerspectiveCameraProperties['viewportAware'] = false
   export let inViewport: PerspectiveCameraProperties['inViewport'] = false
   export let useCamera: PerspectiveCameraProperties['useCamera'] = true
@@ -52,6 +54,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/controls/OrbitControls.svelte
+++ b/packages/core/src/lib/controls/OrbitControls.svelte
@@ -4,6 +4,7 @@
   import { OrbitControls as ThreeOrbitControls } from 'three/examples/jsm/controls/OrbitControls'
   import { useFrame } from '../hooks/useFrame'
   import { useThrelte } from '../hooks/useThrelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import { useParent } from '../internal/HierarchicalObject.svelte'
   import TransformableObject from '../internal/TransformableObject.svelte'
   import { getThrelteUserData } from '../lib/getThrelteUserData'
@@ -120,11 +121,8 @@
     controls.update()
     invalidate('OrbitControls: target changed')
   }
-
-  onDestroy(() => {
-    controls.dispose()
-    invalidate('OrbitControls: onDestroy')
-  })
 </script>
+
+<DisposableObject object={controls} />
 
 <TransformableObject on:transform={updateControls} object={targetObject} position={target} />

--- a/packages/core/src/lib/controls/OrbitControls.svelte
+++ b/packages/core/src/lib/controls/OrbitControls.svelte
@@ -35,6 +35,7 @@
   export let touches: OrbitControlsProperties['touches'] = undefined
   export let zoomSpeed: OrbitControlsProperties['zoomSpeed'] = undefined
   export let target: OrbitControlsProperties['target'] = undefined
+  export let dispose: OrbitControlsProperties['dispose'] = undefined
 
   const parent = useParent()
 
@@ -123,7 +124,6 @@
   }
 </script>
 
-<!-- Force disposal -->
-<DisposableObject dispose object={controls} />
+<DisposableObject {dispose} object={controls} />
 
 <TransformableObject on:transform={updateControls} object={targetObject} position={target} />

--- a/packages/core/src/lib/controls/OrbitControls.svelte
+++ b/packages/core/src/lib/controls/OrbitControls.svelte
@@ -123,6 +123,7 @@
   }
 </script>
 
-<DisposableObject object={controls} />
+<!-- Force disposal -->
+<DisposableObject dispose object={controls} />
 
 <TransformableObject on:transform={updateControls} object={targetObject} position={target} />

--- a/packages/core/src/lib/controls/TransformControls.svelte
+++ b/packages/core/src/lib/controls/TransformControls.svelte
@@ -253,6 +253,7 @@
   })
 </script>
 
-<DisposableObject object={transformControls} />
+<!-- Force disposal -->
+<DisposableObject dispose object={transformControls} />
 
 <LayerableObject object={transformControls} />

--- a/packages/core/src/lib/controls/TransformControls.svelte
+++ b/packages/core/src/lib/controls/TransformControls.svelte
@@ -4,6 +4,7 @@
   import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
   import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
   import { useThrelte } from '../hooks/useThrelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import { useParent } from '../internal/HierarchicalObject.svelte'
   import LayerableObject from '../internal/LayerableObject.svelte'
   import { getThrelteUserData } from '../lib/getThrelteUserData'
@@ -249,8 +250,9 @@
     transformControls.detach()
     scene.remove(transformControls)
     removeListeners()
-    transformControls.dispose()
   })
 </script>
+
+<DisposableObject object={transformControls} />
 
 <LayerableObject object={transformControls} />

--- a/packages/core/src/lib/controls/TransformControls.svelte
+++ b/packages/core/src/lib/controls/TransformControls.svelte
@@ -23,6 +23,7 @@
   export let showZ: TransformControlsProperties['showZ'] = undefined
   export let size: TransformControlsProperties['size'] = undefined
   export let space: TransformControlsProperties['space'] = undefined
+  export let dispose: TransformControlsProperties['dispose'] = undefined
 
   const { camera, renderer, invalidate, scene } = useThrelte()
   const parent = useParent()
@@ -253,7 +254,6 @@
   })
 </script>
 
-<!-- Force disposal -->
-<DisposableObject dispose object={transformControls} />
+<DisposableObject {dispose} object={transformControls} />
 
 <LayerableObject object={transformControls} />

--- a/packages/core/src/lib/helpers/PositionalAudioHelper.svelte
+++ b/packages/core/src/lib/helpers/PositionalAudioHelper.svelte
@@ -16,5 +16,6 @@
 </script>
 
 {#if helper}
-  <Object3DInstance object={helper} />
+  <!-- Force disposal as helper is not user-provided -->
+  <Object3DInstance dispose object={helper} />
 {/if}

--- a/packages/core/src/lib/hooks/useThrelteDisposal.ts
+++ b/packages/core/src/lib/hooks/useThrelteDisposal.ts
@@ -1,0 +1,6 @@
+import { getContext } from 'svelte'
+import type { ThrelteDisposalContext } from '../types/types'
+
+export const useThrelteDisposal = (): ThrelteDisposalContext => {
+  return getContext<ThrelteDisposalContext>('threlte-disposal-context')
+}

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -57,6 +57,7 @@ export { default as LayerableObject } from './internal/LayerableObject.svelte'
 export { default as SceneGraphObject } from './internal/SceneGraphObject.svelte'
 export { default as TransformableObject } from './internal/TransformableObject.svelte'
 export { default as ViewportAwareObject } from './internal/ViewportAwareObject.svelte'
+export { default as DisposableObject } from './internal/DisposableObject.svelte'
 
 // hooks
 export { useFrame } from './hooks/useFrame'
@@ -89,6 +90,7 @@ export type {
   InteractiveObjectProperties,
   LayerableObjectProperties,
   TransformableObjectProperties,
+  DisposableObjectProperties,
   ViewportAwareObjectProperties,
   Object3DInstanceProperties,
   MeshInstanceProperties,

--- a/packages/core/src/lib/instances/AudioInstance.svelte
+++ b/packages/core/src/lib/instances/AudioInstance.svelte
@@ -19,6 +19,8 @@
   export let frustumCulled: Props['frustumCulled'] = undefined
   export let renderOrder: Props['renderOrder'] = undefined
   export let visible: Props['visible'] = undefined
+  export let userData: Props['userData'] = undefined
+  export let dispose: Props['dispose'] = undefined
 
   export let autoplay: Props['autoplay'] = undefined
   export let detune: Props['detune'] = undefined
@@ -167,6 +169,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {castShadow}
   {receiveShadow}
   {viewportAware}

--- a/packages/core/src/lib/instances/CameraInstance.svelte
+++ b/packages/core/src/lib/instances/CameraInstance.svelte
@@ -17,6 +17,8 @@
   export let frustumCulled: CameraInstanceProperties['frustumCulled'] = undefined
   export let renderOrder: CameraInstanceProperties['renderOrder'] = undefined
   export let visible: CameraInstanceProperties['visible'] = undefined
+  export let userData: CameraInstanceProperties['userData'] = undefined
+  export let dispose: CameraInstanceProperties['dispose'] = undefined
 
   export let useCamera: CameraInstanceProperties['useCamera'] = false
 
@@ -42,6 +44,8 @@
   {rotation}
   {viewportAware}
   {visible}
+  {userData}
+  {dispose}
   on:viewportenter
   on:viewportleave
   bind:inViewport

--- a/packages/core/src/lib/instances/LightInstance.svelte
+++ b/packages/core/src/lib/instances/LightInstance.svelte
@@ -18,6 +18,8 @@
   export let frustumCulled: LightInstanceProperties['frustumCulled'] = undefined
   export let renderOrder: LightInstanceProperties['renderOrder'] = undefined
   export let visible: LightInstanceProperties['visible'] = undefined
+  export let userData: LightInstanceProperties['userData'] = undefined
+  export let dispose: LightInstanceProperties['dispose'] = undefined
 
   export let color: LightInstanceProperties['color'] = undefined
   export let intensity: LightInstanceProperties['intensity'] = undefined
@@ -44,6 +46,8 @@
   {rotation}
   {viewportAware}
   {visible}
+  {userData}
+  {dispose}
   on:viewportenter
   on:viewportleave
   bind:inViewport

--- a/packages/core/src/lib/instances/LineInstance.svelte
+++ b/packages/core/src/lib/instances/LineInstance.svelte
@@ -15,6 +15,8 @@
   export let frustumCulled: LineInstanceProperties['frustumCulled'] = undefined
   export let renderOrder: LineInstanceProperties['renderOrder'] = undefined
   export let visible: LineInstanceProperties['visible'] = undefined
+  export let userData: LineInstanceProperties['userData'] = undefined
+  export let dispose: LineInstanceProperties['dispose'] = undefined
   export let interactive: LineInstanceProperties['interactive'] = false
   export let ignorePointer: LineInstanceProperties['ignorePointer'] = false
 </script>
@@ -30,6 +32,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   on:viewportenter
   on:viewportleave

--- a/packages/core/src/lib/instances/MeshInstance.svelte
+++ b/packages/core/src/lib/instances/MeshInstance.svelte
@@ -15,6 +15,8 @@
   export let frustumCulled: MeshInstanceProperties['frustumCulled'] = undefined
   export let renderOrder: MeshInstanceProperties['renderOrder'] = undefined
   export let visible: MeshInstanceProperties['visible'] = undefined
+  export let userData: MeshInstanceProperties['userData'] = undefined
+  export let dispose: MeshInstanceProperties['dispose'] = undefined
   export let interactive: MeshInstanceProperties['interactive'] = false
   export let ignorePointer: MeshInstanceProperties['ignorePointer'] = false
 </script>
@@ -30,6 +32,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   on:viewportenter
   on:viewportleave

--- a/packages/core/src/lib/instances/Object3DInstance.svelte
+++ b/packages/core/src/lib/instances/Object3DInstance.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { useThrelte } from '../hooks/useThrelte'
-  import SceneGraphObject from '../internal/SceneGraphObject.svelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import LayerableObject from '../internal/LayerableObject.svelte'
+  import SceneGraphObject from '../internal/SceneGraphObject.svelte'
   import TransformableObject from '../internal/TransformableObject.svelte'
   import ViewportAwareObject from '../internal/ViewportAwareObject.svelte'
   import type { Object3DInstanceProperties } from '../types/components'
@@ -34,6 +35,8 @@
     invalidate('Object3DInstance: props changed')
   }
 </script>
+
+<DisposableObject {object} />
 
 <LayerableObject {object} />
 

--- a/packages/core/src/lib/instances/Object3DInstance.svelte
+++ b/packages/core/src/lib/instances/Object3DInstance.svelte
@@ -22,6 +22,8 @@
   export let frustumCulled: Object3DInstanceProperties['frustumCulled'] = undefined
   export let renderOrder: Object3DInstanceProperties['renderOrder'] = undefined
   export let visible: Object3DInstanceProperties['visible'] = undefined
+  export let dispose: Object3DInstanceProperties['dispose'] = undefined
+  export let userData: Object3DInstanceProperties['userData'] = undefined
 
   const { invalidate } = useThrelte()
   const getObject = () => object
@@ -32,18 +34,24 @@
     if (receiveShadow !== undefined) getObject().receiveShadow = receiveShadow
     if (frustumCulled !== undefined) getObject().frustumCulled = frustumCulled
     if (renderOrder !== undefined) getObject().renderOrder = renderOrder
+    if (userData !== undefined) {
+      getObject().userData = {
+        ...getObject().userData,
+        ...userData
+      }
+    }
     invalidate('Object3DInstance: props changed')
   }
 </script>
-
-<DisposableObject {object} />
 
 <LayerableObject {object} />
 
 <TransformableObject {object} {position} {rotation} {scale} {lookAt} />
 
-<SceneGraphObject {object}>
-  <slot />
-</SceneGraphObject>
+<DisposableObject {object} {dispose}>
+  <SceneGraphObject {object}>
+    <slot />
+  </SceneGraphObject>
+</DisposableObject>
 
 <ViewportAwareObject bind:inViewport {object} {viewportAware} on:viewportenter on:viewportleave />

--- a/packages/core/src/lib/internal/DisposableObject.svelte
+++ b/packages/core/src/lib/internal/DisposableObject.svelte
@@ -45,12 +45,12 @@
   setContext<ThrelteDisposeContext>('threlte-dispose-context', mergedDispose)
 
   $: {
-    if (object !== previousObject) disposeObject(object)
+    if (object !== previousObject && $mergedDispose) disposeObject(object)
     previousObject = object
   }
 
   onDestroy(() => {
-    disposeObject(object)
+    if ($mergedDispose) disposeObject(object)
   })
 </script>
 

--- a/packages/core/src/lib/internal/DisposableObject.svelte
+++ b/packages/core/src/lib/internal/DisposableObject.svelte
@@ -1,6 +1,10 @@
 <script lang="ts" context="module">
-  // Recursively disposes an object
-  // This function needs to be bombproof
+  /**
+   * Recursively disposes an object.
+   * This function needs to be bulletproof.
+   *
+   * @param obj
+   */
   const dispose = <Obj extends { dispose?: () => void; type?: string; [key: string]: any }>(
     obj?: Obj
   ) => {

--- a/packages/core/src/lib/internal/DisposableObject.svelte
+++ b/packages/core/src/lib/internal/DisposableObject.svelte
@@ -1,56 +1,31 @@
-<script lang="ts" context="module">
-  /**
-   * Recursively disposes an object including all properties that hold a function "dispose".
-   * Does not dispose children.
-   * This function needs to be bulletproof.
-   *
-   * TODO: Implement a list of returnable keys for performance reasons
-   *
-   * @param obj
-   */
-  const disposeObject = <Obj extends DisposableObjectProperties['object']>(obj?: Obj) => {
-    if (!obj) return
-    // Scenes can't be disposed
-    if (obj?.dispose && typeof obj.dispose === 'function' && obj.type !== 'Scene') {
-      obj.dispose()
-    }
-    // iterate over properties of obj
-    Object.entries(obj).forEach(([propKey, propValue]) => {
-      // we don't want to dispose the parent
-      if (propKey === 'parent' || propKey === 'children') return
-      // children don't need to be disposed as they manage their own disposal
-      const value = propValue as any
-      if (value?.dispose) {
-        disposeObject(value)
-      }
-    })
-  }
-</script>
-
 <script lang="ts">
   import { getContext, onDestroy, setContext } from 'svelte'
   import { writable } from 'svelte/store'
+  import { useThrelteDisposal } from '../hooks/useThrelteDisposal'
   import type { DisposableObjectProperties } from '../types/components'
   import type { ThrelteDisposeContext } from '../types/types'
+
+  const { addDisposableObject } = useThrelteDisposal()
 
   export let object: DisposableObjectProperties['object'] = undefined
   let previousObject = object
   export let dispose: DisposableObjectProperties['dispose'] = undefined
 
-  const parentDispose = getContext<ThrelteDisposeContext | undefined>('threlte-dispose-context')
+  const contextName = 'threlte-disposable-object-context'
+  const parentDispose = getContext<ThrelteDisposeContext | undefined>(contextName)
 
   let mergedDispose = writable(dispose ?? $parentDispose ?? true)
   $: mergedDispose.set(dispose ?? $parentDispose ?? true)
 
-  setContext<ThrelteDisposeContext>('threlte-dispose-context', mergedDispose)
+  setContext<ThrelteDisposeContext>(contextName, mergedDispose)
 
   $: {
-    if (object !== previousObject && $mergedDispose) disposeObject(object)
+    if (object !== previousObject && $mergedDispose) addDisposableObject(object)
     previousObject = object
   }
 
   onDestroy(() => {
-    if ($mergedDispose) disposeObject(object)
+    if ($mergedDispose) addDisposableObject(object)
   })
 </script>
 

--- a/packages/core/src/lib/internal/DisposableObject.svelte
+++ b/packages/core/src/lib/internal/DisposableObject.svelte
@@ -10,6 +10,13 @@
     Object.entries(obj).forEach(([propKey, propValue]) => {
       // we don't want to dispose the parent
       if (propKey === 'parent') return
+      // dispose all children
+      if (propKey === 'children' && Array.isArray(propValue)) {
+        const children = propValue as Object3D[]
+        children.forEach((child) => {
+          dispose(child)
+        })
+      }
       const value = propValue as any
       if (value?.dispose) {
         dispose(value)
@@ -20,8 +27,9 @@
 
 <script lang="ts">
   import { onDestroy } from 'svelte'
+  import type { Object3D } from 'three'
 
-  type Object = $$Generic<{ dispose?: () => void; type?: string; [key: string]: any }>
+  type Object = $$Generic<{ dispose?: () => void; type?: string; [key: string]: any } | undefined>
 
   export let object: Object
 

--- a/packages/core/src/lib/internal/DisposableObject.svelte
+++ b/packages/core/src/lib/internal/DisposableObject.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" context="module">
+  // Recursively disposes an object
+  // This function needs to be bombproof
+  const dispose = <Obj extends { dispose?: () => void; type?: string; [key: string]: any }>(
+    obj?: Obj
+  ) => {
+    if (!obj) return
+    if (obj?.dispose && typeof obj.dispose === 'function' && obj.type !== 'Scene') obj.dispose()
+    // iterate over properties of obj
+    Object.entries(obj).forEach(([propKey, propValue]) => {
+      // we don't want to dispose the parent
+      if (propKey === 'parent') return
+      const value = propValue as any
+      if (value?.dispose) {
+        dispose(value)
+      }
+    })
+  }
+</script>
+
+<script lang="ts">
+  import { onDestroy } from 'svelte'
+
+  type Object = $$Generic<{ dispose?: () => void; type?: string; [key: string]: any }>
+
+  export let object: Object
+
+  onDestroy(() => {
+    dispose(object)
+  })
+</script>

--- a/packages/core/src/lib/internal/DisposableObject.svelte
+++ b/packages/core/src/lib/internal/DisposableObject.svelte
@@ -9,7 +9,10 @@
     obj?: Obj
   ) => {
     if (!obj) return
-    if (obj?.dispose && typeof obj.dispose === 'function' && obj.type !== 'Scene') obj.dispose()
+    // Scenes can't be disposed
+    if (obj?.dispose && typeof obj.dispose === 'function' && obj.type !== 'Scene') {
+      obj.dispose()
+    }
     // iterate over properties of obj
     Object.entries(obj).forEach(([propKey, propValue]) => {
       // we don't want to dispose the parent

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -144,18 +144,7 @@ export const createContexts = (
   }
 
   const disposalCtx: ThrelteDisposalContext = {
-    /**
-     * These objects will be disposed on the next frame.
-     */
     disposableObjects: new Set(),
-    /**
-     * Adds a disposable object and all its disposable properties
-     * to disposalCtx.disposableObjects which will be disposed on
-     * the next frame.
-     *
-     * @param object
-     * @returns
-     */
     addDisposableObject: (object) => {
       if (!object) return
       // Scenes can't be disposed
@@ -172,6 +161,12 @@ export const createContexts = (
           disposalCtx.addDisposableObject(value)
         }
       })
+    },
+    dispose: () => {
+      disposalCtx.disposableObjects.forEach((object) => {
+        object.dispose?.()
+      })
+      disposalCtx.disposableObjects.clear()
     }
   }
 

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -8,6 +8,7 @@ import type {
   Size,
   ThrelteAudioContext,
   ThrelteContext,
+  ThrelteDisposalContext,
   ThrelteRenderContext,
   ThrelteRootContext
 } from '../types/types'
@@ -20,16 +21,19 @@ export const createContexts = (
   userSize: Writable<Size | undefined>,
   parentSize: Writable<Size>,
   debugFrameloop: boolean,
-  frameloop: 'always' | 'demand' | 'never'
+  frameloop: 'always' | 'demand' | 'never',
+  debugInfo: boolean
 ): {
   ctx: ThrelteContext
   rootCtx: ThrelteRootContext
   renderCtx: ThrelteRenderContext
   audioCtx: ThrelteAudioContext
+  disposalCtx: ThrelteDisposalContext
   getCtx: () => ThrelteContext
   getRootCtx: () => ThrelteRootContext
   getRenderCtx: () => ThrelteRenderContext
   getAudioCtx: () => ThrelteAudioContext
+  getDisposalCtx: () => ThrelteDisposalContext
 } => {
   const audioCtx: ThrelteAudioContext = {
     audioListeners: new Map(),
@@ -60,6 +64,7 @@ export const createContexts = (
   }
 
   const renderCtx: ThrelteRenderContext = {
+    debugInfo,
     debugFrameloop,
     frameloop,
     frame: 0,
@@ -138,24 +143,60 @@ export const createContexts = (
     }
   }
 
+  const disposalCtx: ThrelteDisposalContext = {
+    /**
+     * These objects will be disposed on the next frame.
+     */
+    disposableObjects: new Set(),
+    /**
+     * Adds a disposable object and all its disposable properties
+     * to disposalCtx.disposableObjects which will be disposed on
+     * the next frame.
+     *
+     * @param object
+     * @returns
+     */
+    addDisposableObject: (object) => {
+      if (!object) return
+      // Scenes can't be disposed
+      if (object?.dispose && typeof object.dispose === 'function' && object.type !== 'Scene') {
+        disposalCtx.disposableObjects.add(object)
+      }
+      // iterate over properties of obj
+      Object.entries(object).forEach(([propKey, propValue]) => {
+        // we don't want to dispose the parent
+        if (propKey === 'parent' || propKey === 'children') return
+        // children don't need to be disposed as they manage their own disposal
+        const value = propValue as any
+        if (value?.dispose) {
+          disposalCtx.addDisposableObject(value)
+        }
+      })
+    }
+  }
+
   setContext<ThrelteContext>('threlte', ctx)
   setContext<ThrelteRootContext>('threlte-root', rootCtx)
   setContext<ThrelteRenderContext>('threlte-render-context', renderCtx)
   setContext<ThrelteAudioContext>('threlte-audio-context', audioCtx)
+  setContext<ThrelteDisposalContext>('threlte-disposal-context', disposalCtx)
 
   const getCtx = (): ThrelteContext => ctx
   const getRootCtx = (): ThrelteRootContext => rootCtx
   const getRenderCtx = (): ThrelteRenderContext => renderCtx
   const getAudioCtx = (): ThrelteAudioContext => audioCtx
+  const getDisposalCtx = (): ThrelteDisposalContext => disposalCtx
 
   return {
     ctx,
     rootCtx,
     renderCtx,
     audioCtx,
+    disposalCtx,
     getCtx,
     getRootCtx,
     getRenderCtx,
-    getAudioCtx
+    getAudioCtx,
+    getDisposalCtx
   }
 }

--- a/packages/core/src/lib/lib/createObjectStore.ts
+++ b/packages/core/src/lib/lib/createObjectStore.ts
@@ -1,9 +1,10 @@
 import { onDestroy } from 'svelte'
-import { writable, type Writable } from 'svelte/store'
-import type { Object3D } from 'three'
+import { writable, type Updater, type Writable } from 'svelte/store'
 
 /**
  * A store that only ever updates if the objects are actually different.
+ * Accepts any object that has a property "uuid" (i.e. most Three.js objects).
+ *
  * ### Example
  *
  * ```ts
@@ -11,25 +12,45 @@ import type { Object3D } from 'three'
  * store.set(sameObject) // will not update
  * store.set(otherObject) // will update
  * ```
+ *
  * @param object
  * @returns store
  */
-export function createObjectStore<T extends Object3D | undefined>(object: T): Writable<T>
-export function createObjectStore<T extends Object3D>(object: T): Writable<T>
-export function createObjectStore<T extends Object3D | undefined>(object: T): Writable<T> {
+export function createObjectStore<T extends { uuid: string } | undefined>(
+  object: T,
+  onChange?: (newObject: T, oldObject: T) => void
+): Writable<T>
+export function createObjectStore<T extends { uuid: string }>(
+  object: T,
+  onChange?: (newObject: T, oldObject: T) => void
+): Writable<T>
+export function createObjectStore<T extends { uuid: string } | undefined>(
+  object: T,
+  onChange?: (newObject: T, oldObject: T) => void
+): Writable<T> {
   const objectStore = writable(object)
   let unwrappedObject = object
   const unsubscribeObjectStore = objectStore.subscribe((o) => (unwrappedObject = o))
   onDestroy(unsubscribeObjectStore)
 
   const set = (newObject: T) => {
-    if (!newObject || !unwrappedObject) return objectStore.set(newObject)
-    if (newObject.uuid === unwrappedObject.uuid) return
+    if (newObject?.uuid === unwrappedObject?.uuid) return
+    const oldObject = unwrappedObject
     objectStore.set(newObject)
+    onChange?.(newObject, oldObject)
+  }
+
+  const update = (callback: Updater<T>) => {
+    const newObject = callback(unwrappedObject)
+    if (newObject?.uuid === unwrappedObject?.uuid) return
+    const oldObject = unwrappedObject
+    objectStore.set(newObject)
+    onChange?.(newObject, oldObject)
   }
 
   return {
     ...objectStore,
-    set
+    set,
+    update
   }
 }

--- a/packages/core/src/lib/lib/frameloop.ts
+++ b/packages/core/src/lib/lib/frameloop.ts
@@ -63,13 +63,7 @@ export const useFrameloop = (
   const { raycast } = useFrameloopRaycast(ctx, rootCtx)
 
   useRaf(() => {
-    /**
-     * Dispose all objects that are marked as disposable
-     */
-    disposalCtx.disposableObjects.forEach((object) => {
-      object.dispose?.()
-    })
-    disposalCtx.disposableObjects.clear()
+    disposalCtx.dispose()
 
     const shouldRender =
       renderCtx.frameloop === 'always' ||

--- a/packages/core/src/lib/lib/frameloop.ts
+++ b/packages/core/src/lib/lib/frameloop.ts
@@ -1,7 +1,12 @@
 import { onDestroy } from 'svelte'
 import { get } from 'svelte/store'
 import { useRaf } from '../hooks/useRaf'
-import type { ThrelteContext, ThrelteRenderContext, ThrelteRootContext } from '../types/types'
+import type {
+  ThrelteContext,
+  ThrelteDisposalContext,
+  ThrelteRenderContext,
+  ThrelteRootContext
+} from '../types/types'
 import { useFrameloopRaycast } from './interactivity'
 
 const runFrameloopCallbacks = (ctx: ThrelteContext, renderCtx: ThrelteRenderContext): void => {
@@ -48,7 +53,8 @@ const debugFrame = (renderCtx: ThrelteRenderContext): void => {
 export const useFrameloop = (
   ctx: ThrelteContext,
   rootCtx: ThrelteRootContext,
-  renderCtx: ThrelteRenderContext
+  renderCtx: ThrelteRenderContext,
+  disposalCtx: ThrelteDisposalContext
 ): void => {
   let camera = get(ctx.camera)
   const unsubscribeCamera = ctx.camera.subscribe((c) => (camera = c))
@@ -57,6 +63,14 @@ export const useFrameloop = (
   const { raycast } = useFrameloopRaycast(ctx, rootCtx)
 
   useRaf(() => {
+    /**
+     * Dispose all objects that are marked as disposable
+     */
+    disposalCtx.disposableObjects.forEach((object) => {
+      object.dispose?.()
+    })
+    disposalCtx.disposableObjects.clear()
+
     const shouldRender =
       renderCtx.frameloop === 'always' ||
       (renderCtx.frameloop === 'demand' &&

--- a/packages/core/src/lib/lib/onObjectChange.ts
+++ b/packages/core/src/lib/lib/onObjectChange.ts
@@ -1,0 +1,39 @@
+/**
+ * Callback to object changes.
+ *
+ * ### Example
+ *
+ * ```ts
+ * const set = onObjectChange(object, (newObject, oldObject) => {
+ *   console.log(newObject, oldObject)
+ * })
+ * set(sameObject) // will not trigger callback
+ * set(otherObject) // will trigger callback
+ * ```
+ *
+ * @param object
+ * @returns store
+ */
+export function onObjectChange<T extends { uuid: string } | undefined>(
+  object: T,
+  onChange?: (newObject: T, oldObject: T) => void
+): (object: T) => void
+export function onObjectChange<T extends { uuid: string }>(
+  object: T,
+  onChange?: (newObject: T, oldObject: T) => void
+): (object: T) => void
+export function onObjectChange<T extends { uuid: string } | undefined>(
+  object: T,
+  onChange?: (newObject: T, oldObject: T) => void
+): (object: T) => void {
+  let currentObject = object
+
+  const set = (newObject: T) => {
+    if (currentObject === undefined && newObject === undefined) return
+    if (newObject?.uuid === currentObject?.uuid) return
+    onChange?.(newObject, currentObject)
+    currentObject = newObject
+  }
+
+  return set
+}

--- a/packages/core/src/lib/lights/AmbientLight.svelte
+++ b/packages/core/src/lib/lights/AmbientLight.svelte
@@ -12,6 +12,8 @@
   export let frustumCulled: AmbientLightProperties['frustumCulled'] = undefined
   export let renderOrder: AmbientLightProperties['renderOrder'] = undefined
   export let visible: AmbientLightProperties['visible'] = undefined
+  export let userData: AmbientLightProperties['userData'] = undefined
+  export let dispose: AmbientLightProperties['dispose'] = undefined
   export let viewportAware: AmbientLightProperties['viewportAware'] = false
   export let inViewport: AmbientLightProperties['inViewport'] = false
   export let color: AmbientLightProperties['color'] = undefined
@@ -31,6 +33,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/lights/DirectionalLight.svelte
+++ b/packages/core/src/lib/lights/DirectionalLight.svelte
@@ -6,6 +6,7 @@
   import SceneGraphObject from '../internal/SceneGraphObject.svelte'
   import TransformableObject from '../internal/TransformableObject.svelte'
   import type { DirectionalLightProperties } from '../types/components'
+  import DisposableObject from '../internal/DisposableObject.svelte'
 
   export let position: DirectionalLightProperties['position'] = undefined
   export let scale: DirectionalLightProperties['scale'] = undefined
@@ -14,6 +15,8 @@
   export let frustumCulled: DirectionalLightProperties['frustumCulled'] = undefined
   export let renderOrder: DirectionalLightProperties['renderOrder'] = undefined
   export let visible: DirectionalLightProperties['visible'] = undefined
+  export let userData: DirectionalLightProperties['userData'] = undefined
+  export let dispose: DirectionalLightProperties['dispose'] = undefined
   export let viewportAware: DirectionalLightProperties['viewportAware'] = false
   export let inViewport: DirectionalLightProperties['inViewport'] = false
   export let color: DirectionalLightProperties['color'] = undefined
@@ -73,6 +76,7 @@
 {#if target && !(target instanceof Object3D)}
   <SceneGraphObject object={originalTarget} />
   <TransformableObject object={originalTarget} position={target} />
+  <DisposableObject {dispose} object={target} />
 {/if}
 
 <LightInstance
@@ -85,6 +89,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/lights/HemisphereLight.svelte
+++ b/packages/core/src/lib/lights/HemisphereLight.svelte
@@ -17,6 +17,8 @@
   export let frustumCulled: HemisphereLightProperties['frustumCulled'] = undefined
   export let renderOrder: HemisphereLightProperties['renderOrder'] = undefined
   export let visible: HemisphereLightProperties['visible'] = undefined
+  export let userData: HemisphereLightProperties['userData'] = undefined
+  export let dispose: HemisphereLightProperties['dispose'] = undefined
   export let intensity: HemisphereLightProperties['intensity'] = undefined
   export let skyColor: HemisphereLightProperties['skyColor'] = undefined
   export let groundColor: HemisphereLightProperties['groundColor'] = undefined
@@ -45,6 +47,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/lights/PointLight.svelte
+++ b/packages/core/src/lib/lights/PointLight.svelte
@@ -14,6 +14,8 @@
   export let frustumCulled: PointLightProperties['frustumCulled'] = undefined
   export let renderOrder: PointLightProperties['renderOrder'] = undefined
   export let visible: PointLightProperties['visible'] = undefined
+  export let userData: PointLightProperties['userData'] = undefined
+  export let dispose: PointLightProperties['dispose'] = undefined
   export let intensity: PointLightProperties['intensity'] = undefined
   export let color: PointLightProperties['color'] = undefined
   export let distance: PointLightProperties['distance'] = undefined
@@ -61,6 +63,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/lights/SpotLight.svelte
+++ b/packages/core/src/lib/lights/SpotLight.svelte
@@ -17,6 +17,8 @@
   export let receiveShadow: SpotLightProperties['receiveShadow'] = undefined
   export let renderOrder: SpotLightProperties['renderOrder'] = undefined
   export let visible: SpotLightProperties['visible'] = undefined
+  export let userData: SpotLightProperties['userData'] = undefined
+  export let dispose: SpotLightProperties['dispose'] = undefined
   export let color: SpotLightProperties['color'] = undefined
   export let intensity: SpotLightProperties['intensity'] = undefined
 
@@ -98,6 +100,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/core/src/lib/objects/Group.svelte
+++ b/packages/core/src/lib/objects/Group.svelte
@@ -14,6 +14,8 @@
   export let frustumCulled: GroupProperties['frustumCulled'] = undefined
   export let renderOrder: GroupProperties['renderOrder'] = undefined
   export let visible: GroupProperties['visible'] = undefined
+  export let userData: GroupProperties['userData'] = undefined
+  export let dispose: GroupProperties['dispose'] = undefined
 
   export const group = new ThreeGroup()
 </script>
@@ -27,6 +29,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {castShadow}
   {receiveShadow}
   {viewportAware}

--- a/packages/core/src/lib/objects/InstancedMesh.svelte
+++ b/packages/core/src/lib/objects/InstancedMesh.svelte
@@ -37,6 +37,8 @@
 </script>
 
 <script lang="ts">
+  import DisposableObject from '../internal/DisposableObject.svelte'
+
   // MeshInstance
   export let position: InstancedMeshProperties['position'] = undefined
   export let scale: InstancedMeshProperties['scale'] = undefined
@@ -47,6 +49,8 @@
   export let receiveShadow: InstancedMeshProperties['receiveShadow'] = undefined
   export let renderOrder: InstancedMeshProperties['renderOrder'] = undefined
   export let visible: InstancedMeshProperties['visible'] = undefined
+  export let userData: InstancedMeshProperties['userData'] = undefined
+  export let dispose: InstancedMeshProperties['dispose'] = undefined
   export let interactive: InstancedMeshProperties['interactive'] = false
   export let ignorePointer: InstancedMeshProperties['ignorePointer'] = false
   export let lookAt: InstancedMeshProperties['lookAt'] = undefined
@@ -213,6 +217,9 @@
   }
 </script>
 
+<DisposableObject object={geometry} />
+<DisposableObject object={material} />
+
 <Object3DInstance object={parentObject} {position} {scale} {rotation} {lookAt}>
   {#key $instancedMesh.uuid}
     <MeshInstance
@@ -222,6 +229,8 @@
       frustumCulled={undefined}
       {renderOrder}
       {visible}
+      {userData}
+      {dispose}
       {interactive}
       {ignorePointer}
       on:click={onEvent}

--- a/packages/core/src/lib/objects/InstancedMesh.svelte
+++ b/packages/core/src/lib/objects/InstancedMesh.svelte
@@ -217,8 +217,8 @@
   }
 </script>
 
-<DisposableObject object={geometry} />
-<DisposableObject object={material} />
+<DisposableObject {dispose} object={geometry} />
+<DisposableObject {dispose} object={material} />
 
 <Object3DInstance object={parentObject} {position} {scale} {rotation} {lookAt}>
   {#key $instancedMesh.uuid}

--- a/packages/core/src/lib/objects/Line.svelte
+++ b/packages/core/src/lib/objects/Line.svelte
@@ -87,10 +87,10 @@
   }
 </script>
 
-<DisposableObject object={geometry} />
-<DisposableObject object={material} />
+<DisposableObject {dispose} object={geometry} />
+<DisposableObject {dispose} object={material} />
 
-<!-- Force disposal, not user-provided -->
+<!-- Force disposal: not user-provided -->
 <DisposableObject dispose object={tempGeometry} />
 
 <LineInstance

--- a/packages/core/src/lib/objects/Line.svelte
+++ b/packages/core/src/lib/objects/Line.svelte
@@ -2,6 +2,7 @@
   import { BufferGeometry, Line as ThreeLine, Vector3 } from 'three'
   import { useThrelte } from '../hooks/useThrelte'
   import LineInstance from '../instances/LineInstance.svelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import type { LineProperties } from '../types/components'
 
   // LineInstance
@@ -15,6 +16,8 @@
   export let frustumCulled: LineProperties['frustumCulled'] = undefined
   export let renderOrder: LineProperties['renderOrder'] = undefined
   export let visible: LineProperties['visible'] = undefined
+  export let userData: LineProperties['userData'] = undefined
+  export let dispose: LineProperties['dispose'] = undefined
   export let interactive: LineProperties['interactive'] = false
   export let ignorePointer: LineProperties['ignorePointer'] = false
   export let lookAt: LineProperties['lookAt'] = undefined
@@ -84,6 +87,12 @@
   }
 </script>
 
+<DisposableObject object={geometry} />
+<DisposableObject object={material} />
+
+<!-- Force disposal, not user-provided -->
+<DisposableObject dispose object={tempGeometry} />
+
 <LineInstance
   {line}
   {position}
@@ -95,6 +104,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {interactive}
   {ignorePointer}
   on:click

--- a/packages/core/src/lib/objects/Line2.svelte
+++ b/packages/core/src/lib/objects/Line2.svelte
@@ -69,8 +69,10 @@
   }
 </script>
 
-<DisposableObject object={fallbackGeometry} />
-<DisposableObject object={geometry} />
+<DisposableObject {dispose} object={geometry} />
+
+<!-- Force disposal: not user-provided -->
+<DisposableObject dispose object={fallbackGeometry} />
 
 <MeshInstance
   mesh={line2}

--- a/packages/core/src/lib/objects/Line2.svelte
+++ b/packages/core/src/lib/objects/Line2.svelte
@@ -5,6 +5,7 @@
   import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry'
   import { useThrelte } from '../hooks/useThrelte'
   import MeshInstance from '../instances/MeshInstance.svelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import type { Line2Properties } from '../types/components'
 
   // LineInstance
@@ -65,6 +66,12 @@
     previousMaterial = material
   }
 </script>
+
+<DisposableObject object={fallbackGeometry} />
+
+{#if geometry}
+  <DisposableObject object={geometry} />
+{/if}
 
 <MeshInstance
   mesh={line2}

--- a/packages/core/src/lib/objects/Line2.svelte
+++ b/packages/core/src/lib/objects/Line2.svelte
@@ -68,10 +68,7 @@
 </script>
 
 <DisposableObject object={fallbackGeometry} />
-
-{#if geometry}
-  <DisposableObject object={geometry} />
-{/if}
+<DisposableObject object={geometry} />
 
 <MeshInstance
   mesh={line2}

--- a/packages/core/src/lib/objects/Line2.svelte
+++ b/packages/core/src/lib/objects/Line2.svelte
@@ -19,6 +19,8 @@
   export let frustumCulled: Line2Properties['frustumCulled'] = undefined
   export let renderOrder: Line2Properties['renderOrder'] = undefined
   export let visible: Line2Properties['visible'] = undefined
+  export let userData: Line2Properties['userData'] = undefined
+  export let dispose: Line2Properties['dispose'] = undefined
   export let interactive: Line2Properties['interactive'] = false
   export let ignorePointer: Line2Properties['ignorePointer'] = false
   export let lookAt: Line2Properties['lookAt'] = undefined
@@ -81,6 +83,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {interactive}
   {ignorePointer}
   on:click

--- a/packages/core/src/lib/objects/LineSegments.svelte
+++ b/packages/core/src/lib/objects/LineSegments.svelte
@@ -55,8 +55,8 @@
   }
 </script>
 
-<DisposableObject object={geometry} />
-<DisposableObject object={material} />
+<DisposableObject {dispose} object={geometry} />
+<DisposableObject {dispose} object={material} />
 
 <LineInstance
   line={lineSegments}

--- a/packages/core/src/lib/objects/LineSegments.svelte
+++ b/packages/core/src/lib/objects/LineSegments.svelte
@@ -2,6 +2,7 @@
   import { LineSegments as ThreeLineSegments } from 'three'
   import { useThrelte } from '../hooks/useThrelte'
   import LineInstance from '../instances/LineInstance.svelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import type { LineSegmentsProperties } from '../types/components'
 
   // LineInstance
@@ -15,6 +16,8 @@
   export let frustumCulled: LineSegmentsProperties['frustumCulled'] = undefined
   export let renderOrder: LineSegmentsProperties['renderOrder'] = undefined
   export let visible: LineSegmentsProperties['visible'] = undefined
+  export let userData: LineSegmentsProperties['userData'] = undefined
+  export let dispose: LineSegmentsProperties['dispose'] = undefined
   export let interactive: LineSegmentsProperties['interactive'] = false
   export let ignorePointer: LineSegmentsProperties['ignorePointer'] = false
   export let lookAt: LineSegmentsProperties['lookAt'] = undefined
@@ -52,6 +55,9 @@
   }
 </script>
 
+<DisposableObject object={geometry} />
+<DisposableObject object={material} />
+
 <LineInstance
   line={lineSegments}
   {position}
@@ -63,6 +69,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {interactive}
   {ignorePointer}
   on:click

--- a/packages/core/src/lib/objects/Mesh.svelte
+++ b/packages/core/src/lib/objects/Mesh.svelte
@@ -2,6 +2,7 @@
   import { Mesh as ThreeMesh } from 'three'
   import { useThrelte } from '../hooks/useThrelte'
   import MeshInstance from '../instances/MeshInstance.svelte'
+  import DisposableObject from '../internal/DisposableObject.svelte'
   import type { MeshProperties } from '../types/components'
 
   // MeshInstance
@@ -15,6 +16,8 @@
   export let frustumCulled: MeshProperties['frustumCulled'] = undefined
   export let renderOrder: MeshProperties['renderOrder'] = undefined
   export let visible: MeshProperties['visible'] = undefined
+  export let userData: MeshProperties['userData'] = undefined
+  export let dispose: MeshProperties['dispose'] = undefined
   export let interactive: MeshProperties['interactive'] = false
   export let ignorePointer: MeshProperties['ignorePointer'] = false
   export let lookAt: MeshProperties['lookAt'] = undefined
@@ -52,6 +55,9 @@
   }
 </script>
 
+<DisposableObject object={geometry} />
+<DisposableObject object={material} />
+
 <MeshInstance
   {mesh}
   {position}
@@ -65,6 +71,8 @@
   {visible}
   {interactive}
   {ignorePointer}
+  {userData}
+  {dispose}
   on:click
   on:contextmenu
   on:pointerup

--- a/packages/core/src/lib/objects/Mesh.svelte
+++ b/packages/core/src/lib/objects/Mesh.svelte
@@ -55,8 +55,8 @@
   }
 </script>
 
-<DisposableObject object={geometry} />
-<DisposableObject object={material} />
+<DisposableObject {dispose} object={geometry} />
+<DisposableObject {dispose} object={material} />
 
 <MeshInstance
   {mesh}

--- a/packages/core/src/lib/objects/Object3D.svelte
+++ b/packages/core/src/lib/objects/Object3D.svelte
@@ -15,6 +15,8 @@
   export let frustumCulled: Object3DProperties['frustumCulled'] = undefined
   export let renderOrder: Object3DProperties['renderOrder'] = undefined
   export let visible: Object3DProperties['visible'] = undefined
+  export let userData: Object3DProperties['userData'] = undefined
+  export let dispose: Object3DProperties['dispose'] = undefined
 
   export const object = new ThreeObject3D()
 </script>
@@ -28,6 +30,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {castShadow}
   {receiveShadow}
   {viewportAware}

--- a/packages/core/src/lib/types/components.ts
+++ b/packages/core/src/lib/types/components.ts
@@ -24,11 +24,13 @@ export type HierarchicalObjectProperties = {
   onChildDestroy?: (child: Object3D) => void
 }
 
+export type DisposableThreeObject = {
+  dispose?: () => void
+  type?: string
+} & Record<string, any>
+
 export type DisposableObjectProperties = {
-  object?: {
-    dispose?: () => void
-    type?: string
-  } & Record<string, any>
+  object?: DisposableThreeObject
   dispose?: boolean
 }
 

--- a/packages/core/src/lib/types/components.ts
+++ b/packages/core/src/lib/types/components.ts
@@ -24,6 +24,14 @@ export type HierarchicalObjectProperties = {
   onChildDestroy?: (child: Object3D) => void
 }
 
+export type DisposableObjectProperties = {
+  object?: {
+    dispose?: () => void
+    type?: string
+  } & Record<string, any>
+  dispose?: boolean
+}
+
 export type SceneGraphObjectProperties = {
   object: Object3D
 }
@@ -58,12 +66,14 @@ export type ViewportAwareObjectProperties = {
 export type Object3DInstanceProperties = HierarchicalObjectProperties &
   LayerableObjectProperties &
   TransformableObjectProperties &
-  ViewportAwareObjectProperties & {
+  ViewportAwareObjectProperties &
+  DisposableObjectProperties & {
     castShadow?: boolean
     receiveShadow?: boolean
     frustumCulled?: boolean
     renderOrder?: number
     visible?: boolean
+    userData?: Record<string, any>
   }
 
 export type MeshInstanceProperties = Omit<Object3DInstanceProperties, 'object'> &

--- a/packages/core/src/lib/types/components.ts
+++ b/packages/core/src/lib/types/components.ts
@@ -110,6 +110,7 @@ export type PerspectiveCameraProperties = Omit<CameraInstanceProperties, 'camera
 }
 
 export type OrbitControlsProperties = {
+  dispose?: boolean
   autoRotate?: boolean
   autoRotateSpeed?: number
   dampingFactor?: number
@@ -151,6 +152,7 @@ export type TransformControlsProperties = {
   showZ?: boolean
   size?: number
   space?: 'world' | 'local' | undefined
+  dispose?: boolean
 }
 
 export type PassProperties = {

--- a/packages/core/src/lib/types/types.ts
+++ b/packages/core/src/lib/types/types.ts
@@ -93,6 +93,8 @@ export type ThrelteAudioContext = {
   removeAudioListener: (id?: string) => void
 }
 
+export type ThrelteDisposeContext = Writable<boolean>
+
 export type ThrelteUseFrame = {
   stop: () => void
   start: () => void

--- a/packages/core/src/lib/types/types.ts
+++ b/packages/core/src/lib/types/types.ts
@@ -19,6 +19,7 @@ import type {
 } from 'three'
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import type { EffectComposer, Pass } from 'three/examples/jsm/postprocessing/EffectComposer'
+import type { DisposableThreeObject } from './components'
 
 export type ThreltePointerEventMap = {
   click: ThreltePointerEvent
@@ -84,6 +85,11 @@ export type ThrelteRenderContext = {
   invalidations: Record<string, number>
   frameHandlers: Set<ThrelteFrameHandler>
   advance: boolean
+}
+
+export type ThrelteDisposalContext = {
+  disposableObjects: Set<DisposableThreeObject>
+  addDisposableObject: (object?: DisposableThreeObject) => void
 }
 
 export type ThrelteAudioContext = {

--- a/packages/core/src/lib/types/types.ts
+++ b/packages/core/src/lib/types/types.ts
@@ -88,8 +88,23 @@ export type ThrelteRenderContext = {
 }
 
 export type ThrelteDisposalContext = {
+  /**
+   * These objects will be disposed on the next frame.
+   */
   disposableObjects: Set<DisposableThreeObject>
+  /**
+   * Adds a disposable object and all its disposable properties
+   * to disposalCtx.disposableObjects which will be disposed on
+   * the next frame.
+   *
+   * @param object
+   * @returns
+   */
   addDisposableObject: (object?: DisposableThreeObject) => void
+  /**
+   * Disposes all disposable objects and clears the Set
+   */
+  dispose: () => void
 }
 
 export type ThrelteAudioContext = {

--- a/packages/extras/src/lib/components/Disposables/Disposables.svelte
+++ b/packages/extras/src/lib/components/Disposables/Disposables.svelte
@@ -6,7 +6,7 @@
 
 <!-- Manually dispose objects -->
 {#each disposables as disposable}
-  <DisposableObject object={disposable} />
+  <DisposableObject dispose object={disposable} />
 {/each}
 
 <!-- Tell the tree to stop disposing from here on -->

--- a/packages/extras/src/lib/components/Disposables/Disposables.svelte
+++ b/packages/extras/src/lib/components/Disposables/Disposables.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { DisposableObject, type DisposableObjectProperties } from '@threlte/core'
+
+  export let disposables: NonNullable<DisposableObjectProperties['object']>[]
+</script>
+
+<!-- Manually dispose objects -->
+{#each disposables as disposable}
+  <DisposableObject object={disposable} />
+{/each}
+
+<!-- Tell the tree to stop disposing from here on -->
+<DisposableObject dispose={false}>
+  <slot />
+</DisposableObject>

--- a/packages/extras/src/lib/components/Edges/Edges.svelte
+++ b/packages/extras/src/lib/components/Edges/Edges.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { LineSegments,useParent,useThrelte } from '@threlte/core'
+  import { DisposableObject, LineSegments, useParent, useThrelte } from '@threlte/core'
   import { onDestroy } from 'svelte'
-  import { Color,EdgesGeometry,LineBasicMaterial,Mesh } from 'three'
+  import { Color, EdgesGeometry, LineBasicMaterial, Mesh } from 'three'
   import type { EdgesProperties } from '../../types/components'
 
   export let color: EdgesProperties['color'] = undefined
@@ -73,6 +73,10 @@
     edgesGeometry.dispose()
   })
 </script>
+
+<DisposableObject object={edgesGeometry} />
+<DisposableObject object={geometry} />
+<DisposableObject object={activeMaterial} />
 
 {#if edgesGeometry}
   <LineSegments

--- a/packages/extras/src/lib/components/Edges/Edges.svelte
+++ b/packages/extras/src/lib/components/Edges/Edges.svelte
@@ -19,6 +19,8 @@
   export let frustumCulled: EdgesProperties['frustumCulled'] = undefined
   export let renderOrder: EdgesProperties['renderOrder'] = undefined
   export let visible: EdgesProperties['visible'] = undefined
+  export let userData: EdgesProperties['userData'] = undefined
+  export let dispose: EdgesProperties['dispose'] = undefined
   export let interactive: EdgesProperties['interactive'] = false
   export let ignorePointer: EdgesProperties['ignorePointer'] = false
   export let lookAt: EdgesProperties['lookAt'] = undefined
@@ -74,9 +76,10 @@
   })
 </script>
 
-<DisposableObject object={edgesGeometry} />
-<DisposableObject object={geometry} />
-<DisposableObject object={activeMaterial} />
+<!-- Force disposal: not user-provided -->
+<DisposableObject dispose object={edgesGeometry} />
+
+<DisposableObject {dispose} object={activeMaterial} />
 
 {#if edgesGeometry}
   <LineSegments
@@ -91,6 +94,8 @@
     {frustumCulled}
     {renderOrder}
     {visible}
+    {userData}
+    {dispose}
     {interactive}
     {ignorePointer}
     on:click

--- a/packages/extras/src/lib/components/Float/Float.svelte
+++ b/packages/extras/src/lib/components/Float/Float.svelte
@@ -15,6 +15,8 @@
   export let frustumCulled: FloatProperties['frustumCulled'] = undefined
   export let renderOrder: FloatProperties['renderOrder'] = undefined
   export let visible: FloatProperties['visible'] = undefined
+  export let userData: FloatProperties['userData'] = undefined
+  export let dispose: FloatProperties['dispose'] = undefined
 
   // Float Properties
   export let speed: FloatProperties['speed'] = 1
@@ -76,6 +78,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {viewportAware}
   bind:inViewport
   on:viewportenter

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -30,6 +30,7 @@
   export let lookAt: HTMLProperties['lookAt'] = undefined
   export let viewportAware: HTMLProperties['viewportAware'] = false
   export let inViewport: HTMLProperties['inViewport'] = false
+  export let dispose: HTMLProperties['dispose'] = false
 
   export let transform: HTMLProperties['transform'] = false
   export let calculatePosition: HTMLProperties['calculatePosition'] = defaultCalculatePosition
@@ -320,6 +321,7 @@
   {rotation}
   {lookAt}
   {viewportAware}
+  {dispose}
   bind:group
   bind:inViewport
   on:viewportenter

--- a/packages/extras/src/lib/components/Text/Text.svelte
+++ b/packages/extras/src/lib/components/Text/Text.svelte
@@ -16,6 +16,8 @@
   export let frustumCulled: TextProperties['frustumCulled'] = undefined
   export let renderOrder: TextProperties['renderOrder'] = undefined
   export let visible: TextProperties['visible'] = undefined
+  export let userData: TextProperties['userData'] = undefined
+  export let dispose: TextProperties['dispose'] = undefined
   export let interactive: TextProperties['interactive'] = false
   export let ignorePointer: TextProperties['ignorePointer'] = false
   export let lookAt: TextProperties['lookAt'] = undefined
@@ -99,10 +101,6 @@
       dispatch('sync')
     })
   }
-
-  onDestroy(() => {
-    textObject.dispose()
-  })
 </script>
 
 <MeshInstance
@@ -116,6 +114,8 @@
   {frustumCulled}
   {renderOrder}
   {visible}
+  {userData}
+  {dispose}
   {interactive}
   {ignorePointer}
   on:click

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -9,6 +9,7 @@ export { default as Edges } from './components/Edges/Edges.svelte'
 export { default as HTML } from './components/HTML/HTML.svelte'
 export { default as Float } from './components/Float/Float.svelte'
 export { default as GLTF } from './components/GLTF/GLTF.svelte'
+export { default as Disposables } from './components/Disposables/Disposables.svelte'
 
 // text component
 export { default as Text } from './components/Text/Text.svelte'


### PR DESCRIPTION
This PR adds a new trait component: `<DisposableObject>` which will dispose a provided three.js object on unmounting. A new component in the package `@threlte/extras` called `<Disposables>` accepts three.js objects which will be disposed on unmounting  and switches off automatic disposal for child components.
This PR also adds a new property "userData" to `<Object3DInstance>`.