### PR TITLE
Grid : shaders in separate files

### DIFF
--- a/packages/extras/src/lib/components/Grid/Grid.svelte
+++ b/packages/extras/src/lib/components/Grid/Grid.svelte
@@ -21,9 +21,12 @@
 
   export let ref: Mesh
 
+  import { default as vertexShader } from './vertexShader.glsl?raw'
+  import { default as fragmentShader } from './fragmentShader.glsl?raw'
+
   const { invalidate } = useThrelte()
 
-  const makeGridMaterial = (axes: GridProps['axes']) => {
+  const makeGridMaterial = () => {
     return new ShaderMaterial({
       side: DoubleSide,
 
@@ -57,80 +60,29 @@
         },
         uFollowCamera: {
           value: 0
+        },
+        uAxis0: {
+          value: 0
+        },
+        uAxis1: {
+          value: 2
+        },
+        uAxis2: {
+          value: 1
         }
       },
       transparent: true,
-      vertexShader: `
-      varying vec3 worldPosition;
-      uniform float uFadeDistance;
-      uniform float uInfiniteGrid;
-      uniform float uFollowCamera;
-
-      void main() {
-
-        vec3 pos = position.${axes} * (1. + uFadeDistance * uInfiniteGrid);
-        pos.${axes.slice(0, 2)} += (cameraPosition.${axes.slice(0, 2)} * uFollowCamera);
-
-        worldPosition = pos;
-
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
-
-      }`,
-
-      fragmentShader: `
-      varying vec3 worldPosition;
-      uniform float uSize1;
-      uniform float uSize2;
-      uniform vec3 uColor1;
-      uniform vec3 uColor2;
-      uniform float uFadeDistance;
-      uniform float uFadeStrength;
-      uniform float uThickness1;
-      uniform float uThickness2;
-      uniform float uInfiniteGrid;
-
-      float getGrid(float size, float thickness) {
-
-        vec2 r = worldPosition.${axes.slice(0, 2)} / size;
-
-        vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
-        float line = min(grid.x, grid.y) + 1. - thickness;
-
-        return 1.0 - min(line, 1.);
-      }
-
-      void main() {
-
-        float g1 = getGrid(uSize1, uThickness1);
-        float g2 = getGrid(uSize2, uThickness2);
-
-        float d = 1.0 - min(distance(cameraPosition.${axes.slice(0, 2)}, worldPosition.${axes.slice(
-        0,
-        2
-      )}) / uFadeDistance, 1.);
-        vec3 color = mix(uColor1, uColor2, min(1.,uThickness2*g2));
-
-        gl_FragColor = vec4(color, (g1 + g2) * pow(d,uFadeStrength));
-        gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
-
-        if(gl_FragColor.a <= 0.0)
-          discard;
-
-      }
-
-       `,
-
+      vertexShader,
+      fragmentShader,
       extensions: {
         derivatives: true
       }
     })
   }
 
-  $: material = makeGridMaterial(axes)
-  $: material && invalidate('Grid axes changed')
+  const material = makeGridMaterial()
 
   $: {
-    axes
     material.uniforms.uSize1 = { value: cellSize }
     material.uniforms.uSize2 = { value: sectionSize }
     material.uniforms.uColor1 = { value: new Color(cellColor) }
@@ -141,6 +93,12 @@
     material.uniforms.uThickness2 = { value: sectionThickness }
     material.uniforms.uFollowCamera = { value: followCamera ? 1 : 0 }
     material.uniforms.uInfiniteGrid = { value: infiniteGrid ? 1 : 0 }
+    const axesMap: { [key: string]: number } = { x: 0, y: 1, z: 2 }
+    const gridAxes = [...(axes || 'xzy')]
+    material.uniforms.uAxis0.value = axesMap[gridAxes[0]]
+    material.uniforms.uAxis1.value = axesMap[gridAxes[1]]
+    material.uniforms.uAxis2.value = axesMap[gridAxes[2]]
+
     invalidate('Grid uniforms changed')
   }
 </script>

--- a/packages/extras/src/lib/components/Grid/fragmentShader.glsl
+++ b/packages/extras/src/lib/components/Grid/fragmentShader.glsl
@@ -1,0 +1,37 @@
+varying vec3 worldPosition;
+uniform float uSize1;
+uniform float uSize2;
+uniform vec3 uColor1;
+uniform vec3 uColor2;
+uniform float uFadeDistance;
+uniform float uFadeStrength;
+uniform float uThickness1;
+uniform float uThickness2;
+uniform int uAxis0;
+uniform int uAxis1;
+
+float getGrid(float size, float thickness) {
+
+  vec2 r = vec2(worldPosition[uAxis0], worldPosition[uAxis1]) / size;
+
+  vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
+  float line = min(grid.x, grid.y) + 1. - thickness;
+
+  return 1.0 - min(line, 1.);
+}
+
+void main() {
+
+  float g1 = getGrid(uSize1, uThickness1);
+  float g2 = getGrid(uSize2, uThickness2);
+
+  float d = 1.0 - min(distance(vec2(cameraPosition[uAxis0], cameraPosition[uAxis1]), vec2(worldPosition[uAxis0], worldPosition[uAxis1])) / uFadeDistance, 1.);
+  vec3 color = mix(uColor1, uColor2, min(1., uThickness2 * g2));
+
+  gl_FragColor = vec4(color, (g1 + g2) * pow(d, uFadeStrength));
+  gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
+
+  if(gl_FragColor.a <= 0.0)
+    discard;
+
+}

--- a/packages/extras/src/lib/components/Grid/vertexShader.glsl
+++ b/packages/extras/src/lib/components/Grid/vertexShader.glsl
@@ -1,0 +1,22 @@
+varying vec3 worldPosition;
+uniform float uFadeDistance;
+uniform float uInfiniteGrid;
+uniform float uFollowCamera;
+
+uniform int uAxis0;
+uniform int uAxis1;
+uniform int uAxis2;
+
+void main() {
+
+  vec3 nPos = vec3(position[uAxis0], position[uAxis1], position[uAxis2]);
+
+  vec3 pos = nPos * (1. + uFadeDistance * uInfiniteGrid);
+  pos[uAxis0] += (cameraPosition[uAxis0] * uFollowCamera);
+  pos[uAxis1] += (cameraPosition[uAxis1] * uFollowCamera);
+
+  worldPosition = pos;
+
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+
+}


### PR DESCRIPTION
I've changed how axes work. Instead of rebuilding material, the axes are passed as uniforms instead of being injected into the string.

It let met separate the shaders into separate files and makes it so material isn't re-built.