### PR TITLE
[Enhancemen] Environment - ground projection reactivity & docs

### DIFF
--- a/.changeset/late-zebras-move.md
+++ b/.changeset/late-zebras-move.md
@@ -1,0 +1,6 @@
+---
+'@threlte/docs': patch
+'@threlte/extras': patch
+---
+
+Environment - GroundProjection reactivity bugfix & docs update

--- a/apps/docs/src/examples/core/positional-audio/Scene.svelte
+++ b/apps/docs/src/examples/core/positional-audio/Scene.svelte
@@ -1,64 +1,58 @@
 <script lang="ts">
-  import {
-  AudioListener,
-  DirectionalLight,
-  HemisphereLight,
-  Mesh,
-  OrbitControls,
-  OrthographicCamera,
-  useLoader,
-  useThrelte
-  } from '@threlte/core'
-  import { spring } from 'svelte/motion'
-  import {
-  CircleBufferGeometry,EquirectangularReflectionMapping,
-  MeshStandardMaterial
-  } from 'three'
-  import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
-  import { DEG2RAD } from 'three/src/math/MathUtils'
-  import Speaker from './Speaker.svelte'
-  import Turntable from './Turntable.svelte'
+	import {
+		AudioListener,
+		DirectionalLight,
+		HemisphereLight,
+		Mesh,
+		OrbitControls,
+		OrthographicCamera,
+		useLoader,
+		useThrelte
+	} from '@threlte/core'
+	import { Environment } from '@threlte/extras'
+	import { spring } from 'svelte/motion'
+	import { CircleGeometry, MeshStandardMaterial } from 'three'
+	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+	import { DEG2RAD } from 'three/src/math/MathUtils'
+	import Speaker from './Speaker.svelte'
+	import Turntable from './Turntable.svelte'
 
-  let volume = 0
-  let isPlaying = false
+	let volume = 0
+	let isPlaying = false
 
-  const smoothVolume = spring(0)
-  $: smoothVolume.set(volume)
+	const smoothVolume = spring(0)
+	$: smoothVolume.set(volume)
 
-  const { size } = useThrelte()
+	const { size } = useThrelte()
 
-  const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-  const { scene, invalidate } = useThrelte()
-  rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', (texture) => {
-    texture.mapping = EquirectangularReflectionMapping
-    scene.environment = texture
-    scene.environment.rotation = 180
-    invalidate('texture loaded')
-  })
+	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
+	const { scene, invalidate } = useThrelte()
 
-  let zoom = $size.width / 18
-  $: zoom = $size.width / 18
+	let zoom = $size.width / 18
+	$: zoom = $size.width / 18
 </script>
 
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
+
 <OrthographicCamera {zoom} position={{ z: 9, y: 9, x: 6 }}>
-  <OrbitControls
-    autoRotate={isPlaying}
-    autoRotateSpeed={0.5}
-    enableDamping
-    maxPolarAngle={DEG2RAD * 80}
-    target={{ y: 1.5 }}
-  />
-  <AudioListener />
+	<OrbitControls
+		autoRotate={isPlaying}
+		autoRotateSpeed={0.5}
+		enableDamping
+		maxPolarAngle={DEG2RAD * 80}
+		target={{ y: 1.5 }}
+	/>
+	<AudioListener />
 </OrthographicCamera>
 
 <!-- FLOOR -->
 <Mesh
-  receiveShadow
-  geometry={new CircleBufferGeometry(10, 64)}
-  material={new MeshStandardMaterial({
-    color: 0x333333
-  })}
-  rotation={{ x: DEG2RAD * -90 }}
+	receiveShadow
+	geometry={new CircleGeometry(10, 64)}
+	material={new MeshStandardMaterial({
+		color: 0x333333
+	})}
+	rotation={{ x: DEG2RAD * -90 }}
 />
 
 <Turntable bind:isPlaying bind:volume />
@@ -67,16 +61,16 @@
 <Speaker position={{ x: -6 }} rotation={{ y: DEG2RAD * 7 }} {volume} />
 
 <DirectionalLight
