### PR TITLE
Added collapsible categories in docs.

### DIFF
--- a/.changeset/chilled-ducks-know.md
+++ b/.changeset/chilled-ducks-know.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': minor
+---
+
+Implemented package-level collapsibles

--- a/.changeset/curvy-apples-give.md
+++ b/.changeset/curvy-apples-give.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': minor
+---
+
+Implementing collapsible categories.

--- a/.changeset/rich-pens-shop.md
+++ b/.changeset/rich-pens-shop.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': minor
+---
+
+Only collapse packages, open @threlte/core by default

--- a/apps/docs/src/routes/__layout.svelte
+++ b/apps/docs/src/routes/__layout.svelte
@@ -123,6 +123,24 @@
 				workingGroup = [];
 			}
 		}
+
+		// Here we convert each package into details-summary blocks.
+		const packages = Array.from(document.querySelectorAll("nav > ul > li"));
+		for(let p of packages){
+			const packageName = p.children[0];
+			const packageContent = p.children[1];
+			const details = document.createElement("details");
+			const summary = document.createElement("summary");
+			p.replaceChild(details, packageName);
+			summary.appendChild(packageName);
+			details.appendChild(summary);
+			details.appendChild(packageContent);
+
+			// Again, we set list style to none here, because with list items it will look weird.
+			summary.style.listStyleType = "none";
+		}
+
+
 	});
 </script>
 

--- a/apps/docs/src/routes/__layout.svelte
+++ b/apps/docs/src/routes/__layout.svelte
@@ -2,7 +2,7 @@
 	export const load = createKitDocsLoader()
 </script>
 
-<script>
+<script lang="ts">
 	import '@docsearch/css'
 	import '@svelteness/kit-docs/client/styles/docsearch.css'
 	import '../app.css'
@@ -26,9 +26,10 @@
 	import DiscordIcon from '../kit-docs/DiscordIcon.svelte'
 	import GithubIcon from '../kit-docs/GithubIcon.svelte'
 	import PlaygroundIcon from '../kit-docs/PlaygroundIcon.svelte'
+  import { onMount } from 'svelte'
 
 	/** @type {import('@svelteness/kit-docs').MarkdownMeta | null} */
-	export let meta = null
+	export let meta : any = null
 
 	let mergedMeta = meta ?? {
 		description: '',
@@ -59,6 +60,70 @@
 	$: category = $activeCategory ? `${$activeCategory}: ` : ''
 	$: title = meta ? `${category}${meta.title} | Threlte` : null
 	$: description = meta?.description
+
+	// Hack to insert collapsibles to navbar on mount.
+	// KitDocs doesn't seem to have exposed any interface to modify each navbar item's template,
+	// so we have to do things this way.
+	onMount(() => {
+		const categories = Array.from(document.querySelectorAll("nav ul > li > ul > li"));
+		// Here we collect each category group (which is flattened by kitdocs and has to be reconstructed)
+		// Each group is put under workingGroup array, and they belong to the groupHead element.
+		let workingGroup : Element[] = [];
+		let i = 0;
+		while(i < categories.length){
+			if(categories[i].querySelector("a")?.getAttribute("href")){
+				i++;
+				continue;
+			}
+			const groupHead = categories[i++];
+			if(i >= categories.length) {
+				// Last category on last element.
+				break;
+			}
+			else {
+				let selectedElement : Element | null = null;
+				while(i < categories.length
+				&& categories[i].parentNode === groupHead.parentNode
+				&& categories[i].querySelector("a")?.getAttribute("href")){
+					if(categories[i].querySelector("a")?.getAttribute("href") === window.location.pathname) {
+						selectedElement = categories[i].querySelector("a");
+					}
+					workingGroup.push(categories[i++]);
+				}
+				if(workingGroup.length === 0) continue;
+				// Here we convert the workingGroup and the groupHead into a details + summary block.
+				// (Basically provides collapsible functionalities)
+				const details = document.createElement("details");
+				const summary = document.createElement("summary");
+				const parent = groupHead.parentNode;
+				details.append(summary);
+				workingGroup.forEach(element => details.append(element));
+				parent?.replaceChild(details, groupHead);
+				summary.append(groupHead);
+
+				// We set list style to none here, because with list items it will look weird.
+				summary.style.listStyleType = "none";
+				const a = groupHead.querySelector("a");
+				if(a !== null) {
+					// We set this attribute so we can use CSS to suppress the href on this element.
+					// Without this, clicking any collapsible group will refresh the page.
+					a.setAttribute("aria-current", "page");
+				}
+				if(selectedElement) {
+					// Open the collapsible for the current category.
+					details.setAttribute("open", "true");
+					// And also scroll it into view.
+					selectedElement.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+            inline: 'center'
+        	});
+				}
+				// Wipe the working group clean, and move on to the next group.
+				workingGroup = [];
+			}
+		}
+	});
 </script>
 
 <svelte:head>

