### PR TITLE
Removed duplicate slash `/` in source path

### DIFF
--- a/apps/docs/src/routes/extras/disposables.md
+++ b/apps/docs/src/routes/extras/disposables.md
@@ -2,7 +2,7 @@
 title: Disposables
 ---
 
-!!!module_summary title=Disposables|sourcePath=/components/Disposables/Disposables.svelte|name=Disposables|from=extras|type=component
+!!!module_summary title=Disposables|sourcePath=components/Disposables/Disposables.svelte|name=Disposables|from=extras|type=component
 
 This component switches of the automatic disposal of three.js objects for all child components (direct or indirect). The property `disposables` accepts three.js objects like meshes, material, textures and geometries that upon unmounting of the component will be **deeply disposed**.
 

--- a/apps/docs/src/routes/extras/edges.md
+++ b/apps/docs/src/routes/extras/edges.md
@@ -6,7 +6,7 @@ title: Edges
 import Wrapper from '$examples/edges/Wrapper.svelte'
 </script>
 
-!!!module_summary title=Edges|sourcePath=/components/Edges/Edges.svelte|name=Edges|from=extras|type=component|relatedDocs={[{name:"three.js EdgesGeometry reference",url:"https://threejs.org/docs/api/en/geometries/EdgesGeometry.html"}]}
+!!!module_summary title=Edges|sourcePath=components/Edges/Edges.svelte|name=Edges|from=extras|type=component|relatedDocs={[{name:"three.js EdgesGeometry reference",url:"https://threejs.org/docs/api/en/geometries/EdgesGeometry.html"}]}
 
 Abstracts `THREE.EdgesGeometry`. This component automatically pulls the geometry from its parent.
 

--- a/apps/docs/src/routes/extras/float.md
+++ b/apps/docs/src/routes/extras/float.md
@@ -6,7 +6,7 @@ title: Float
 import Wrapper from '$examples/extras/float/Wrapper.svelte'
 </script>
 
