### PR TITLE
Grid: remove axes, include color mapping and encoding

### DIFF
--- a/apps/docs/src/examples/extras/grid/App.svelte
+++ b/apps/docs/src/examples/extras/grid/App.svelte
@@ -29,7 +29,7 @@
 
 	const cellThickness = addInput({
 		label: 'Cell thickness',
-		value: 1,
+		value: 1.4,
 		params: {
 			step: 0.1,
 			min: 1,
@@ -59,7 +59,7 @@
 	})
 	const sectionThickness = addInput({
 		label: 'Section thickness',
-		value: 1.3,
+		value: 1.7,
 		params: {
 			step: 0.1,
 			min: 1,
@@ -75,7 +75,7 @@
 
 	const gridSize1 = addInput({
 		label: 'Grid size1',
-		value: 10,
+		value: 20,
 		params: {
 			step: 1,
 			min: 1,
@@ -86,7 +86,7 @@
 	})
 	const gridSize2 = addInput({
 		label: 'Grid size2',
-		value: 10,
+		value: 20,
 		params: {
 			step: 1,
 			min: 1,
@@ -94,20 +94,6 @@
 		},
 		parent: generalFolder
 	})
-
-	const axes = addInput({
-		label: 'axes',
-		value: 'xzy',
-		params: {
-			options: {
-				xzy: 'xzy',
-				xyz: 'xyz',
-				zyx: 'zyx'
-			}
-		},
-		parent: generalFolder
-	})
-	$: axisTyped = $axes as 'xzy' | 'xyz' | 'zyx'
 
 	const followCamera = addInput({
 		label: 'followCamera',
@@ -151,7 +137,6 @@
 
 <Canvas>
 	<Grid
-		axes={axisTyped}
 		cellColor={$cellColor}
 		cellSize={$cellSize}
 		cellThickness={$cellThickness}
@@ -164,7 +149,6 @@
 		fadeStrength={$fadeStregth}
 		gridSize={[$gridSize1, $gridSize2]}
 	/>
-
 	<!-- Example scene with boxes -->
 	<Scene />
 </Canvas>

--- a/apps/docs/src/examples/extras/grid/Scene.svelte
+++ b/apps/docs/src/examples/extras/grid/Scene.svelte
@@ -13,7 +13,7 @@
 	]
 </script>
 
-<T.PerspectiveCamera makeDefault position={[0, 10, 20]} fov={36} target={[0, 0, 0]}>
+<T.PerspectiveCamera makeDefault position={[-15, 15, 20]} fov={25} target={[0, 0, 0]}>
 	<OrbitControls />
 </T.PerspectiveCamera>
 

--- a/apps/docs/src/routes/extras/grid.md
+++ b/apps/docs/src/routes/extras/grid.md
@@ -40,14 +40,13 @@ You can extend the grid into infinity if you set the `infiniteGrid` parameter to
 Changing `fadeDistance` sets how far from the camera position the grid begins to fade by having its alpha reduced. `fadeStrength` determines how fast it happens (exponent). `fadeStrength = 0` means that there is no fading (not recommended for large grids).
 
 ## Follow camera
-Setting `followCamera` to true applies a transform that moves the grid to the camera's position on the chosen `axes`.
+Setting `followCamera` to true applies a transform that moves the grid to the camera's position.
 
 `ref` passes a reference from the `<T.Mesh/> the grid is constructed on.
 
 ### Properties
 
 ```ts  
-  axes: 'xzy' | 'xyz' | 'zyx' = 'xzy'
   cellColor: ColorRepresentation = '#000000'
   cellSize: number = 1
   cellThickness: number = 1

--- a/packages/extras/src/lib/components/Grid/Grid.svelte.d.ts
+++ b/packages/extras/src/lib/components/Grid/Grid.svelte.d.ts
@@ -3,7 +3,6 @@ import { SvelteComponentTyped } from 'svelte'
 import type { ColorRepresentation, Mesh } from 'three'
 
 export type GridProps = Omit<Props<Mesh>, 'material' | 'geometry'> & {
-  axes?: 'xzy' | 'xyz' | 'zyx'
   cellColor?: ColorRepresentation
   cellSize?: number
   cellThickness?: number


### PR DESCRIPTION
- Removed axes from types, docs and the example -