--- a/apps/docs/src/routes/__layout.svelte
+++ b/apps/docs/src/routes/__layout.svelte
@@ -65,69 +65,70 @@
 	// KitDocs doesn't seem to have exposed any interface to modify each navbar item's template,
 	// so we have to do things this way.
 	onMount(() => {
-		const categories = Array.from(document.querySelectorAll("nav ul > li > ul > li"));
-		// Here we collect each category group (which is flattened by kitdocs and has to be reconstructed)
-		// Each group is put under workingGroup array, and they belong to the groupHead element.
-		let workingGroup : Element[] = [];
-		let i = 0;
-		while(i < categories.length){
-			if(categories[i].querySelector("a")?.getAttribute("href")){
-				i++;
-				continue;
-			}
-			const groupHead = categories[i++];
-			if(i >= categories.length) {
-				// Last category on last element.
-				break;
-			}
-			else {
-				let selectedElement : Element | null = null;
-				while(i < categories.length
-				&& categories[i].parentNode === groupHead.parentNode
-				&& categories[i].querySelector("a")?.getAttribute("href")){
-					if(categories[i].querySelector("a")?.getAttribute("href") === window.location.pathname) {
-						selectedElement = categories[i].querySelector("a");
-					}
-					workingGroup.push(categories[i++]);
-				}
-				if(workingGroup.length === 0) continue;
-				// Here we convert the workingGroup and the groupHead into a details + summary block.
-				// (Basically provides collapsible functionalities)
-				const details = document.createElement("details");
-				const summary = document.createElement("summary");
-				const parent = groupHead.parentNode;
-				details.append(summary);
-				workingGroup.forEach(element => details.append(element));
-				parent?.replaceChild(details, groupHead);
-				summary.append(groupHead);
+		// const categories = Array.from(document.querySelectorAll("nav ul > li > ul > li"));
+		// // Here we collect each category group (which is flattened by kitdocs and has to be reconstructed)
+		// // Each group is put under workingGroup array, and they belong to the groupHead element.
+		// let workingGroup : Element[] = [];
+		// let i = 0;
+		// while(i < categories.length){
+		// 	if(categories[i].querySelector("a")?.getAttribute("href")){
+		// 		i++;
+		// 		continue;
+		// 	}
+		// 	const groupHead = categories[i++];
+		// 	if(i >= categories.length) {
+		// 		// Last category on last element.
+		// 		break;
+		// 	}
+		// 	else {
+		// 		let selectedElement : Element | null = null;
+		// 		while(i < categories.length
+		// 		&& categories[i].parentNode === groupHead.parentNode
+		// 		&& categories[i].querySelector("a")?.getAttribute("href")){
+		// 			if(categories[i].querySelector("a")?.getAttribute("href") === window.location.pathname) {
+		// 				selectedElement = categories[i].querySelector("a");
+		// 			}
+		// 			workingGroup.push(categories[i++]);
+		// 		}
+		// 		if(workingGroup.length === 0) continue;
+		// 		// Here we convert the workingGroup and the groupHead into a details + summary block.
+		// 		// (Basically provides collapsible functionalities)
+		// 		const details = document.createElement("details");
+		// 		const summary = document.createElement("summary");
+		// 		const parent = groupHead.parentNode;
+		// 		details.append(summary);
+		// 		workingGroup.forEach(element => details.append(element));
+		// 		parent?.replaceChild(details, groupHead);
+		// 		summary.append(groupHead);
 
-				// We set list style to none here, because with list items it will look weird.
-				summary.style.listStyleType = "none";
-				const a = groupHead.querySelector("a");
-				if(a !== null) {
-					// We set this attribute so we can use CSS to suppress the href on this element.
-					// Without this, clicking any collapsible group will refresh the page.
-					a.setAttribute("aria-current", "page");
-				}
-				if(selectedElement) {
-					// Open the collapsible for the current category.
-					details.setAttribute("open", "true");
-					// And also scroll it into view.
-					selectedElement.scrollIntoView({
-            behavior: 'smooth',
-            block: 'center',
-            inline: 'center'
-        	});
-				}
-				// Wipe the working group clean, and move on to the next group.
-				workingGroup = [];
-			}
-		}
+		// 		// We set list style to none here, because with list items it will look weird.
+		// 		summary.style.listStyleType = "none";
+		// 		const a = groupHead.querySelector("a");
+		// 		if(a !== null) {
+		// 			// We set this attribute so we can use CSS to suppress the href on this element.
+		// 			// Without this, clicking any collapsible group will refresh the page.
+		// 			a.setAttribute("aria-current", "page");
+		// 		}
+		// 		if(selectedElement) {
+		// 			// Open the collapsible for the current category.
+		// 			details.setAttribute("open", "true");
+		// 			// And also scroll it into view.
+		// 			selectedElement.scrollIntoView({
+    //         behavior: 'smooth',
+    //         block: 'center',
+    //         inline: 'center'
+    //     	});
+		// 		}
+		// 		// Wipe the working group clean, and move on to the next group.
+		// 		workingGroup = [];
+		// 	}
+		// }
 
 		// Here we convert each package into details-summary blocks.
 		const packages = Array.from(document.querySelectorAll("nav > ul > li"));
 		for(let p of packages){
 			const packageName = p.children[0];
+			if(packageName.innerHTML.trim().length == 0) continue;
 			const packageContent = p.children[1];
 			const details = document.createElement("details");
 			const summary = document.createElement("summary");
@@ -138,6 +139,11 @@
 
 			// Again, we set list style to none here, because with list items it will look weird.
 			summary.style.listStyleType = "none";
+
+			// Open @threlte/core by default.
+			if(packageName.innerHTML === "@threlte/core")
+				details.setAttribute("open", "true");
+
 		}
 
 

--- a/apps/docs/src/styles/kit-docs.css
+++ b/apps/docs/src/styles/kit-docs.css
@@ -271,7 +271,7 @@ nav > div:first-child {
 	@apply z-10;
 }
 
-nav > ul > li > ul {
+nav > ul > li > details > ul {
 	@apply ml-4;
 }
 
@@ -287,7 +287,7 @@ summary {
 	height: 40px;
 }
 
-nav ul > li > ul > li {
+nav ul > li > details > ul > li {
 	margin-top: 0 !important;
 	margin-bottom: 0 !important;
 }
@@ -296,16 +296,16 @@ nav ul > li > ul > li {
 	display: none;
 }
 
-nav ul > li > h5 {
+nav ul > li > details > summary > h5 {
 	@apply text-brand;
 	/* @apply border-b border-black; */
 }
 
-nav ul > li > h5 + ul > li:first-child > a {
+nav ul > li > details > h5 + ul > li:first-child > a {
 	@apply !mt-4;
 }
 
-nav ul > li > h5 + ul > li:first-child > a[href=''] {
+nav ul > li > details > h5 + ul > li:first-child > a[href=''] {
 	@apply !pt-2;
 }
 
@@ -321,4 +321,8 @@ nav ul > li > a > svg {
 
 [aria-current="page"] {
 	pointer-events: none !important;
+}
+
+nav details > summary > li{
+	margin-top: 0 !important;
 }

--- a/apps/docs/src/styles/kit-docs.css
+++ b/apps/docs/src/styles/kit-docs.css
@@ -318,3 +318,7 @@ nav ul > li > a > svg {
 	height: 18px;
 	margin-right: 10px !important;
 }
+
+[aria-current="page"] {
+	pointer-events: none !important;
+}


### PR DESCRIPTION
Addresses issue #123 (Collapsible categories in docs) by injecting code that modifies KitDocs' sidebar, using Svelte's onMount lifecycle callback. The [`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) HTML element is used to minimize the code needed to implement the change.

As KitDocs doesn't include any classes or ids to identify sidebar categories, the resulting solution ended up being very hacky. I've left comments documenting my implementation, though.

Here is a demonstration:
![demo](https://i.gyazo.com/ce28713747c7ca9653df2a367c43cf02.gif)