### PR TITLE
Expose Props, Events and Slots types

### DIFF
--- a/.changeset/four-turtles-flow.md
+++ b/.changeset/four-turtles-flow.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Expose Props, Events and Slots type to move forward with v5 syntax exposure and abstraction abilities

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -62,6 +62,7 @@ export { default as DisposableObject } from './internal/DisposableObject.svelte'
 // <Three> component
 export { default as Three } from './three/Three.svelte'
 export { T } from './three/T'
+export type { Props, Events, Slots } from './three/types'
 
 // hooks
 export { useFrame } from './hooks/useFrame'


### PR DESCRIPTION
With these types exposed, it's easy to make your own types for wrapped components that use `$$restProps`. Let's say you want to type the component "Grouped.svelte":

```html
<script lang="ts">
	import { T } from '@threlte/core'
</script>

<T.Group {...$$restProps} let:ref>
	<T.Mesh>
		<T.BoxBufferGeometry args={[1, 1, 1]} />
		<T.MeshStandardMaterial color="hotpink" />
	</T.Mesh>
	<slot {ref} />
</T.Group>
```

The Svelte language server picks up a file called "Grouped.svelte.d.ts" next to "Grouped.svelte" and provides intellisense on "Grouped.svelte"

```ts
import type { Events, Props, Slots } from '@threlte/core'
import { SvelteComponentTyped } from 'svelte'
import type { Group } from 'three'

export default class Grouped extends SvelteComponentTyped<
	Props<Group>,
	Events<Group>,
	Slots<Group>
> {}
```

PS: Currently there's no Svelte way of forwarding all events, so `Events<Group>` has no effect yet.