### PR TITLE
Add glTF Meshopt decoding

### DIFF
--- a/.changeset/slimy-bottles-do.md
+++ b/.changeset/slimy-bottles-do.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': minor
+---
+
+Add support for glTF Meshopt decoding

--- a/apps/docs/src/routes/extras/gltf.md
+++ b/apps/docs/src/routes/extras/gltf.md
@@ -57,15 +57,19 @@ The `<GLTF>` component supports interaction:
 <GLTF castShadow receiveShadow url={'/models/flower.glb'} position={{ y: 1 }} scale={3} />
 ```
 
-:::admonition type="tip"
+### Compression
+
+The `<GLTF>` component supports compressed glTF files.
+
+#### DRACO
+
 You can set `useDraco` to `true` to use DRACO compression and Threlte will load a default DRACO decoder from Google servers, specifically `https://www.gstatic.com/draco/v1/decoders/`.
 
 Or you can set `useDraco` to your own DRACO decoder path as a `string`.
-:::
 
-:::admonition type="tip"
+#### Meshopt
+
 You can set `useMeshopt` to `true` to use meshopt compression and Threlte will load a default meshopt decoder from Three, specifically `https://github.com/mrdoob/three.js/blob/dev/examples/jsm/libs/meshopt_decoder.module.js`.
-:::
 
 ### Properties
 

--- a/apps/docs/src/routes/extras/gltf.md
+++ b/apps/docs/src/routes/extras/gltf.md
@@ -63,6 +63,10 @@ You can set `useDraco` to `true` to use DRACO compression and Threlte will load 
 Or you can set `useDraco` to your own DRACO decoder path as a `string`.
 :::
 
+:::admonition type="tip"
+You can set `useMeshopt` to `true` to use meshopt compression and Threlte will load a default meshopt decoder from Three, specifically `https://github.com/mrdoob/three.js/blob/dev/examples/jsm/libs/meshopt_decoder.module.js`.
+:::
+
 ### Properties
 
 ```ts
@@ -83,6 +87,7 @@ visible: boolean | undefined = undefined
 dispose: boolean | undefined = undefined
 d̶r̶a̶c̶o̶D̶e̶c̶o̶d̶e̶r̶P̶a̶t̶h̶: string | undefined = undefined // Deprecated - use `useDraco` instead
 useDraco: string | boolean = false
+useMeshopt: boolean = false
 ktxTranscoderPath: string | undefined = undefined
 ignorePointer: boolean = false
 interactive: boolean = false

--- a/apps/docs/src/routes/extras/use-gltf.md
+++ b/apps/docs/src/routes/extras/use-gltf.md
@@ -86,6 +86,23 @@ You can also provide custom DRACO decoder binaries.
 {/if}
 ```
 
+### Meshopt decoding
+
+Use a meshopt decoder for compressed glTF files, defaults to Three's included decoder.
+
+```svelte
+<script lang="ts">
+  import { useGltf } from '@threlte/extras'
+
+  const { gltf } = useGltf('/path/to/model.glb', {
+    useMeshopt: true
+  })
+</script>
+
+{#if $gltf}
+  <Object3DInstance object={$gltf.nodes['node-name']} />
+{/if}
+
 ### Nodes and Materials
 
 The hook provides a map of all objects and materials in the loaded glTF.

--- a/apps/docs/src/routes/extras/use-gltf.md
+++ b/apps/docs/src/routes/extras/use-gltf.md
@@ -102,6 +102,7 @@ Use a meshopt decoder for compressed glTF files, defaults to Three's included de
 {#if $gltf}
   <Object3DInstance object={$gltf.nodes['node-name']} />
 {/if}
+```
 
 ### Nodes and Materials
 

--- a/packages/extras/src/lib/components/GLTF/GLTF.svelte
+++ b/packages/extras/src/lib/components/GLTF/GLTF.svelte
@@ -13,6 +13,7 @@
   import type { GLTF as ThreeGLTF } from 'three/examples/jsm/loaders/GLTFLoader'
   import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
   import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader'
+	import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js'
   import { buildSceneGraph } from '../../lib/buildSceneGraph'
   import type { GLTFProperties } from '../../types/components'
   import type { ThrelteGltf } from '../../types/types'
@@ -37,6 +38,7 @@
    */
   export let dracoDecoderPath: GLTFProperties['dracoDecoderPath'] = undefined
   export let useDraco: GLTFProperties['useDraco'] = false
+	export let useMeshopt: GLTFProperties['useMeshopt'] = false
   export let ktxTranscoderPath: GLTFProperties['ktxTranscoderPath'] = undefined
 
   export let ignorePointer: GLTFProperties['ignorePointer'] = false
@@ -92,6 +94,10 @@
     )
     loader.setDRACOLoader(dracoLoader)
   }
+
+	if (useMeshopt) {
+		loader.setMeshoptDecoder(MeshoptDecoder)
+	}
 
   const { renderer } = useThrelte()
   if (renderer && ktxTranscoderPath) {

--- a/packages/extras/src/lib/hooks/useGltf.ts
+++ b/packages/extras/src/lib/hooks/useGltf.ts
@@ -2,6 +2,7 @@ import { createEventDispatcher } from 'svelte'
 import { writable, type Writable } from 'svelte/store'
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
 import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module'
 import { useLoader } from '@threlte/core'
 import type { ThrelteGltf } from '../types/types'
 import {
@@ -14,6 +15,7 @@ import { DefaultLoadingManager } from 'three'
 
 type UseGltfOptions = {
   useDraco?: boolean | string
+	useMeshopt?: boolean
 }
 
 createEventDispatcher
@@ -42,6 +44,10 @@ export const useGltf = <
     )
     loader.setDRACOLoader(dracoLoader)
   }
+
+	if (options?.useMeshopt) {
+		loader.setMeshoptDecoder(MeshoptDecoder);
+	}
 
   loader.load(url, (data: GLTF) => {
     if (data.scene) Object.assign(data, buildSceneGraph<Graph>(data.scene))

--- a/packages/extras/src/lib/types/components.ts
+++ b/packages/extras/src/lib/types/components.ts
@@ -98,6 +98,7 @@ export type GLTFProperties = Omit<Object3DInstanceProperties, 'object'> & {
   /** @deprecated Use `useDraco` instead*/
   dracoDecoderPath?: string
   useDraco?: string | boolean
+  useMeshopt?: string | boolean
   ktxTranscoderPath?: string
 } & Omit<InteractiveObjectProperties, 'object'>
 

--- a/packages/extras/src/lib/types/components.ts
+++ b/packages/extras/src/lib/types/components.ts
@@ -98,7 +98,7 @@ export type GLTFProperties = Omit<Object3DInstanceProperties, 'object'> & {
   /** @deprecated Use `useDraco` instead*/
   dracoDecoderPath?: string
   useDraco?: string | boolean
-  useMeshopt?: string | boolean
+  useMeshopt?: boolean
   ktxTranscoderPath?: string
 } & Omit<InteractiveObjectProperties, 'object'>
 


### PR DESCRIPTION
Confirmed working with meshopt compressed glTFs!

![chrome_RYnGvsFdga](https://user-images.githubusercontent.com/9439650/202773833-e2c6eaf3-59ed-40d4-9b69-c8c47522a54a.gif)

gLTF metadata:
```js
{"buffers":[{"byteLength":536268},{"byteLength":1380444,"extensions":{"EXT_meshopt_compression":{"fallback":true}}}],"asset":{"version":"2.0","generator":"gltfpack 0.18"}
```