### PR TITLE
This might be a small change.

### DIFF
--- a/packages/core/src/lib/lib/renderer.ts
+++ b/packages/core/src/lib/lib/renderer.ts
@@ -47,10 +47,10 @@ export const setRendererColorOutput = (
 
 export const setRendererAndComposerSize = (ctx: ThrelteContext, size: Size, dpr: number): void => {
   if (!ctx.renderer || !ctx.composer) return
-  ctx.renderer.setSize(size.width, size.height)
-  ctx.renderer.setPixelRatio(dpr)
-  ctx.composer.setSize(size.width, size.height)
-  ctx.composer.setPixelRatio(dpr)
+  ctx.renderer.setSize?.(size.width, size.height)
+  ctx.renderer.setPixelRatio?.(dpr)
+  ctx.composer.setSize?.(size.width, size.height)
+  ctx.composer.setPixelRatio?.(dpr)
 }
 
 export const setRendererShadows = (


### PR DESCRIPTION
But it allows the use of the most used post processing library: `postprocessing`.
The library `postprocessing` can be used with threlte by overriding `ctx.composer` and adding passes. threlte will check for available passes (with `ctx.composer.passes` which is also present on the `postprocessing` `EffectComposer`) and run `ctx.composer.render` (which again is also present on the `postprocessing` `EffectComposer`, how convenient!). Problems arise when the viewport is resized. While the *original* `THREE.EffectComposer` needs to be resized manually, `postprocessing.EffectComposer` is automatically resized by resizing the renderer.

It's a fix, not a permanent solution.