-  shadow={{
-    mapSize: [1024, 1024],
-    camera: {
-      left: -9,
-      right: 9,
-      top: 9,
-      bottom: -9
-    }
-  }}
-  position={{ x: 10, y: 20, z: 8 }}
-  intensity={0.3}
+	shadow={{
+		mapSize: [1024, 1024],
+		camera: {
+			left: -9,
+			right: 9,
+			top: 9,
+			bottom: -9
+		}
+	}}
+	position={{ x: 10, y: 20, z: 8 }}
+	intensity={0.3}
 />
 <HemisphereLight intensity={0} skyColor={0xffbd08} groundColor={0x323973} />

--- a/apps/docs/src/examples/extras/contact-shadows/Scene.svelte
+++ b/apps/docs/src/examples/extras/contact-shadows/Scene.svelte
@@ -6,21 +6,18 @@
 		OrbitControls,
 		PerspectiveCamera,
 		useFrame,
-		useLoader,
 		useThrelte
 	} from '@threlte/core'
-	import { ContactShadows, Float } from '@threlte/extras'
+	import { ContactShadows, Environment, Float } from '@threlte/extras'
 	import { onDestroy } from 'svelte'
-	import { EquirectangularReflectionMapping } from 'three'
 	import {
-		BoxBufferGeometry,
+		BoxGeometry,
 		Color,
 		GridHelper,
-		IcosahedronBufferGeometry,
+		IcosahedronGeometry,
 		MeshStandardMaterial,
-		TorusKnotBufferGeometry
+		TorusKnotGeometry
 	} from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 
 	const material = new MeshStandardMaterial({
 		color: 0x0000ff
@@ -35,16 +32,6 @@
 		scene.remove(gridHelper)
 	})
 
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', (texture) => {
-		texture.mapping = EquirectangularReflectionMapping
-		invalidate('texture loaded')
-	})
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
-	})
-
 	let pos = {
 		x: 0
 	}
@@ -52,6 +39,8 @@
 		pos.x = Math.sin(Date.now() / 2000)
 	})
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ y: 10, x: -10, z: 10 }} fov={25}>
 	<OrbitControls enabled={false} autoRotate autoRotateSpeed={0.5} target={{ y: 1 }} />
@@ -65,7 +54,7 @@
 <Float floatIntensity={1} floatingRange={[0, 1]}>
 	<Mesh
 		position={{ y: 1.2, z: -0.75 }}
-		geometry={new BoxBufferGeometry(1, 1, 1)}
+		geometry={new BoxGeometry(1, 1, 1)}
 		material={new MeshStandardMaterial({
 			color: new Color('#0059BA').convertSRGBToLinear()
 		})}
@@ -76,7 +65,7 @@
 	<Mesh
 		position={{ y: 1.5, x: 1.2, z: 0.75 }}
 		rotation={{ x: 5, y: 71 }}
-		geometry={new TorusKnotBufferGeometry(0.5, 0.15, 100, 12, 2, 3)}
+		geometry={new TorusKnotGeometry(0.5, 0.15, 100, 12, 2, 3)}
 		material={new MeshStandardMaterial({
 			color: new Color('#F85122').convertSRGBToLinear()
 		})}
@@ -87,7 +76,7 @@
 	<Mesh
 		position={{ y: 1.5, x: -1.4, z: 0.75 }}
 		rotation={{ x: -5, y: 128, z: 10 }}
-		geometry={new IcosahedronBufferGeometry(1, 0)}
+		geometry={new IcosahedronGeometry(1, 0)}
 		material={new MeshStandardMaterial({
 			color: new Color('#F8EBCE').convertSRGBToLinear()
 		})}

--- a/apps/docs/src/examples/extras/float/Scene.svelte
+++ b/apps/docs/src/examples/extras/float/Scene.svelte
@@ -1,29 +1,18 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte'
-	import { derived } from 'svelte/store'
-	import { EquirectangularReflectionMapping, GridHelper, Mesh as ThreeMesh } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 	import {
 		AmbientLight,
 		DirectionalLight,
 		OrbitControls,
 		PerspectiveCamera,
-		useLoader,
 		useThrelte
 	} from '@threlte/core'
