### PR TITLE
a more advanced way of automatic disposal

### DIFF
--- a/.changeset/nine-toys-taste.md
+++ b/.changeset/nine-toys-taste.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': minor
+---
+
+Advanced automatic disposal: a resource is not disposed when it's still present somewhere in the scene graph

--- a/apps/docs/src/examples/rapier/rigid-body/Particle.svelte
+++ b/apps/docs/src/examples/rapier/rigid-body/Particle.svelte
@@ -14,5 +14,5 @@
 
 <RigidBody type={'dynamic'} {position} {rotation}>
 	<Collider shape={'cuboid'} args={[0.125, 0.125, 0.125]} />
-	<Mesh dispose={false} castShadow receiveShadow {geometry} {material} />
+	<Mesh castShadow receiveShadow {geometry} {material} />
 </RigidBody>

--- a/apps/docs/src/routes/concepts/disposal.md
+++ b/apps/docs/src/routes/concepts/disposal.md
@@ -4,7 +4,7 @@ title: Disposal
 
 # Disposal
 
-Freeing resources is a [manual chore in three.js](https://threejs.org/docs/index.html#manual/en/introduction/How-to-dispose-of-objects), but Svelte is aware of component lifecycles, hence Threlte will attempt to free resources for you by calling `dispose`, if present, on all unmounted objects and recursively on all properties that can be disposed.
+Freeing resources is a [manual chore in three.js](https://threejs.org/docs/index.html#manual/en/introduction/How-to-dispose-of-objects), but Svelte is aware of component lifecycles, hence Threlte will attempt to free resources for you by calling `dispose`, if present, on all unmounted objects and recursively on all properties that are not being used anywhere else in your scene.
 
 ### Automatic Disposal
 
@@ -67,7 +67,7 @@ You can switch off automatic disposal by placing `dispose={false}` onto componen
 
 ### Disposables
 
-Sometimes it's useful to manage the disposal of objects yourself. This is especially true if objects are shared across separately mounted component trees.
+Sometimes it's useful to manage the disposal of objects yourself.
 
 The component [`<Disposables>`](/extras/disposables) switches off automatic disposal for all child components and disposes the objects provided to the property `disposables` on unmounting.
 

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -56,10 +56,10 @@
     frameloop
   )
 
-  const { getCtx, renderCtx } = contexts
+  const { getCtx, renderCtx, disposalCtx } = contexts
 
   // context bindings
-  export const { ctx, rootCtx, audioCtx, disposalCtx } = contexts
+  export const { ctx, rootCtx, audioCtx } = contexts
 
   setDefaultCameraAspectOnSizeChange(ctx)
 
@@ -98,6 +98,8 @@
     rootCtx,
     renderCtx
   )
+
+  onDestroy(disposalCtx.dispose)
 </script>
 
 <canvas

--- a/packages/core/src/lib/types/types.ts
+++ b/packages/core/src/lib/types/types.ts
@@ -89,22 +89,43 @@ export type ThrelteRenderContext = {
 
 export type ThrelteDisposalContext = {
   /**
-   * These objects will be disposed on the next frame.
-   */
-  disposableObjects: Set<DisposableThreeObject>
-  /**
-   * Adds a disposable object and all its disposable properties
-   * to disposalCtx.disposableObjects which will be disposed on
-   * the next frame.
-   *
-   * @param object
-   * @returns
-   */
-  addDisposableObject: (object?: DisposableThreeObject) => void
-  /**
-   * Disposes all disposable objects and clears the Set
+   * Disposes all disposable objects from disposableObjects
+   * that are not mounted anymore and clears the Map entry.
    */
   dispose: () => void
+
+  /**
+   * Returns an array of disposable objects.
+   * Recursively checks disposable objects for properties
+   * that again hold disposable objects and returns
+   * them as well.
+   */
+  collectDisposableObjects: (
+    object?: DisposableThreeObject,
+    arr?: DisposableThreeObject[]
+  ) => DisposableThreeObject[]
+
+  /**
+   * Add disposable objects that will be disposed on unmounting.
+   */
+  addDisposableObjects: (objects: DisposableThreeObject[]) => void
+
+  /**
+   * Remove disposable objects and possibly dispose them
+   * in the next frame if they are not mounted anywhere else.
+   */
+  removeDisposableObjects: (objects: DisposableThreeObject[]) => void
+
+  /**
+   * A map of currently mounted disposable objects.
+   */
+  disposableObjects: Map<DisposableThreeObject, number>
+
+  /**
+   * A flag that is used to check whether the dispose method
+   * should actually run.
+   */
+  shouldDispose: boolean
 }
 
 export type ThrelteAudioContext = {


### PR DESCRIPTION
Resources that are present somewhere in the scene graph are not disposed on unmounting.

- also fixed a bug where debug proeprties ended up in context creation
- The whole scene is cleaned up on destroy