### PR TITLE
Stronger types on typed threlte GLTF-related modules

### DIFF
--- a/.changeset/friendly-panthers-lick.md
+++ b/.changeset/friendly-panthers-lick.md
@@ -1,0 +1,38 @@
+---
+'@threlte/extras': minor
+---
+
+Stronger types on typed threlte GLTF-related modules. This is technically a **breaking change** but it's types only.
+This is a change that prepares threlte's type system for glTF code generators.
+
+### Upgrade Plan
+
+- Before:
+
+```ts
+const { gltf } = useGltf<'MeshA' | 'MeshB' | 'Object3DA', 'MaterialA' | 'MaterialB'>('/some/url')
+
+// -> $gltf.nodes.MeshA -> THREE.Object3D
+// -> $gltf.nodes.Object3DA -> THREE.Object3D
+// -> $gltf.materials.MaterialA -> THREE.Material
+```
+
+- After:
+
+```ts
+const { gltf } = useGltf<{
+  nodes: {
+    MeshA: THREE.Mesh
+    MeshB: THREE.Mesh
+    Object3DA: THREE.Object3D
+  }
+  materials: {
+    MaterialA: THREE.MeshStandardMaterial
+    MaterialB: THREE.MeshBasicMaterial
+  }
+}>('/some/url')
+
+// -> $gltf.nodes.MeshA -> THREE.Mesh
+// -> $gltf.nodes.Object3DA -> THREE.Object3D
+// -> $gltf.materials.MaterialA -> THREE.MeshStandardMaterial
+```

--- a/apps/docs/src/examples/extras/use-gltf/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-gltf/Scene.svelte
@@ -7,21 +7,24 @@
 		useFrame
 	} from '@threlte/core'
 	import { Environment, useGltf } from '@threlte/extras'
-	import { derived } from 'svelte/store'
+	import type { Material, Object3D } from 'three'
 
 	let rotation = 0
 	useFrame(() => {
 		rotation += 0.01
 	})
 
-	const { gltf } = useGltf<'node_damagedHelmet_-6514', 'Material_MR'>(
-		'/models/helmet/DamagedHelmet.gltf'
-	)
+	// 'node_damagedHelmet_-6514', 'Material_MR'
 
-	const helmet = derived(gltf, (gltf) => {
-		if (!gltf || !gltf.nodes['node_damagedHelmet_-6514']) return
-		return gltf.nodes['node_damagedHelmet_-6514']
-	})
+	const { gltf } = useGltf<{
+		nodes: {
+			'node_damagedHelmet_-6514': Object3D
+		}
+		materials: {
+			Material_MR: Material
+		}
+	}>('/models/helmet/DamagedHelmet.gltf')
+	$: helmet = $gltf?.nodes['node_damagedHelmet_-6514']
 </script>
 
 <Environment path="/hdr/" files="shanghai_riverside_1k.hdr" />
@@ -31,7 +34,7 @@
 <DirectionalLight position={{ y: 10, z: 10 }} />
 
 <Group rotation={{ y: rotation }}>
-	{#if $helmet}
-		<Object3DInstance object={$helmet} />
+	{#if helmet}
+		<Object3DInstance object={helmet} />
 	{/if}
 </Group>

--- a/apps/docs/src/examples/extras/use-gltf/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-gltf/Scene.svelte
@@ -14,8 +14,6 @@
 		rotation += 0.01
 	})
 
