### PR TITLE
Remove the tip that was a remnant from copy-pasting some documentation.

### DIFF
--- a/apps/docs/src/routes/core/interactive-object.md
+++ b/apps/docs/src/routes/core/interactive-object.md
@@ -14,10 +14,6 @@ This is a **trait component**. Trait components are mostly used internally and m
 
 ### Basic Example
 
-:::admonition type="tip"
-You most likely want to use a [`<MeshInstance>`](/core/mesh-instance) component in this scenario. The component `<InteractiveObject>` is part of the component [`<Object3DInstance>`](/core/object3d-instance), which the component `<MeshInstance>` is extending.
-:::
-
 ```svelte
 <script>
 	import { InteractiveObject } from '@threlte/core'


### PR DESCRIPTION
Removing this as it was a copy-paste mistake, mentioned in [this Discord message](https://discord.com/channels/985983540804091964/986233334747254854/1007912434557796362).