### PR TITLE
feature(rapier): add Attractor component

### DIFF
--- a/apps/docs/src/examples/rapier/attractor/Button.svelte
+++ b/apps/docs/src/examples/rapier/attractor/Button.svelte
@@ -1,0 +1,6 @@
+<button
+	on:click
+	class="text-sm rounded-md shadow-lg border border-gray-divider px-4 bg-gray-body hover:bg-gray-hover pointer-events-auto"
+>
+	<slot />
+</button>

--- a/apps/docs/src/examples/rapier/attractor/Ground.svelte
+++ b/apps/docs/src/examples/rapier/attractor/Ground.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { Mesh } from '@threlte/core'
+	import { AutoColliders } from '@threlte/rapier'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+</script>
+
+<AutoColliders shape={'cuboid'} position={{ y: -0.5 }}>
+	<Mesh
+		receiveShadow
+		geometry={new BoxBufferGeometry(10, 1, 10)}
+		material={new MeshStandardMaterial()}
+	/>
+</AutoColliders>

--- a/apps/docs/src/examples/rapier/attractor/Particle.svelte
+++ b/apps/docs/src/examples/rapier/attractor/Particle.svelte
@@ -1,0 +1,61 @@
+<script lang="ts" context="module">
+	const geometry = new BoxBufferGeometry(1, 1, 1)
+	const material = new MeshStandardMaterial()
+	export const muted = writable(true)
+</script>
+
+<script lang="ts">
+	import { Mesh, PositionalAudio, type Position, type Rotation } from '@threlte/core'
+	import { Collider, RigidBody, type ContactEvent } from '@threlte/rapier'
+	import { writable } from 'svelte/store'
+	import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
+	import { clamp } from 'three/src/math/MathUtils'
+
+	export let position: Position | undefined = undefined
+	export let rotation: Rotation | undefined = undefined
+
+	const audios: {
+		threshold: number
+		volume: number
+		stop: (() => any) | undefined
+		play: ((...args: any[]) => any) | undefined
+		source: string
+	}[] = new Array(9).fill(0).map((_, i) => {
+		return {
+			threshold: i / 10,
+			play: undefined,
+			stop: undefined,
+			volume: (i + 2) / 10,
+			source: `/audio/ball_bounce_${i + 1}.mp3`
+		}
+	})
+
+	const fireSound = (e: ContactEvent) => {
+		if ($muted) return
+		const volume = clamp((e.detail.totalForceMagnitude - 30) / 1100, 0.1, 1)
+		const audio = audios.find((a) => a.volume >= volume)
+		audio?.stop?.()
+		audio?.play?.()
+	}
+</script>
+
+<RigidBody type={'dynamic'} {position} {rotation} on:contact={fireSound}>
+	{#each audios as audio}
+		<PositionalAudio
+			autoplay={false}
+			detune={600 - Math.random() * 1200}
+			bind:stop={audio.stop}
+			bind:play={audio.play}
+			source={audio.source}
+			volume={audio.volume}
+		/>
+	{/each}
+
+	<Collider
+		contactForceEventThreshold={30}
+		restitution={0.4}
+		shape={'cuboid'}
+		args={[0.5, 0.5, 0.5]}
+	/>
+	<Mesh castShadow receiveShadow {geometry} {material} />
+</RigidBody>

--- a/apps/docs/src/examples/rapier/attractor/RandomMeshes.svelte
+++ b/apps/docs/src/examples/rapier/attractor/RandomMeshes.svelte
@@ -1,0 +1,53 @@
+<script lang="ts" context="module">
+	const geometry = new SphereBufferGeometry(0.75)
+	const material = new MeshBasicMaterial({ color: 'red' })
+</script>
+
+<script lang="ts">
+	import { SphereBufferGeometry, MeshBasicMaterial } from 'three'
+	import { Mesh } from '@threlte/core'
+	import { RigidBody, Collider } from '@threlte/rapier'
+	import { Vector3 } from 'three'
+
+	export let count: number = 20
+	export let rangeX: [number, number] = [-20, 20]
+	export let rangeY: [number, number] = [-20, 20]
+	export let rangeZ: [number, number] = [-20, 20]
+
+	const getId = () => {
+		return Math.random().toString(16).slice(2)
+	}
+
+	const randomNumber = (min: number, max: number): number => {
+		return Math.random() * (max - min) + min
+	}
+
+	const getRandomPosition = () => {
+		return new Vector3(
+			randomNumber(rangeX[0], rangeX[1]),
+			randomNumber(rangeY[0], rangeY[1]),
+			randomNumber(rangeZ[0], rangeZ[1])
+		)
+	}
+
+	const generateBodies = (c: number) => {
+		return Array(c)
+			.fill('x')
+			.map((_) => {
+				console.log('new bodies')
+				return {
+					id: getId(),
+					position: getRandomPosition()
+				}
+			})
+	}
+
+	$: bodies = generateBodies(count)
+</script>
+
+{#each bodies as body (body.id)}
+	<RigidBody position={body.position}>
+		<Collider shape="ball" args={[0.75]} />
+		<Mesh {geometry} {material} />
+	</RigidBody>
+{/each}

--- a/apps/docs/src/examples/rapier/attractor/Scene.svelte
+++ b/apps/docs/src/examples/rapier/attractor/Scene.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import {
+		DirectionalLight,
+		Object3DInstance,
+		OrbitControls,
+		PerspectiveCamera
+	} from '@threlte/core'
+	import { Debug, Attractor } from '@threlte/rapier'
+	import { GridHelper } from 'three'
+	import RandomMeshes from './RandomMeshes.svelte'
+	let count: number = 50
+	export let showHelper: boolean
+	export let strengthLeft: number
+	export let strengthCenter: number
+	export let strengthRight: number
+	export const reset = () => {
+		count = 0
+		setTimeout(() => (count = 50))
+	}
+</script>
+
+<PerspectiveCamera position={{ y: 50, z: 100 }} fov={70}>
+	<OrbitControls enableZoom={true} target={{ y: 20 }} />
+</PerspectiveCamera>
+
+<DirectionalLight shadow position={{ y: 20, x: 8, z: -3 }} />
+
+<Object3DInstance object={new GridHelper(100)} />
+
+<Debug />
+
+<RandomMeshes {count} rangeX={[-30, 30]} rangeY={[0, 100]} rangeZ={[-10, 10]} />
+
+<Attractor range={20} strength={strengthLeft} {showHelper} position={{ x: -25, y: 10 }} />
+<Attractor range={20} strength={strengthCenter} {showHelper} position={{ y: 10 }} />
+<Attractor range={20} strength={strengthRight} {showHelper} position={{ x: 25, y: 10 }} />

--- a/apps/docs/src/examples/rapier/attractor/Wrapper.svelte
+++ b/apps/docs/src/examples/rapier/attractor/Wrapper.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { Canvas } from '@threlte/core'
+	import { HTML } from '@threlte/extras'
+	import { World } from '@threlte/rapier'
+	import Button from './Button.svelte'
+	import Scene from './Scene.svelte'
+
+	let showHelper: boolean = false
+	let reset: any
+	let strengthLeft: number = 1
+	let strengthCenter: number = 1
+	let strengthRight: number = 1
+</script>
+
+<div class="relative w-full h-full">
+	<div class="flex flex-col gap-2 items-start m-4 absolute">
+		<Button
+			on:click={() => {
+				reset()
+				strengthLeft = 1
+				strengthCenter = 1
+				strengthRight = 1
+			}}>Reset</Button
+		>
+		<Button on:click={() => (showHelper = !showHelper)}>Toggle Helper</Button>
+		<label
+			>Strength Left: {strengthLeft}
+			<input type="range" min="-20" max="20" step="1" bind:value={strengthLeft} />
+		</label>
+		<label
+			>Strength Center: {strengthCenter}
+			<input type="range" min="-20" max="20" step="1" bind:value={strengthCenter} />
+		</label>
+		<label
+			>Strength Right: {strengthRight}
+			<input type="range" min="-20" max="20" step="1" bind:value={strengthRight} />
+		</label>
+	</div>
+	<Canvas>
+		<World gravity={{ y: -2 }}>
+			<Scene {showHelper} bind:reset {strengthLeft} {strengthCenter} {strengthRight} />
+			<HTML slot="fallback" transform>
+				<p class="text-xs">
+					It seems your browser<br />
+					doesn't support WASM.<br />
+					I'm sorry.
+				</p>
+			</HTML>
+		</World>
+	</Canvas>
+</div>

--- a/apps/docs/src/routes/navigation.ts
+++ b/apps/docs/src/routes/navigation.ts
@@ -361,6 +361,10 @@ export const sidebar = {
 				slug: '/rapier/collision-groups'
 			},
 			{
+				title: 'Attractor',
+				slug: '/rapier/attractor'
+			},
+			{
 				title: 'Debug',
 				slug: '/rapier/debug'
 			},

--- a/apps/docs/src/routes/rapier/attractor.md
+++ b/apps/docs/src/routes/rapier/attractor.md
@@ -1,0 +1,32 @@
+---
+title: Attractor
+---
+
+<script lang="ts">
+import Wrapper from '$examples/rapier/attractor/Wrapper.svelte'
+</script>
+
+!!!module_summary title=Attractor|sourcePath=components/Attractor/Attractor.svelte|name=Attractor|from=rapier|type=component
+
+An Attractor simulates a source of gravity. Any RigidBody within range will be "pulled" toward the Attractor at the specified strength.
+
+<ExampleWrapper>
+  <Wrapper />
+</ExampleWrapper>
+
+&&&code_wrapper
+@[code svelte|title=Wrapper.svelte](../../examples/rapier/attractor/Wrapper.svelte)
+@[code svelte|title=Scene.svelte](../../examples/rapier/attractor/Scene.svelte)
+@[code svelte|title=RandomMeshes.svelte](../../examples/rapier/attractor/RandomMeshes.svelte)
+&&&
+
+!!!
+
+### Properties
+
+```ts
+// optional
+position: Position | undefined = undefined
+strength: number | = 1
+range: number = 10
+```

--- a/packages/rapier/src/lib/components/Attractor/Attractor.svelte
+++ b/packages/rapier/src/lib/components/Attractor/Attractor.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { RigidBody } from '@dimforge/rapier3d-compat'
+  import { Mesh, useFrame } from '@threlte/core'
+  import { SphereBufferGeometry } from 'three'
+  import { MeshBasicMaterial } from 'three'
+  import { Vector3 } from 'three'
+  import { useRapier } from '../../hooks/useRapier'
+  import type { AttractorProperties } from '../../types/components'
+
+  const { world } = useRapier()
+
+  export let position: AttractorProperties['position'] = { x: 0, y: 0, z: 0 }
+  export let strength: NonNullable<AttractorProperties['strength']> = 1
+  export let range: NonNullable<AttractorProperties['range']> = 10
+  export let showHelper: AttractorProperties['showHelper'] = false
+
+  const gravitySource = new Vector3(position?.x, position?.y, position?.z)
+
+  function applyImpulseToBodiesInRange() {
+    const impulseVector = new Vector3()
+    world.forEachActiveRigidBody((body: RigidBody) => {
+      const { x, y, z } = body.translation()
+      const bodyV3: Vector3 = new Vector3(x, y, z)
+      const distance: number = gravitySource.distanceTo(bodyV3)
+      if (distance < range) {
+        impulseVector.subVectors(gravitySource, bodyV3).normalize().multiplyScalar(strength)
+        body.applyImpulse(impulseVector, true)
+      }
+    })
+  }
+
+  useFrame(() => {
+    applyImpulseToBodiesInRange()
+  })
+</script>
+
+{#if showHelper}
+  <Mesh
+    geometry={new SphereBufferGeometry(range)}
+    material={new MeshBasicMaterial({ wireframe: true })}
+    {position}
+  />
+  <Mesh
+    geometry={new SphereBufferGeometry()}
+    material={new MeshBasicMaterial({ color: 'black', wireframe: false })}
+    {position}
+  />
+{/if}

--- a/packages/rapier/src/lib/index.ts
+++ b/packages/rapier/src/lib/index.ts
@@ -17,6 +17,7 @@ export { default as Debug } from './components/Debug/Debug.svelte'
 export { default as Collider } from './components/Colliders/Collider.svelte'
 export { default as AutoColliders } from './components/Colliders/AutoColliders.svelte'
 export { default as CollisionGroups } from './components/CollisionGroups/CollisionGroups.svelte'
+export { default as Attractor } from './components/Attractor/Attractor.svelte'
 
 // recipes
 export { default as BasicPlayerController } from './recipes/BasicPlayerController.svelte'
@@ -25,7 +26,8 @@ export type {
   AutoCollidersProperties,
   Boolean3Array,
   RigidBodyProperties,
-  WorldProperties
+  WorldProperties,
+  AttractorProperties
 } from './types/components'
 
 export type {
@@ -39,5 +41,5 @@ export type {
   CollisionExitEvent,
   SensorEnterEvent,
   SensorExitEvent,
-  ContactEvent
+  ContactEvent,
 } from './types/types'

--- a/packages/rapier/src/lib/types/components.ts
+++ b/packages/rapier/src/lib/types/components.ts
@@ -177,3 +177,24 @@ export type CollisionGroupsProperties =
       filter: CollisionGroupsBitMask
       memberships: CollisionGroupsBitMask
     }
+
+
+    export type AttractorProperties = Omit<TransformableObjectProperties, 'object'> & {
+      /**
+       * The radius for the Attractor's sphere of influence within which rigid-bodies will be affected.
+       * Default: 10.0
+       */
+      range?: number
+      /**
+       * The strength factor applied to the impulse affecting rigid-bodies within range.
+       * Default: 1.0
+       */
+      strength?: number
+      
+      /**
+       * A helper to visualize the location and range of the attractor.
+       * Default: false
+       */
+      showHelper?: boolean;
+    }
+    


### PR DESCRIPTION
This first iteration seems to mostly work but a few parts that could use a more thorough review:

1. Dynamically updating the range does not work and I'm not sure why. 
To reproduce: 
*  set world gravity to 0 in `Wrapper.svelte`
*  create a tweened store in `Scene.svelte` and onMount set it to 100 with duration 30000
* You can see with the helper (and via logs) that in the `Attractor.svelte` component the `range` is changing, but the `if (distance < range)` check is not

2. I would like Attractor to inherit parent position if not otherwise specified but I don't know how to do that. This would allow it to work inside a Mesh, Group, etc more easily.

3. I would like Attractor to work inside <RigidBody /> so that the attractors themselves could react to one another (this may be solved by addressing #2 above)

4. I added the `showHelper` prop because I think it's useful, but if #2 above is resolved then users could easily recreate this themselves. It's more of a convenience prop but happy to remove it.

Open to all feedback!