### PR TITLE
fix(typo): add quotes to import names

### DIFF
--- a/apps/docs/src/routes/preprocess/preprocessThrelte.md
+++ b/apps/docs/src/routes/preprocess/preprocessThrelte.md
@@ -92,13 +92,13 @@ const config = {
 	preprocess: preprocessThrelte({
 		extensions: {
 			// import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
-			'three/examples/jsm/controls/OrbitControls': [OrbitControls],
+			'three/examples/jsm/controls/OrbitControls': ['OrbitControls'],
 
 			// import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
-			'three/examples/jsm/controls/TransformControls': [TransformControls],
+			'three/examples/jsm/controls/TransformControls': ['TransformControls'],
 
 			// import { CustomGrid } from '$lib/CustomGrid'
-			'$lib/CustomGrid': [CustomGrid]
+			'$lib/CustomGrid': ['CustomGrid']
 		}
 	})
 }


### PR DESCRIPTION
When extending `preprocessThrelte`, vite will yell at you if these import names don't have quotes because they are undefined. Config works with quotes on the import names. I imagine a lot of people will encounter this issue quickly when using OrbitControls and copy/pasting from the docs.

Can test it with/without quotes here: https://stackblitz.com/edit/threlte-v5-starter?file=svelte.config.js