-	import { useGltf } from '@threlte/extras'
+	import { Environment, useGltf } from '@threlte/extras'
+	import { onDestroy } from 'svelte'
+	import { derived } from 'svelte/store'
+	import { GridHelper, Mesh as ThreeMesh } from 'three'
 	import Blob from './Blob.svelte'
 
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', () => {
-		invalidate('texture loaded')
-	})
-	texture.mapping = EquirectangularReflectionMapping
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
-	})
+	const { scene } = useThrelte()
 
 	type Nodes = 'ball-1' | 'ball-2' | 'ball-3' | 'ball-4' | 'ball-5'
 	const { gltf } = useGltf<Nodes>('/models/blobs/blobs.glb', {
@@ -42,6 +31,8 @@
 		scene.remove(gridHelper)
 	})
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ z: 20 }} fov={50}>
 	<OrbitControls target={{ y: -2 }} enableDamping />

--- a/apps/docs/src/examples/extras/gltf/Scene.svelte
+++ b/apps/docs/src/examples/extras/gltf/Scene.svelte
@@ -1,29 +1,9 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte'
-	import { EquirectangularReflectionMapping } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
-	import {
-		AmbientLight,
-		OrbitControls,
-		PerspectiveCamera,
-		useLoader,
-		useThrelte
-	} from '@threlte/core'
-	import { GLTF } from '@threlte/extras'
-
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', () => {
-		invalidate('texture loaded')
-	})
-	texture.mapping = EquirectangularReflectionMapping
-	scene.environment = texture
-
-	onDestroy(() => {
-		texture.dispose()
-	})
+	import { AmbientLight, OrbitControls, PerspectiveCamera } from '@threlte/core'
+	import { Environment, GLTF } from '@threlte/extras'
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ x: 5, y: 2, z: 5 }} fov={25}>
 	<OrbitControls autoRotate enableDamping />

--- a/apps/docs/src/examples/extras/html/phone/Scene.svelte
+++ b/apps/docs/src/examples/extras/html/phone/Scene.svelte
@@ -1,29 +1,11 @@
 <script lang="ts">
-	import { AmbientLight, PerspectiveCamera, useLoader, useThrelte } from '@threlte/core'
-	import { Mesh } from '@threlte/core'
-	import { Float, GLTF, HTML, useGltf } from '@threlte/extras'
-	import { onDestroy } from 'svelte'
+	import { AmbientLight, Mesh, PerspectiveCamera, useThrelte } from '@threlte/core'
+	import { Environment, Float, HTML, useGltf } from '@threlte/extras'
 	import { spring } from 'svelte/motion'
 	import { derived } from 'svelte/store'
 	import type { Mesh as ThreeMesh } from 'three'
-	import { MeshStandardMaterial } from 'three'
-	import { Color } from 'three'
-	import { EquirectangularReflectionMapping } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+	import { Color, MeshStandardMaterial } from 'three'
 	import { DEG2RAD } from 'three/src/math/MathUtils'
-
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', () => {
-		invalidate('texture loaded')
-	})
-	texture.mapping = EquirectangularReflectionMapping
-	scene.environment = texture
-
-	onDestroy(() => {
-		texture.dispose()
-	})
 
 	const { pointer } = useThrelte()
 
@@ -40,6 +22,8 @@
 
 	const url = window.origin
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ z: $offsetX, x: 50, y: -$offsetY }} fov={20} lookAt={{}} />
 

--- a/apps/docs/src/examples/extras/use-gltf/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-gltf/Scene.svelte
@@ -1,33 +1,17 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte'
-	import { derived } from 'svelte/store'
-	import { EquirectangularReflectionMapping } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 	import {
 		DirectionalLight,
 		Group,
 		Object3DInstance,
 		PerspectiveCamera,
-		useFrame,
-		useLoader,
-		useThrelte
+		useFrame
 	} from '@threlte/core'
-	import { useGltf } from '@threlte/extras'
+	import { Environment, useGltf } from '@threlte/extras'
+	import { derived } from 'svelte/store'
 
 	let rotation = 0
 	useFrame(() => {
 		rotation += 0.01
-	})
-
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', () => {
-		invalidate('texture loaded')
-	})
-	texture.mapping = EquirectangularReflectionMapping
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
 	})
 
 	const { gltf } = useGltf<'node_damagedHelmet_-6514', 'Material_MR'>(
@@ -39,6 +23,8 @@
 		return gltf.nodes['node_damagedHelmet_-6514']
 	})
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ z: 10 }} fov={20} />
 

--- a/apps/docs/src/examples/extras/use-progress/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-progress/Scene.svelte
@@ -4,30 +4,14 @@
 		Group,
 		Object3DInstance,
 		PerspectiveCamera,