-!!!module_summary title=Float|sourcePath=/components/Float/Float.svelte|name=Float|from=extras|type=component
+!!!module_summary title=Float|sourcePath=components/Float/Float.svelte|name=Float|from=extras|type=component
 
 This component is a port of [drei's `<Float>` component](https://github.com/pmndrs/drei#float) and makes its contents float or hover.
 

--- a/apps/docs/src/routes/extras/gltf.md
+++ b/apps/docs/src/routes/extras/gltf.md
@@ -6,7 +6,7 @@ title: GLTF
 import Wrapper from '$examples/gltf/Wrapper.svelte'
 </script>
 
-!!!module_summary title=GLTF|sourcePath=/components/GLTF/GLTF.svelte|name=GLTF|from=extras|type=component|relatedDocs={[{name:"three.js GLTFLoader reference",url:"https://threejs.org/docs/examples/en/loaders/GLTFLoader.html"}]}
+!!!module_summary title=GLTF|sourcePath=components/GLTF/GLTF.svelte|name=GLTF|from=extras|type=component|relatedDocs={[{name:"three.js GLTFLoader reference",url:"https://threejs.org/docs/examples/en/loaders/GLTFLoader.html"}]}
 To use DRACO compression, provide a path to the DRACO decoder.
 To use KTX2 compressed textures, provide a path to the KTX2 transcoder.
 

--- a/apps/docs/src/routes/extras/html.md
+++ b/apps/docs/src/routes/extras/html.md
@@ -6,7 +6,7 @@ title: HTML
 import Wrapper from '$examples/extras/html/Wrapper.svelte'
 </script>
 
-!!!module_summary title=HTML|sourcePath=/components/HTML/HTML.svelte|name=HTML|from=extras|type=component
+!!!module_summary title=HTML|sourcePath=components/HTML/HTML.svelte|name=HTML|from=extras|type=component
 
 This component is a port of [drei's `<Html>` component](https://github.com/pmndrs/drei#html). It allows you to tie HTML content to any object of your scene. It will be projected to the objects whereabouts automatically.
 

--- a/apps/docs/src/routes/extras/text.md
+++ b/apps/docs/src/routes/extras/text.md
@@ -2,7 +2,7 @@
 title: Text
 ---
 
-!!!module_summary title=Text|sourcePath=/components/Text/Text.svelte|name=Text|from=extras|type=component|relatedDocs={[{name:"troika-three-text reference",url:"https://protectwise.github.io/troika/troika-three-text/"}]}
+!!!module_summary title=Text|sourcePath=components/Text/Text.svelte|name=Text|from=extras|type=component|relatedDocs={[{name:"troika-three-text reference",url:"https://protectwise.github.io/troika/troika-three-text/"}]}
 The `<Text>` component uses [troika-three-text](https://github.com/protectwise/troika/tree/master/packages/troika-three-text) to render text.
 !!!
 

--- a/apps/docs/src/routes/extras/use-cursor.md
+++ b/apps/docs/src/routes/extras/use-cursor.md
@@ -6,7 +6,7 @@ title: useCursor
 import Wrapper from '$examples/extras/use-cursor/Wrapper.svelte'
 </script>
 
-!!!module_summary title=useCursor|sourcePath=/hooks/useCursor.ts|name=useCursor|from=extras|type=hook
+!!!module_summary title=useCursor|sourcePath=hooks/useCursor.ts|name=useCursor|from=extras|type=hook
 A hook that sets the css cursor property according to the hover state of a mesh, so that you can give the user visual feedback.
 
 If a context is present, the cursor property will be set on the DOM element of the renderer, otherwise it will be set on the body element.

--- a/apps/docs/src/routes/extras/use-gltf-animations.md
+++ b/apps/docs/src/routes/extras/use-gltf-animations.md
@@ -6,7 +6,7 @@ title: useGltfAnimations
 import Wrapper from '$examples/use-gltf-animations/Wrapper.svelte'
 </script>
 
-!!!module_summary title=useGltfAnimations|sourcePath=/hooks/useGltfAnimations.ts|name=useGltfAnimations|from=extras|type=hook|needsContext=true
+!!!module_summary title=useGltfAnimations|sourcePath=hooks/useGltfAnimations.ts|name=useGltfAnimations|from=extras|type=hook|needsContext=true
 Convenience hook to use animations loaded with a `<GLTF>` threlte component.
 
 <ExampleWrapper>

--- a/apps/docs/src/routes/extras/use-gltf.md
+++ b/apps/docs/src/routes/extras/use-gltf.md
@@ -6,7 +6,7 @@ title: useGltf
 import Wrapper from '$examples/use-gltf/Wrapper.svelte'
 </script>
 
-!!!module_summary title=useGltf|sourcePath=/hooks/useGltf.ts|name=useGltf|from=extras|type=hook|relatedDocs={[{name:"three.js GLTFLoader reference",url:"https://threejs.org/docs/examples/en/loaders/GLTFLoader.html"}]}
+!!!module_summary title=useGltf|sourcePath=hooks/useGltf.ts|name=useGltf|from=extras|type=hook|relatedDocs={[{name:"three.js GLTFLoader reference",url:"https://threejs.org/docs/examples/en/loaders/GLTFLoader.html"}]}
 A Hook to load glTF files and use separate object nodes and materials of it.
 
 Use the component [`<GLTF>`](/extras/gltf) if you want to use a model in its entirety.

--- a/apps/docs/src/routes/extras/use-progress.md
+++ b/apps/docs/src/routes/extras/use-progress.md
@@ -6,7 +6,7 @@ title: useProgress
 import Wrapper from '$examples/use-progress/Wrapper.svelte'
 </script>
 
-!!!module_summary title=useProgress|sourcePath=/hooks/useProgress.ts|name=useProgress|from=extras|type=hook|relatedDocs={[{name:"three.js DefaultLoadingManager reference",url:"https://threejs.org/docs/api/en/loaders/managers/DefaultLoadingManager.html"}]}
+!!!module_summary title=useProgress|sourcePath=hooks/useProgress.ts|name=useProgress|from=extras|type=hook|relatedDocs={[{name:"three.js DefaultLoadingManager reference",url:"https://threejs.org/docs/api/en/loaders/managers/DefaultLoadingManager.html"}]}
 Convenience hook that wraps `THREE.DefaultLoadingManager`.
 
 <ExampleWrapper>

--- a/apps/docs/src/routes/rapier/auto-colliders.md
+++ b/apps/docs/src/routes/rapier/auto-colliders.md
@@ -6,7 +6,7 @@ title: AutoColliders
 import Wrapper from '$examples/rapier/auto-colliders/Wrapper.svelte'
 </script>
 
-!!!module_summary title=AutoColliders|sourcePath=/components/AutoColliders/AutoColliders.svelte|name=AutoColliders|from=rapier|type=component|relatedDocs={[{name:"Rapier Collider reference",url:"https://rapier.rs/javascript3d/classes/Collider.html"}, {name:"Rapier Collider Guide",url:"https://rapier.rs/docs/user_guides/javascript/colliders"}]}
+!!!module_summary title=AutoColliders|sourcePath=components/AutoColliders/AutoColliders.svelte|name=AutoColliders|from=rapier|type=component|relatedDocs={[{name:"Rapier Collider reference",url:"https://rapier.rs/javascript3d/classes/Collider.html"}, {name:"Rapier Collider Guide",url:"https://rapier.rs/docs/user_guides/javascript/colliders"}]}
 
 The `<AutoColliders>` component generates colliders based on its children. Currently these shapes are available:
 

--- a/apps/docs/src/routes/rapier/collider.md
+++ b/apps/docs/src/routes/rapier/collider.md
@@ -6,7 +6,7 @@ title: Collider
 import Wrapper from '$examples/rapier/collider/Wrapper.svelte'
 </script>
 
-!!!module_summary title=Collider|sourcePath=/components/Collider/Collider.svelte|name=Collider|from=rapier|type=component|relatedDocs={[{name:"Rapier Collider reference",url:"https://rapier.rs/javascript3d/classes/Collider.html"}, {name:"Rapier Collider Guide",url:"https://rapier.rs/docs/user_guides/javascript/colliders"}]}
+!!!module_summary title=Collider|sourcePath=components/Collider/Collider.svelte|name=Collider|from=rapier|type=component|relatedDocs={[{name:"Rapier Collider reference",url:"https://rapier.rs/javascript3d/classes/Collider.html"}, {name:"Rapier Collider Guide",url:"https://rapier.rs/docs/user_guides/javascript/colliders"}]}
 
 Colliders represent the geometric shapes that generate contacts and collision events when they touch. Attaching one or multiple colliders to a rigid body allow the rigid-body to be affected by contact forces.
 

--- a/apps/docs/src/routes/rapier/collision-groups.md
+++ b/apps/docs/src/routes/rapier/collision-groups.md
@@ -6,7 +6,7 @@ title: CollisionGroups
 import Wrapper from '$examples/rapier/collision-groups/Wrapper.svelte'
 </script>
 
-!!!module_summary title=CollisionGroups|sourcePath=/components/CollisionGroups/CollisionGroups.svelte|name=CollisionGroups|from=rapier|type=component|relatedDocs={[{name:"Rapier Collider Guide – Collision Groups",url:"https://rapier.rs/docs/user_guides/javascript/colliders#collision-groups-and-solver-groups"}]}
+!!!module_summary title=CollisionGroups|sourcePath=components/CollisionGroups/CollisionGroups.svelte|name=CollisionGroups|from=rapier|type=component|relatedDocs={[{name:"Rapier Collider Guide – Collision Groups",url:"https://rapier.rs/docs/user_guides/javascript/colliders#collision-groups-and-solver-groups"}]}
 
 The most efficient way of preventing some pairs of colliders from interacting with each other is to use a `<CollisionGroups>` component.
 

--- a/apps/docs/src/routes/rapier/debug.md
+++ b/apps/docs/src/routes/rapier/debug.md
@@ -2,7 +2,7 @@
 title: Debug
 ---
 
-!!!module_summary title=Debug|sourcePath=/components/Debug/Debug.svelte|name=Debug|from=rapier|type=component|relatedDocs={[{name:"Rapier DebugRenderBuffers Reference",url:"https://rapier.rs/javascript3d/classes/DebugRenderBuffers.html"}]}
+!!!module_summary title=Debug|sourcePath=components/Debug/Debug.svelte|name=Debug|from=rapier|type=component|relatedDocs={[{name:"Rapier DebugRenderBuffers Reference",url:"https://rapier.rs/javascript3d/classes/DebugRenderBuffers.html"}]}
 
 Use the Debug component to see live representations of all colliders in a scene.
 

--- a/apps/docs/src/routes/rapier/rigid-body.md
+++ b/apps/docs/src/routes/rapier/rigid-body.md
@@ -6,7 +6,7 @@ title: RigidBody
 import Wrapper from '$examples/rapier/rigid-body/Wrapper.svelte'
 </script>
 
-!!!module_summary title=RigidBody|sourcePath=/components/RigidBody/RigidBody.svelte|name=RigidBody|from=rapier|type=component|relatedDocs={[{name:"Rapier RigidBody reference",url:"https://rapier.rs/javascript3d/classes/RigidBody.html"}, {name:"Rapier Collider Guide",url:"https://rapier.rs/docs/user_guides/javascript/rigid_bodies"}]}
+!!!module_summary title=RigidBody|sourcePath=components/RigidBody/RigidBody.svelte|name=RigidBody|from=rapier|type=component|relatedDocs={[{name:"Rapier RigidBody reference",url:"https://rapier.rs/javascript3d/classes/RigidBody.html"}, {name:"Rapier Collider Guide",url:"https://rapier.rs/docs/user_guides/javascript/rigid_bodies"}]}
 
 The real-time simulation of rigid bodies subjected to forces and contacts is the main feature of a physics engine for videogames, robotics, or animation. Rigid bodies are typically used to simulate the dynamics of non-deformable solids as well as to integrate the trajectory of solids which velocities are controlled by the user (e.g. moving platforms).
 

--- a/apps/docs/src/routes/rapier/use-collision-groups.md
+++ b/apps/docs/src/routes/rapier/use-collision-groups.md
@@ -2,7 +2,7 @@
 title: useCollisionGroups
 ---
 
-!!!module_summary title=useCollisionGroups|sourcePath=/hooks/useCollisionGroups.svelte|name=useCollisionGroups|from=rapier|type=component
+!!!module_summary title=useCollisionGroups|sourcePath=hooks/useCollisionGroups.svelte|name=useCollisionGroups|from=rapier|type=component
 
 This hook can be used in conjunction with the component [`<CollisionGroups>`](/rapier/collision-groups). It uses the collision groups provided by a parent `<CollisionGroups>` component and lets you easily apply them to colliders.
 

--- a/apps/docs/src/routes/rapier/use-fixed-joint.md
+++ b/apps/docs/src/routes/rapier/use-fixed-joint.md
@@ -2,7 +2,7 @@
 title: useFixedJoint
 ---
 
-!!!module_summary title=useFixedJoint|sourcePath=/hooks/useFixedJoint.svelte|name=useFixedJoint|from=rapier|type=component
+!!!module_summary title=useFixedJoint|sourcePath=hooks/useFixedJoint.svelte|name=useFixedJoint|from=rapier|type=component
 
 Use this hook to initialize a [`FixedImpulseJoint`](https://rapier.rs/docs/user_guides/javascript/joints#fixed-joint).
 

--- a/apps/docs/src/routes/rapier/use-joint.md
+++ b/apps/docs/src/routes/rapier/use-joint.md
@@ -2,7 +2,7 @@
 title: useJoint
 ---
 
-!!!module_summary title=useJoint|sourcePath=/hooks/useJoint.svelte|name=useJoint|from=rapier|type=component
+!!!module_summary title=useJoint|sourcePath=hooks/useJoint.svelte|name=useJoint|from=rapier|type=component
 
 Use this hook to initialize any [Rapier joint](https://rapier.rs/docs/user_guides/javascript/joints).
 

--- a/apps/docs/src/routes/rapier/use-prismatic-joint.md
+++ b/apps/docs/src/routes/rapier/use-prismatic-joint.md
@@ -2,7 +2,7 @@
 title: usePrismaticJoint
 ---
 
-!!!module_summary title=usePrismaticJoint|sourcePath=/hooks/usePrismaticJoint.svelte|name=usePrismaticJoint|from=rapier|type=component
+!!!module_summary title=usePrismaticJoint|sourcePath=hooks/usePrismaticJoint.svelte|name=usePrismaticJoint|from=rapier|type=component
 
 Use this hook to initialize a [`PrismaticImpulseJoint`](https://rapier.rs/docs/user_guides/javascript/joints#prismatic-joint).
 

--- a/apps/docs/src/routes/rapier/use-rapier.md
+++ b/apps/docs/src/routes/rapier/use-rapier.md
@@ -2,7 +2,7 @@
 title: useRapier
 ---
 
-!!!module_summary title=useRapier|sourcePath=/hooks/useRapier.svelte|name=useRapier|from=rapier|type=component
+!!!module_summary title=useRapier|sourcePath=hooks/useRapier.svelte|name=useRapier|from=rapier|type=component
 
 This hook provides access to the underlying `RAPIER.World` as well as the means to add and remove colliders and rigid bodies from the events system.
 

--- a/apps/docs/src/routes/rapier/use-revolute-joint.md
+++ b/apps/docs/src/routes/rapier/use-revolute-joint.md
@@ -2,7 +2,7 @@
 title: useRevoluteJoint
 ---
 
-!!!module_summary title=useRevoluteJoint|sourcePath=/hooks/useRevoluteJoint.svelte|name=useRevoluteJoint|from=rapier|type=component
+!!!module_summary title=useRevoluteJoint|sourcePath=hooks/useRevoluteJoint.svelte|name=useRevoluteJoint|from=rapier|type=component
 
 Use this hook to initialize a [`RevoluteImpulseJoint`](https://rapier.rs/docs/user_guides/javascript/joints#revolute-joint).
 

--- a/apps/docs/src/routes/rapier/use-rigid-body.md
+++ b/apps/docs/src/routes/rapier/use-rigid-body.md
@@ -2,7 +2,7 @@
 title: useRigidBody
 ---
 
-!!!module_summary title=useRigidBody|sourcePath=/hooks/useRigidBody.svelte|name=useRigidBody|from=rapier|type=component
+!!!module_summary title=useRigidBody|sourcePath=hooks/useRigidBody.svelte|name=useRigidBody|from=rapier|type=component
 
 This hook provides access to the `RAPIER.RigidBody` from a parent [`<RigidBody>`](/rapier/rigid-body) component.
 

--- a/apps/docs/src/routes/rapier/use-spherical-joint.md
+++ b/apps/docs/src/routes/rapier/use-spherical-joint.md
@@ -2,7 +2,7 @@
 title: useSphericalJoint
 ---
 
-!!!module_summary title=useSphericalJoint|sourcePath=/hooks/useSphericalJoint.svelte|name=useSphericalJoint|from=rapier|type=component
+!!!module_summary title=useSphericalJoint|sourcePath=hooks/useSphericalJoint.svelte|name=useSphericalJoint|from=rapier|type=component
 
 Use this hook to initialize a [`SphericalImpulseJoint`](https://rapier.rs/docs/user_guides/javascript/joints#spherical-joint).
 

--- a/apps/docs/src/routes/rapier/world.md
+++ b/apps/docs/src/routes/rapier/world.md
@@ -6,7 +6,7 @@ title: World
 import Wrapper from '$examples/rapier/world/Wrapper.svelte'
 </script>
 
-!!!module_summary title=World|sourcePath=/components/World/World.svelte|name=World|from=rapier|type=component|relatedDocs={[{name:"Rapier World reference",url:"https://rapier.rs/javascript3d/classes/World.html"}]}
+!!!module_summary title=World|sourcePath=components/World/World.svelte|name=World|from=rapier|type=component|relatedDocs={[{name:"Rapier World reference",url:"https://rapier.rs/javascript3d/classes/World.html"}]}
 
 This component provides the basic physics context and loads [rapier](https://rapier.rs/).
 


### PR DESCRIPTION
I noticed there's an extra `/` in some components/hooks source path URL, which is not good for the environment, so I removed them.

![Screenshot_20220812_012352](https://user-images.githubusercontent.com/12211826/184528328-c7c0f065-e2e4-4e4a-8c13-31bb446b7813.png)
 
You can check it out, by hovering over the `View Source Code` link in [this page](https://threlte.xyz/extras/edges#example) for example