### PR TITLE
Orthographic camera frustum props

### DIFF
--- a/.changeset/breezy-parents-grin.md
+++ b/.changeset/breezy-parents-grin.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+OrthographicCamera component now accepts all frustum props

--- a/packages/core/src/lib/cameras/OrthographicCamera.svelte
+++ b/packages/core/src/lib/cameras/OrthographicCamera.svelte
@@ -24,16 +24,20 @@
   // OrthographicCamera
   export let near: OrthographicCameraProperties['near'] = undefined
   export let far: OrthographicCameraProperties['far'] = undefined
+  export let left: OrthographicCameraProperties['left'] = undefined
+  export let right: OrthographicCameraProperties['right'] = undefined
+  export let top: OrthographicCameraProperties['top'] = undefined
+  export let bottom: OrthographicCameraProperties['bottom'] = undefined
   export let zoom: OrthographicCameraProperties['zoom'] = undefined
 
   const { size, invalidate } = useThrelte()
   const { setCamera } = useThrelteRoot()
 
   export const camera = new ThreeOrthographicCamera(
-    $size.width / -2,
-    $size.width / 2,
-    $size.height / 2,
-    $size.height / -2,
+    left ?? $size.width / -2,
+    right ?? $size.width / 2,
+    top ?? $size.height / 2,
+    bottom ?? $size.height / -2,
     near,
     far
   )
@@ -41,20 +45,15 @@
   $: if (useCamera) setCamera(camera)
 
   $: {
-    camera.left = $size.width / -2
-    camera.right = $size.width / 2
-    camera.top = $size.height / 2
-    camera.bottom = $size.height / -2
-    camera.updateProjectionMatrix()
-    invalidate('OrthographicCamera: onResize')
-  }
-
-  $: {
+    camera.left = left ?? $size.width / -2
+    camera.right = right ?? $size.width / 2
+    camera.top = top ?? $size.height / 2
+    camera.bottom = bottom ?? $size.height / -2
     if (near !== undefined) camera.near = near
     if (far !== undefined) camera.far = far
     if (zoom !== undefined) camera.zoom = zoom
     camera.updateProjectionMatrix()
-    invalidate('OrthographicCamera: props changed')
+    invalidate('OrthographicCamera: frustum changed')
   }
 </script>
 

--- a/packages/core/src/lib/types/components.ts
+++ b/packages/core/src/lib/types/components.ts
@@ -102,6 +102,10 @@ export type CameraInstanceProperties = Omit<Object3DInstanceProperties, 'object'
 export type OrthographicCameraProperties = Omit<CameraInstanceProperties, 'camera'> & {
   near?: number
   far?: number
+  left?: number
+  right?: number
+  top?: number
+  bottom?: number
   zoom?: number
 }
 


### PR DESCRIPTION
finally fixes #34 

The types are a bit wonky as all props that are not provided are calculated from the viewport size. So a camera set up like this:

```svelte
<OrthographicCamera left={50} right={50} />
```

still applies *calculated* `top` and `bottom` frustum values based on the viewport size:

```ts
new ThreeOrthographicCamera(
  left ?? $size.width / -2,
  right ?? $size.width / 2,
  top ?? $size.height / 2,
  bottom ?? $size.height / -2,
  near,
  far
)
```

This is most commonly not in the intend of the consumer, but `$$Generic` types for this became too abstract to deal with it just yet. I hope the type system will improve over time.