-		useFrame,
-		useLoader,
-		useThrelte
+		useFrame
 	} from '@threlte/core'
-	import { useGltf } from '@threlte/extras'
-	import { onDestroy } from 'svelte'
+	import { Environment, useGltf } from '@threlte/extras'
 	import { derived } from 'svelte/store'
-	import { EquirectangularReflectionMapping } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 
 	let rotation = 0
 	useFrame(() => {
 		rotation += 0.01
-	})
-
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', () => {
-		invalidate('texture loaded')
-	})
-	texture.mapping = EquirectangularReflectionMapping
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
 	})
 
 	const { gltf } = useGltf<'node_damagedHelmet_-6514', 'Material_MR'>(
@@ -39,6 +23,8 @@
 		return gltf.nodes['node_damagedHelmet_-6514']
 	})
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ z: 10 }} fov={20} />
 

--- a/apps/docs/src/examples/rapier/auto-colliders/Scene.svelte
+++ b/apps/docs/src/examples/rapier/auto-colliders/Scene.svelte
@@ -4,29 +4,14 @@
 		Mesh,
 		Object3DInstance,
 		OrbitControls,
-		PerspectiveCamera,
-		useLoader,
-		useThrelte
+		PerspectiveCamera
 	} from '@threlte/core'
-	import { useGltf } from '@threlte/extras'
+	import { Environment, useGltf } from '@threlte/extras'
 	import { AutoColliders, RigidBody } from '@threlte/rapier'
-	import { onDestroy } from 'svelte'
 	import { derived } from 'svelte/store'
-	import { EquirectangularReflectionMapping, GridHelper, Mesh as ThreeMesh } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+	import { GridHelper, Mesh as ThreeMesh } from 'three'
 	import { DEG2RAD } from 'three/src/math/MathUtils'
 	import Ground from './Ground.svelte'
-
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', (texture) => {
-		texture.mapping = EquirectangularReflectionMapping
-		invalidate('texture loaded')
-	})
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
-	})
 
 	const { gltf } = useGltf<'node_damagedHelmet_-6514', 'Material_MR'>(
 		'/models/helmet/DamagedHelmet.gltf'
@@ -36,6 +21,8 @@
 		return gltf.nodes['node_damagedHelmet_-6514'] as ThreeMesh
 	})
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ y: 13, x: 12 }} fov={40}>
 	<OrbitControls target={{ x: 2.5 }} />

--- a/apps/docs/src/examples/rapier/basic-car-controller/Scene.svelte
+++ b/apps/docs/src/examples/rapier/basic-car-controller/Scene.svelte
@@ -1,34 +1,16 @@
 <script lang="ts">
-	import {
-		DirectionalLight,
-		Mesh,
-		Object3DInstance,
-		PerspectiveCamera,
-		useLoader,
-		useThrelte
-	} from '@threlte/core'
-	import { HTML, useGltf } from '@threlte/extras'
+	import { DirectionalLight, Mesh, Object3DInstance, PerspectiveCamera } from '@threlte/core'
+	import { Environment, HTML, useGltf } from '@threlte/extras'
 	import { AutoColliders, RigidBody } from '@threlte/rapier'
-	import { onDestroy } from 'svelte'
-	import { BoxBufferGeometry, EquirectangularReflectionMapping, MeshStandardMaterial } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+	import { BoxGeometry, MeshStandardMaterial } from 'three'
 	import { DEG2RAD } from 'three/src/math/MathUtils'
 	import Car from './Car.svelte'
 	import Ground from './Ground.svelte'
 
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', (texture) => {
-		texture.mapping = EquirectangularReflectionMapping
-		invalidate('texture loaded')
-	})
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
-	})
-
 	const { gltf } = useGltf('/models/loop/loop.glb')
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <DirectionalLight position={{ y: 20, x: 8, z: -3 }} />
 
@@ -39,7 +21,7 @@
 		<p>Dominance: 1</p>
 	</HTML>
 	<AutoColliders shape={'cuboid'}>
-		<Mesh geometry={new BoxBufferGeometry(1, 1, 1)} material={new MeshStandardMaterial()} />
+		<Mesh geometry={new BoxGeometry(1, 1, 1)} material={new MeshStandardMaterial()} />
 	</AutoColliders>
 </RigidBody>
 