-	// 'node_damagedHelmet_-6514', 'Material_MR'
-
 	const { gltf } = useGltf<{
 		nodes: {
 			'node_damagedHelmet_-6514': Object3D

--- a/apps/docs/src/routes/extras/use-gltf.md
+++ b/apps/docs/src/routes/extras/use-gltf.md
@@ -95,22 +95,32 @@ The hook provides a map of all objects and materials in the loaded glTF.
   import { useGltf } from '@threlte/extras'
 
   const { gltf } = useGltf('/path/to/model.glb')
-  $: if ($gltf) console.log('Nodes', $gltf.nodes)
+  $: nodes: $gltf?.nodes
+	$: materials: $gltf?.materials
 </script>
 ```
 
-Provide types to use your IDEs autocompletion.
+Provide types to use your IDEs autocompletion. Use [gltfjsx](https://github.com/pmndrs/gltfjsx) to extract types from glTF files.
 
 ```svelte
 <script lang="ts">
   import { useGltf } from '@threlte/extras'
 
-  const { gltf } = useGltf<'Object-A' | 'Object-B', 'Material-A' | 'Material-B'>(
-    '/path/to/model.glb'
-  )
+  const { gltf } = useGltf<{
+		nodes: {
+			MeshA: THREE.Mesh
+			MeshB: THREE.Mesh
+			Object3DA: THREE.Object3D
+		}
+		materials: {
+			MaterialA: THREE.MeshStandardMaterial
+			MaterialB: THREE.MeshBasicMaterial
+		}
+	}>('/path/to/model.glb')
+
   $: if ($gltf) {
-    const objectA = $gltf.nodes['Object-A']
-    const materialA = $gltf.materials['Material-A']
+    const objectA = $gltf.nodes['MeshA'] // -> THREE.Mesh
+    const materialA = $gltf.materials['MaterialA'] // -> THREE.MeshStandardMaterial
   }
 </script>
 ```

--- a/packages/extras/src/lib/components/GLTF/GLTF.svelte
+++ b/packages/extras/src/lib/components/GLTF/GLTF.svelte
@@ -57,8 +57,18 @@
   export let scenes: ThreeGLTF['scenes'] | undefined = undefined
   export let userData: ThreeGLTF['userData'] | undefined = undefined
   export let parser: ThreeGLTF['parser'] | undefined = undefined
-  export let materials: ThrelteGltf['materials'] | undefined = undefined
-  export let nodes: ThrelteGltf['nodes'] | undefined = undefined
+  export let materials:
+    | ThrelteGltf<{
+        nodes: Record<string, any>
+        materials: Record<string, any>
+      }>['materials']
+    | undefined = undefined
+  export let nodes:
+    | ThrelteGltf<{
+        nodes: Record<string, any>
+        materials: Record<string, any>
+      }>['nodes']
+    | undefined = undefined
 
   const loader = useLoader(GLTFLoader, () => new GLTFLoader())
 
@@ -143,7 +153,10 @@
     {#if node}
       {#key node.uuid}
         <!-- dispose all nodes, i.e. meshes, skinnedMeshs -->
-        <DisposableObject {dispose} object={node} />
+        <DisposableObject
+          {dispose}
+          object={node}
+        />
 
         <LayerableObject object={node} />
 
@@ -169,7 +182,10 @@
 <!-- dispose all materials -->
 {#if materials}
   {#each Object.values(materials) as material}
-    <DisposableObject {dispose} object={material} />
+    <DisposableObject
+      {dispose}
+      object={material}
+    />
   {/each}
 {/if}
 

--- a/packages/extras/src/lib/hooks/useGltf.ts
+++ b/packages/extras/src/lib/hooks/useGltf.ts
@@ -1,10 +1,10 @@
+import { useLoader } from '@threlte/core'
 import { createEventDispatcher } from 'svelte'
 import { writable, type Writable } from 'svelte/store'
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
 import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
-import { useLoader } from '@threlte/core'
+import { buildSceneGraph, type SceneGraph } from '../lib/buildSceneGraph'
 import type { ThrelteGltf } from '../types/types'
-import { buildSceneGraph } from '../lib/buildSceneGraph'
 
 type UseGltfOptions = {
   useDraco?: boolean | string
@@ -12,13 +12,18 @@ type UseGltfOptions = {
 
 createEventDispatcher
 
-export const useGltf = <Nodes extends string = any, Materials extends string = any>(
+export const useGltf = <
+  Graph extends SceneGraph = {
+    nodes: Record<string, any>
+    materials: Record<string, any>
+  }
+>(
   url: string,
   options?: UseGltfOptions
 ): {
-  gltf: Writable<ThrelteGltf<Nodes, Materials> | undefined>
+  gltf: Writable<ThrelteGltf<Graph> | undefined>
 } => {
-  const gltf = writable<ThrelteGltf<Nodes, Materials> | undefined>(undefined)
+  const gltf = writable<ThrelteGltf<Graph> | undefined>(undefined)
 
   const loader = useLoader(GLTFLoader, () => new GLTFLoader())
   if (options?.useDraco) {
@@ -33,8 +38,8 @@ export const useGltf = <Nodes extends string = any, Materials extends string = a
   }
 
   loader.load(url, (data: GLTF) => {
-    if (data.scene) Object.assign(data, buildSceneGraph(data.scene))
-    gltf.set(data as ThrelteGltf<Nodes, Materials>)
+    if (data.scene) Object.assign(data, buildSceneGraph<Graph>(data.scene))
+    gltf.set(data as ThrelteGltf<Graph>)
   })
 
   return {

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -17,13 +17,13 @@ export { default as Environment } from './components/Environment/Environment.sve
 export { default as Text } from './components/Text/Text.svelte'
 
 export type {
-	EdgesProperties,
-	FloatProperties,
-	HTMLProperties,
-	TextProperties,
-	GLTFProperties,
-	ContactShadowProperties,
-	EnvironmentProperties
+  EdgesProperties,
+  FloatProperties,
+  HTMLProperties,
+  TextProperties,
+  GLTFProperties,
+  ContactShadowProperties,
+  EnvironmentProperties
 } from './types/components'
 
 export type { ThrelteGltf } from './types/types'

--- a/packages/extras/src/lib/lib/buildSceneGraph.ts
+++ b/packages/extras/src/lib/lib/buildSceneGraph.ts
@@ -1,20 +1,21 @@
-import type { Material, Object3D } from 'three'
+import type { Object3D } from 'three'
 
-export type SceneGraph<Nodes extends string = any, Materials extends string = any> = {
-  nodes: { [name in Nodes]?: Object3D }
-  materials: { [name in Materials]?: Material }
+export type Nodes = Record<string, any>
+export type Materials = Record<string, any>
+
+export type SceneGraph = {
+  nodes: Nodes
+  materials: Materials
 }
 
-export const buildSceneGraph = <Nodes extends string, Materials extends string>(
-  object: THREE.Object3D
-): SceneGraph<Nodes, Materials> => {
-  const data: SceneGraph = { nodes: {}, materials: {} }
+export const buildSceneGraph = <Graph extends SceneGraph = any>(object: Object3D): Graph => {
+  const data: Graph = { nodes: {}, materials: {} } as Graph
   if (object) {
     object.traverse((obj: any) => {
-      if (obj.name) data.nodes[obj.name] = obj
+      if (obj.name) data.nodes[obj.name as any] = obj
       if (obj.material && !data.materials[obj.material.name])
-        data.materials[obj.material.name] = obj.material
+        data.materials[obj.material.name as any] = obj.material
     })
   }
-  return data as SceneGraph<Nodes, Materials>
+  return data as Graph
 }

--- a/packages/extras/src/lib/types/types.ts
+++ b/packages/extras/src/lib/types/types.ts
@@ -229,5 +229,4 @@ export interface Text extends Mesh {
 /**
  * Extends THREE.GLTF by materials and nodes properties
  */
-export type ThrelteGltf<Nodes extends string = any, Materials extends string = any> = GLTF &
-  SceneGraph<Nodes, Materials>
+export type ThrelteGltf<Graph extends SceneGraph> = GLTF & Graph


### PR DESCRIPTION
Stronger types on typed threlte GLTF-related modules. This is technically a **breaking change** but it's types only.
This is a change that prepares threlte's type system for glTF code generators.

### Upgrade Plan

- Before:

```ts
const { gltf } = useGltf<'MeshA' | 'MeshB' | 'Object3DA', 'MaterialA' | 'MaterialB'>('/some/url')

// -> $gltf.nodes.MeshA -> THREE.Object3D
// -> $gltf.nodes.Object3DA -> THREE.Object3D
// -> $gltf.materials.MaterialA -> THREE.Material
```

- After:

```ts
const { gltf } = useGltf<{
  nodes: {
    MeshA: THREE.Mesh
    MeshB: THREE.Mesh
    Object3DA: THREE.Object3D
  }
  materials: {
    MaterialA: THREE.MeshStandardMaterial
    MaterialB: THREE.MeshBasicMaterial
  }
}>('/some/url')

// -> $gltf.nodes.MeshA -> THREE.Mesh
// -> $gltf.nodes.Object3DA -> THREE.Object3D
// -> $gltf.materials.MaterialA -> THREE.MeshStandardMaterial
```