### PR TITLE
fix(docs): fixes examples menu styling in navigation

### DIFF
--- a/apps/docs/src/routes/navigation.ts
+++ b/apps/docs/src/routes/navigation.ts
@@ -17,7 +17,7 @@ export const sidebar = {
 			},
 			{
 				title: 'Examples',
-				slug: '/examples/'
+				slug: '/examples'
 			},
 			{
 				title: 'Features',


### PR DESCRIPTION
Addresses navigation bug where **Examples** is not highlighted also footer navigation is broken.