@@ -48,7 +30,7 @@
 		<p>Dominance: -1</p>
 	</HTML>
 	<AutoColliders shape={'cuboid'}>
-		<Mesh geometry={new BoxBufferGeometry(3, 3, 3)} material={new MeshStandardMaterial()} />
+		<Mesh geometry={new BoxGeometry(3, 3, 3)} material={new MeshStandardMaterial()} />
 	</AutoColliders>
 </RigidBody>
 
@@ -57,7 +39,7 @@
 		<p>Dominance: 0</p>
 	</HTML>
 	<AutoColliders shape={'cuboid'}>
-		<Mesh geometry={new BoxBufferGeometry(2, 2, 2)} material={new MeshStandardMaterial()} />
+		<Mesh geometry={new BoxGeometry(2, 2, 2)} material={new MeshStandardMaterial()} />
 	</AutoColliders>
 </RigidBody>
 

--- a/apps/docs/src/examples/rapier/collision-groups/Scene.svelte
+++ b/apps/docs/src/examples/rapier/collision-groups/Scene.svelte
@@ -2,42 +2,24 @@
 	import {
 		DirectionalLight,
 		Mesh,
-		MeshInstance,
 		Object3DInstance,
 		OrbitControls,
-		PerspectiveCamera,
-		useLoader,
-		useThrelte
+		PerspectiveCamera
 	} from '@threlte/core'
-	import { useGltf } from '@threlte/extras'
-	import { AutoColliders, Debug, RigidBody, CollisionGroups } from '@threlte/rapier'
-	import { onDestroy } from 'svelte'
-	import { derived } from 'svelte/store'
-	import { BoxBufferGeometry } from 'three'
-	import { MeshStandardMaterial } from 'three'
-	import { EquirectangularReflectionMapping, GridHelper, Mesh as ThreeMesh } from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
-	import { DEG2RAD } from 'three/src/math/MathUtils'
+	import { Environment } from '@threlte/extras'
+	import { AutoColliders, CollisionGroups, RigidBody } from '@threlte/rapier'
+	import { BoxGeometry, GridHelper, MeshStandardMaterial } from 'three'
 	import Ground from './Ground.svelte'
 
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	const { scene, invalidate } = useThrelte()
-	const texture = rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', (texture) => {
-		texture.mapping = EquirectangularReflectionMapping
-		invalidate('texture loaded')
-	})
-	scene.environment = texture
-	onDestroy(() => {
-		texture.dispose()
-	})
-
-	const geometry = new BoxBufferGeometry(1, 1, 1)
+	const geometry = new BoxGeometry(1, 1, 1)
 
 	let resetCounter = 0
 	export const reset = () => {
 		resetCounter += 1
 	}
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <PerspectiveCamera position={{ y: 13, x: 12 }} fov={40}>
 	<OrbitControls target={{ x: 2.5 }} />

--- a/apps/docs/src/examples/rapier/world/Scene.svelte
+++ b/apps/docs/src/examples/rapier/world/Scene.svelte
@@ -6,36 +6,24 @@
 		Object3DInstance,
 		OrthographicCamera,
 		useFrame,
-		useLoader,
 		useThrelte
 	} from '@threlte/core'
+	import { Environment } from '@threlte/extras'
 	import { AutoColliders, CollisionGroups, Debug } from '@threlte/rapier'
 	import { spring } from 'svelte/motion'
 	import {
-		BoxBufferGeometry,
-		EquirectangularReflectionMapping,
+		BoxGeometry,
 		GridHelper,
 		Group as ThreeGroup,
 		Mesh as ThreeMesh,
 		MeshStandardMaterial,
 		Vector3
 	} from 'three'
-	import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 	import Door from './Door.svelte'
 	import Ground from './Ground.svelte'
 	import Player from './Player.svelte'
 
-	const { scene, invalidate } = useThrelte()
-
 	let targetGroup: ThreeGroup
-
-	const rgbeLoader = useLoader(RGBELoader, () => new RGBELoader())
-	rgbeLoader.load('/hdr/shanghai_riverside_1k.hdr', (texture) => {
-		texture.mapping = EquirectangularReflectionMapping
-		scene.environment = texture
-		scene.environment.rotation = 180
-		invalidate('texture loaded')
-	})
 
 	let playerMesh: ThreeMesh
 	let positionHasBeenSet = false
