### PR TITLE
Updated docs

### DIFF
--- a/apps/docs/src/routes/index.md
+++ b/apps/docs/src/routes/index.md
@@ -15,8 +15,8 @@ Threlte is a component library for Svelte to build and render three.js scenes de
 </ExampleWrapper>
 
 &&&code_wrapper
-@[code svelte|title=Wrapper.svelte](../../examples/Introduction/Wrapper.svelte)
-@[code svelte|title=Scene.svelte](../../examples/Introduction/Scene.svelte)
+@[code svelte|title=Wrapper.svelte](../examples/Introduction/Wrapper.svelte)
+@[code svelte|title=Scene.svelte](../examples/Introduction/Scene.svelte)
 
 :::admonition type="info"
 Hooks that make use of the context (as does [useFrame](/core/use-frame) in this example) need to be nested in a child component to `<Canvas>`.


### PR DESCRIPTION
The main page of [threlte docs](https://threlte.xyz) has an invalid path for the code example as seen in this screenshot:
![image](https://user-images.githubusercontent.com/12211826/182038312-213379c3-313d-4184-96ff-245a3291345a.png)