@@ -58,6 +46,8 @@
 	const { size } = useThrelte()
 	$: zoom = $size.width / 8
 </script>
+
+<Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
 
 <Group position={{ x: $smoothPlayerPosX, z: $smoothPlayerPosZ }}>
 	<Group position={{ y: 0.9 }} bind:group={targetGroup}>
@@ -95,7 +85,7 @@
 			receiveShadow
 			castShadow
 			position={{ y: 1.275, x: 30 + 0.7 + 0.15 }}
-			geometry={new BoxBufferGeometry(60, 2.55, 0.15)}
+			geometry={new BoxGeometry(60, 2.55, 0.15)}
 			material={new MeshStandardMaterial({
 				transparent: true,
 				opacity: 0.5,
@@ -106,7 +96,7 @@
 			receiveShadow
 			castShadow
 			position={{ y: 1.275, x: -30 - 0.7 - 0.15 }}
-			geometry={new BoxBufferGeometry(60, 2.55, 0.15)}
+			geometry={new BoxGeometry(60, 2.55, 0.15)}
 			material={new MeshStandardMaterial({
 				transparent: true,
 				opacity: 0.5,

--- a/apps/docs/src/routes/extras/environment.md
+++ b/apps/docs/src/routes/extras/environment.md
@@ -31,6 +31,8 @@ The component decides whether to use **cubic** or **equirectangular** map based 
 
 Currently supported formats are 'ldr' (.jpg, .png, etc.) and 'hdr' .hdr. Format is inferred based on file extension but it can be provided in `format` prop.
 
+`isBackground` prop controls if environment is set as the background of `scene`. This is not related to GroundProjection which produces a faux background effect by creating a spherical object textured by the provided environment.
+
 ```svelte
 <!-- Cubic jpg envmap -->
 <Environment

--- a/packages/extras/src/lib/components/Environment/GroundProjectedEnv.svelte
+++ b/packages/extras/src/lib/components/Environment/GroundProjectedEnv.svelte
@@ -34,15 +34,17 @@
     }
   }
 
+  const removeGroundEnv = () => {
+    scene.remove(currentGroundEnv)
+    currentGroundEnv = undefined
+  }
+
   const toggleGroundEnv = (
     groundEnv: GroundProjectedEnv | undefined,
     groundEnvProps: EnvironmentProperties['groundProjection'],
     envMap: Texture
   ) => {
-    if (groundEnv && previousEnvMap != envMap) {
-      scene.remove(currentGroundEnv)
-      currentGroundEnv = undefined
-    }
+    if (groundEnv && previousEnvMap != envMap) removeGroundEnv()
     if ((!groundEnv || previousEnvMap != envMap) && groundEnvProps && envMap) {
       currentGroundEnv = new GroundProjectedEnv(envMap)
 
@@ -60,10 +62,7 @@
   $: toggleGroundEnv(currentGroundEnv, groundProjection, currentEnvMap)
 
   onDestroy(() => {
-    if (currentGroundEnv) {
-      scene.remove(currentGroundEnv)
-      currentGroundEnv = undefined
-    }
+    if (currentGroundEnv) removeGroundEnv()
     invalidate('Removing ground projected environment')
   })
 </script>

--- a/packages/extras/src/lib/components/Environment/GroundProjectedEnv.svelte
+++ b/packages/extras/src/lib/components/Environment/GroundProjectedEnv.svelte
@@ -39,6 +39,10 @@
     groundEnvProps: EnvironmentProperties['groundProjection'],
     envMap: Texture
   ) => {
+    if (groundEnv && previousEnvMap != envMap) {
+      scene.remove(currentGroundEnv)
+      currentGroundEnv = undefined
+    }
     if ((!groundEnv || previousEnvMap != envMap) && groundEnvProps && envMap) {
       currentGroundEnv = new GroundProjectedEnv(envMap)
 


### PR DESCRIPTION
1. I fixed a Ground projected environment bug pointed out on Discord by fogy.

It wouldn't update properly if toggled multiple times because it never cleared old projection if it was different than current environment map.

```js
if (groundEnv && previousEnvMap != envMap) removeGroundEnv()
```

2. I updated examples that manually loaded environment to instead use `<Environment/>` component