### PR TITLE
RFC: Plugin API

### DIFF
--- a/apps/docs/src/examples/test/App.svelte
+++ b/apps/docs/src/examples/test/App.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Canvas } from '@threlte/core'
+	import InteractivityPlugin from './plugins/InteractivityPlugin.svelte'
+	import LayersPlugin from './plugins/LayersPlugin.svelte'
+	import Scene from './Scene.svelte'
+</script>
+
+<div class="w-full h-full fixed top-0 left-0">
+	<Canvas>
+		<LayersPlugin>
+			<InteractivityPlugin>
+				<Scene />
+			</InteractivityPlugin>
+		</LayersPlugin>
+	</Canvas>
+</div>

--- a/apps/docs/src/examples/test/Scene.svelte
+++ b/apps/docs/src/examples/test/Scene.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { InteractiveObject, Layers, T, TransformableObject, useFrame } from '@threlte/core'
+	import { GLTF } from '@threlte/extras'
+	import { DEG2RAD } from 'three/src/math/MathUtils'
+
+	let rotation = 0
+
+	useFrame(() => {
+		rotation += 0.002
+	})
+
+	let showLight = true
+	let color = 'red'
+</script>
+
+<T.Group rotation.y={rotation}>
+	<T.OrthographicCamera zoom={80} let:ref={cam} position={[0, 5, 10]} makeDefault>
+		<TransformableObject object={cam} lookAt={{ y: 2 }} />
+	</T.OrthographicCamera>
+</T.Group>
+
+<GLTF castShadow receiveShadow url={'/models/threlte.glb'} interactive />
+
+<T.Mesh
+	receiveShadow
+	rotation.x={DEG2RAD * -90}
+	on:click={() => {
+		color === 'red' ? (color = 'blue') : (color = 'red')
+		showLight = !showLight
+	}}
+>
+	<T.CircleGeometry args={[4, 60]} />
+	<T.MeshStandardMaterial />
+</T.Mesh>
+
+{#if showLight}
+	<Layers layers={'all'}>
+		<T.DirectionalLight position={[3, 10, 10]} args={[color]} castShadow />
+	</Layers>
+{/if}
+
+<T.DirectionalLight position={[-3, 10, -10]} intensity={0.2} />
+<T.AmbientLight intensity={0.5} />

--- a/apps/docs/src/examples/test/Scene.svelte
+++ b/apps/docs/src/examples/test/Scene.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { InteractiveObject, Layers, T, TransformableObject, useFrame } from '@threlte/core'
+	import { Layers, T, useFrame, useThrelte } from '@threlte/core'
 	import { GLTF } from '@threlte/extras'
 	import { DEG2RAD } from 'three/src/math/MathUtils'
+	import TransformControls from './TransformControls.svelte'
 
 	let rotation = 0
 
@@ -9,17 +10,19 @@
 		rotation += 0.002
 	})
 
+	const { renderer } = useThrelte()
+
 	let showLight = true
 	let color = 'red'
 </script>
 
-<T.Group rotation.y={rotation}>
-	<T.OrthographicCamera zoom={80} let:ref={cam} position={[0, 5, 10]} makeDefault>
-		<TransformableObject object={cam} lookAt={{ y: 2 }} />
-	</T.OrthographicCamera>
-</T.Group>
+<T.OrthographicCamera zoom={80} let:ref={cam} position={[0, 5, 10]} makeDefault>
+	<T.OrbitControls args={[cam, renderer?.domElement]} target={[0, 0, 0]} />
+</T.OrthographicCamera>
 
-<GLTF castShadow receiveShadow url={'/models/threlte.glb'} interactive />
+<T.Group rotation.y={rotation}>
+	<GLTF castShadow receiveShadow url={'/models/threlte.glb'} interactive />
+</T.Group>
 
 <T.Mesh
 	receiveShadow
@@ -31,6 +34,8 @@
 >
 	<T.CircleGeometry args={[4, 60]} />
 	<T.MeshStandardMaterial />
+
+	<TransformControls />
 </T.Mesh>
 
 {#if showLight}

--- a/apps/docs/src/examples/test/TransformControls.svelte
+++ b/apps/docs/src/examples/test/TransformControls.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { injectRootPlugin, useParent, useThrelte } from '@threlte/core'
+	import { onDestroy } from 'svelte'
+	import { Object3D } from 'three'
+	import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+	import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
+
+	const parent = useParent()
+	const { renderer, camera, scene } = useThrelte()
+	const orbitControlsInstances = new Set<OrbitControls>()
+	injectRootPlugin('transform-controls', ({ ref }) => {
+		if (!(ref instanceof OrbitControls)) return
+		orbitControlsInstances.add(ref)
+		return {
+			onDestroy: () => {
+				orbitControlsInstances.delete(ref)
+			}
+		}
+	})
+
+	const tc = new TransformControls($camera, renderer?.domElement)
+	if ($parent instanceof Object3D) tc.attach($parent)
+	scene.add(tc)
+	tc.addEventListener('mouseDown', () => {
+		orbitControlsInstances.forEach((oc) => (oc.enabled = false))
+	})
+	tc.addEventListener('mouseUp', () => {
+		orbitControlsInstances.forEach((oc) => (oc.enabled = true))
+	})
+	onDestroy(() => {
+		if (tc) {
+			tc.detach()
+			tc.dispose()
+		}
+	})
+</script>

--- a/apps/docs/src/examples/test/plugins/InteractivityPlugin.svelte
+++ b/apps/docs/src/examples/test/plugins/InteractivityPlugin.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { useThrelteRoot, injectPlugin, type ThreltePointerEvent } from '@threlte/core'
+	import { createEventDispatcher } from 'svelte'
+	import type { Object3D } from 'three'
+
+	injectPlugin('interactivity', () => {
+		const getThrelteUserData = (object: any): any => {
+			return object.userData as any
+		}
+
+		const eventDispatcher = createEventDispatcher<{
+			click: ThreltePointerEvent
+			contextmenu: ThreltePointerEvent
+			pointerup: ThreltePointerEvent
+			pointerdown: ThreltePointerEvent
+			pointerenter: ThreltePointerEvent
+			pointerleave: ThreltePointerEvent
+			pointermove: ThreltePointerEvent
+		}>()
+
+		const {
+			addInteractiveObject,
+			removeInteractiveObject,
+			addRaycastableObject,
+			removeRaycastableObject
+		} = useThrelteRoot()
+
+		const removeObjectInteractivity = (object: Object3D) => {
+			removeRaycastableObject(object)
+			removeInteractiveObject(object)
+			delete getThrelteUserData(object).eventDispatcher
+		}
+
+		const setupObjectInteractivity = (object: Object3D) => {
+			getThrelteUserData(object).eventDispatcher = eventDispatcher
+			addRaycastableObject(object)
+			addInteractiveObject(object)
+		}
+
+		return {
+			onRefChange: (ref) => {
+				if (!ref.raycast) return
+				setupObjectInteractivity(ref)
+				return () => {
+					removeObjectInteractivity(ref)
+				}
+			},
+			pluginProps: ['entity']
+		}
+	})
+</script>
+
+<slot />

--- a/apps/docs/src/examples/test/plugins/LayersPlugin.svelte
+++ b/apps/docs/src/examples/test/plugins/LayersPlugin.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { useThrelte, injectPlugin } from '@threlte/core'
+	import type { ThrelteLayersContext } from '@threlte/core/src/lib/types/types'
+	import { getContext, onDestroy } from 'svelte'
+	import { get } from 'svelte/store'
+	import type { Object3D } from 'three'
+
+	const isObject3D = (object: any): object is Object3D => {
+		return object?.isObject3D
+	}
+
+	injectPlugin('layers', () => {
+		const layers = getContext<ThrelteLayersContext>('threlte-layers')
+		if (!layers) return
+
+		const { invalidate } = useThrelte()
+
+		let currentRef: Object3D
+		let previousMask: number
+
+		let currentLayers = get(layers)
+		const applyLayers = () => {
+			if (!isObject3D(currentRef)) return
+			if (currentLayers === 'all') {
+				currentRef.layers.enableAll()
+			} else if (currentLayers === 'none') {
+				currentRef.layers.disableAll()
+			} else if (Array.isArray(currentLayers)) {
+				for (let index = 0; index < 32; index += 1) {
+					const layerIndex = index as typeof currentLayers[number]
+					const enabled = currentLayers.includes(layerIndex)
+					if (enabled) {
+						currentRef.layers.enable(index)
+					} else {
+						currentRef.layers.disable(index)
+					}
+				}
+			} else if (currentLayers !== undefined) {
+				currentRef.layers.set(currentLayers)
+			}
+			invalidate('Layers plugin')
+		}
+
+		const unsubscribe = layers.subscribe((layers) => {
+			currentLayers = layers
+			applyLayers()
+		})
+		onDestroy(unsubscribe)
+
+		return {
+			onRefChange: (ref) => {
+				if (isObject3D(ref)) {
+					currentRef = ref
+					previousMask = ref.layers.mask
+					applyLayers()
+					return () => {
+						currentRef.layers.mask = previousMask
+					}
+				}
+			}
+		}
+	})
+</script>
+
+<slot />

--- a/apps/docs/src/routes/test/index@reset.svelte
+++ b/apps/docs/src/routes/test/index@reset.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import App from '$examples/test/App.svelte'
+</script>
+
+<App />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check --plugin-search-dir=. . && eslint .",
     "format": "prettier --write --plugin-search-dir=. .",
-    "cleanup": "rm -rf node_modules && rm -rf .svelte-kit"
+    "cleanup": "rm -rf node_modules && rm -rf .svelte-kit && rm -rf dist"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "1.0.0-next.61",

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -1,4 +1,7 @@
-<script context="module" lang="ts">
+<script
+  context="module"
+  lang="ts"
+>
   import { onDestroy, onMount, setContext } from 'svelte'
   import { writable } from 'svelte/store'
   import type { ShadowMapType, WebGLRendererParameters } from 'three'
@@ -16,6 +19,7 @@
     setRendererColorOutput,
     setRendererShadows
   } from './lib/renderer'
+  import type { RootPluginContext, RootPluginContextName } from './plugins/types'
   import type { Size, ThrelteParentContext } from './types/types'
 
   const invalidationHandlers: Set<(debugFrameloopMessage?: string) => void> = new Set()
@@ -102,6 +106,10 @@
   onDestroy(() => {
     disposalCtx.dispose(true)
   })
+
+  // root plugins context
+  const rootPluginsContextName: RootPluginContextName = 'threlte-root-plugin-context'
+  setContext<RootPluginContext>(rootPluginsContextName, writable({}))
 </script>
 
 <canvas

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -65,7 +65,8 @@ export { T } from './three/T'
 export type { Props, Events, Slots } from './three/types'
 // <Three> component plugins
 export { injectPlugin } from './plugins/injectPlugin'
-export type { Plugin } from './plugins/types'
+export { createPlugin } from './plugins/createPlugin'
+export type { Plugin, NamedPlugin } from './plugins/types'
 
 // hooks
 export { useFrame } from './hooks/useFrame'

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -64,9 +64,11 @@ export { default as Three } from './three/Three.svelte'
 export { T } from './three/T'
 export type { Props, Events, Slots } from './three/types'
 // <Three> component plugins
-export { injectPlugin } from './plugins/injectPlugin'
 export { createPlugin } from './plugins/createPlugin'
-export type { Plugin, NamedPlugin } from './plugins/types'
+export { injectPlugin } from './plugins/injectPlugin'
+export { createRootPlugin } from './plugins/createRootPlugin'
+export { injectRootPlugin } from './plugins/injectRootPlugin'
+export type { Plugin, NamedPlugin, RootPlugin, NamedRootPlugin } from './plugins/types'
 
 // hooks
 export { useFrame } from './hooks/useFrame'

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -63,6 +63,9 @@ export { default as DisposableObject } from './internal/DisposableObject.svelte'
 export { default as Three } from './three/Three.svelte'
 export { T } from './three/T'
 export type { Props, Events, Slots } from './three/types'
+// <Three> component plugins
+export { injectPlugin } from './plugins/injectPlugin'
+export type { Plugin } from './plugins/types'
 
 // hooks
 export { useFrame } from './hooks/useFrame'

--- a/packages/core/src/lib/plugins/createPlugin.ts
+++ b/packages/core/src/lib/plugins/createPlugin.ts
@@ -1,0 +1,5 @@
+import type { NamedPlugin, Plugin } from './types'
+
+export function createPlugin(name: string, plugin: Plugin): NamedPlugin {
+  return [name, plugin]
+}

--- a/packages/core/src/lib/plugins/createRootPlugin.ts
+++ b/packages/core/src/lib/plugins/createRootPlugin.ts
@@ -1,0 +1,5 @@
+import type { NamedRootPlugin, RootPlugin } from './types'
+
+export function createRootPlugin(name: string, plugin: RootPlugin): NamedRootPlugin {
+  return [name, plugin]
+}

--- a/packages/core/src/lib/plugins/injectPlugin.ts
+++ b/packages/core/src/lib/plugins/injectPlugin.ts
@@ -1,11 +1,24 @@
 import { getContext, setContext } from 'svelte'
-import type { Plugin, PluginContext, PluginContextName } from './types'
+import type { Plugin, NamedPlugin, PluginContext, PluginContextName } from './types'
 
-export const injectPlugin = (name: string, plugin: Plugin) => {
+export function injectPlugin(namedPlugin: NamedPlugin): void
+export function injectPlugin(name: string, plugin: Plugin): void
+export function injectPlugin(nameOrNamedPlugin: string | NamedPlugin, maybePlugin?: Plugin): void {
   const contextName: PluginContextName = 'threlte-plugin-context'
 
-  setContext<PluginContext>(contextName, {
-    ...getContext<PluginContext | undefined>(contextName),
-    [name]: plugin
-  })
+  if (Array.isArray(nameOrNamedPlugin)) {
+    const [name, plugin] = nameOrNamedPlugin
+    setContext<PluginContext>(contextName, {
+      ...getContext<PluginContext | undefined>(contextName),
+      [name]: plugin
+    })
+  } else {
+    const name = nameOrNamedPlugin
+    const plugin = maybePlugin
+    if (!plugin) return
+    setContext<PluginContext>(contextName, {
+      ...getContext<PluginContext | undefined>(contextName),
+      [name]: plugin
+    })
+  }
 }

--- a/packages/core/src/lib/plugins/injectPlugin.ts
+++ b/packages/core/src/lib/plugins/injectPlugin.ts
@@ -1,0 +1,11 @@
+import { getContext, setContext } from 'svelte'
+import type { Plugin, PluginContext, PluginContextName } from './types'
+
+export const injectPlugin = (name: string, plugin: Plugin) => {
+  const contextName: PluginContextName = 'threlte-plugin-context'
+
+  setContext<PluginContext>(contextName, {
+    ...getContext<PluginContext | undefined>(contextName),
+    [name]: plugin
+  })
+}

--- a/packages/core/src/lib/plugins/injectRootPlugin.ts
+++ b/packages/core/src/lib/plugins/injectRootPlugin.ts
@@ -1,0 +1,39 @@
+import { getContext, onDestroy } from 'svelte'
+import type { NamedRootPlugin, RootPlugin, RootPluginContext, RootPluginContextName } from './types'
+
+export function injectRootPlugin(namedRootPlugin: NamedRootPlugin): void
+export function injectRootPlugin(name: string, rootPlugin: RootPlugin): void
+export function injectRootPlugin(
+  nameOrNamedRootPlugin: string | NamedRootPlugin,
+  maybeRootPlugin?: RootPlugin
+): void {
+  const contextName: RootPluginContextName = 'threlte-root-plugin-context'
+
+  let pluginName: string | undefined = undefined
+  let plugin: RootPlugin | undefined = undefined
+
+  if (Array.isArray(nameOrNamedRootPlugin)) {
+    pluginName = nameOrNamedRootPlugin[0]
+    plugin = nameOrNamedRootPlugin[1]
+  } else {
+    pluginName = nameOrNamedRootPlugin
+    plugin = maybeRootPlugin
+  }
+
+  if (!pluginName || !plugin) return
+
+  const rootPlugins = getContext<RootPluginContext | undefined>(contextName)
+
+  rootPlugins?.update((rootPlugins) => {
+    if (!pluginName || !plugin) return rootPlugins
+    return { ...rootPlugins, [pluginName]: plugin }
+  })
+
+  onDestroy(() => {
+    rootPlugins?.update((rootPlugins) => {
+      if (!pluginName || !plugin) return rootPlugins
+      const { [pluginName]: _, ...rest } = rootPlugins
+      return rest
+    })
+  })
+}

--- a/packages/core/src/lib/plugins/types.ts
+++ b/packages/core/src/lib/plugins/types.ts
@@ -1,7 +1,5 @@
 export type Plugin = (params: { ref: any; props: Record<string, any> }) => {
   pluginProps?: Record<string, any>
-  onMount?: () => void
-  onDestroy?: () => void
   onRefChange?: (ref: any) => void | (() => void)
   onPropsChange?: (props: Record<string, any>) => void
   onRestPropsChange?: (restProps: Record<string, any>) => void

--- a/packages/core/src/lib/plugins/types.ts
+++ b/packages/core/src/lib/plugins/types.ts
@@ -1,7 +1,4 @@
-export type Plugin = (
-  ref: any,
-  props: Record<string, any>
-) => {
+export type Plugin = (params: { ref: any; props: Record<string, any> }) => {
   pluginProps?: Record<string, any>
   onMount?: () => void
   onDestroy?: () => void

--- a/packages/core/src/lib/plugins/types.ts
+++ b/packages/core/src/lib/plugins/types.ts
@@ -1,0 +1,15 @@
+export type Plugin = (
+  ref: any,
+  props: Record<string, any>
+) => {
+  pluginProps?: Record<string, any>
+  onMount?: () => void
+  onDestroy?: () => void
+  onRefChange?: (ref: any) => void | (() => void)
+  onPropsChange?: (props: Record<string, any>) => void
+  onRestPropsChange?: (restProps: Record<string, any>) => void
+} | void
+
+export type PluginContext = Record<string, Plugin>
+
+export type PluginContextName = 'threlte-plugin-context'

--- a/packages/core/src/lib/plugins/types.ts
+++ b/packages/core/src/lib/plugins/types.ts
@@ -1,12 +1,25 @@
+import type { Writable } from 'svelte/store'
+
 export type Plugin = (params: { ref: any; props: Record<string, any> }) => {
-  pluginProps?: Record<string, any>
+  pluginProps?: string[]
   onRefChange?: (ref: any) => void | (() => void)
   onPropsChange?: (props: Record<string, any>) => void
   onRestPropsChange?: (restProps: Record<string, any>) => void
 } | void
 
 export type NamedPlugin = [name: string, plugin: Plugin]
-
 export type PluginContext = Record<string, Plugin>
-
 export type PluginContextName = 'threlte-plugin-context'
+
+export type RootPlugin = (params: { ref: any; props: Record<string, any> }) => {
+  pluginProps?: string[]
+  onRefChange?: (ref: any) => void | (() => void)
+  onPropsChange?: (props: Record<string, any>) => void
+  onRestPropsChange?: (restProps: Record<string, any>) => void
+  onMount?: () => void
+  onDestroy?: () => void
+} | void
+
+export type NamedRootPlugin = [name: string, plugin: RootPlugin]
+export type RootPluginContext = Writable<Record<string, RootPlugin>>
+export type RootPluginContextName = 'threlte-root-plugin-context'

--- a/packages/core/src/lib/plugins/types.ts
+++ b/packages/core/src/lib/plugins/types.ts
@@ -5,6 +5,8 @@ export type Plugin = (params: { ref: any; props: Record<string, any> }) => {
   onRestPropsChange?: (restProps: Record<string, any>) => void
 } | void
 
+export type NamedPlugin = [name: string, plugin: Plugin]
+
 export type PluginContext = Record<string, Plugin>
 
 export type PluginContextName = 'threlte-plugin-context'

--- a/packages/core/src/lib/three/Three.svelte
+++ b/packages/core/src/lib/three/Three.svelte
@@ -64,9 +64,6 @@
   // Plugins
   const plugins = usePlugins({ ref, props: $$props })
   const pluginsProps = plugins?.pluginsProps ?? []
-  $: plugins?.updateRef(ref)
-  $: plugins?.updateProps($$props)
-  $: plugins?.updateRestProps($$restProps)
 
   // Props
   const props = useProps()
@@ -87,6 +84,11 @@
   // Events
   const events = useEvents()
   $: events.updateRef(ref)
+
+  // update plugins after all other updates
+  $: plugins?.updateRef(ref)
+  $: plugins?.updateProps($$props)
+  $: plugins?.updateRestProps($$restProps)
 
   const extendsObject3D = (object: any): object is Object3D => {
     return !!(object as any).isObject3D

--- a/packages/core/src/lib/three/Three.svelte
+++ b/packages/core/src/lib/three/Three.svelte
@@ -8,6 +8,7 @@
   import { useAttach } from './lib/useAttach'
   import { useCamera } from './lib/useCamera'
   import { useEvents } from './lib/useEvents'
+  import { usePlugins } from './lib/usePlugins'
   import { useProps } from './lib/useProps'
   import type { AnyClass, MaybeInstance, Props } from './types'
 
@@ -60,10 +61,18 @@
   $: objectStore.set(ref)
   setContext<ThrelteThreeParentContext>('threlte-hierarchical-parent-context', objectStore)
 
+  // Plugins
+  const plugins = usePlugins(ref, $$props)
+  const pluginsProps = plugins?.pluginsProps ?? []
+  $: plugins?.updateRef(ref)
+  $: plugins?.updateProps($$props)
+  $: plugins?.updateRestProps($$restProps)
+
   // Props
   const props = useProps()
   $: props.updateProps(ref, $$restProps, {
-    manualCamera: manual
+    manualCamera: manual,
+    pluginsProps
   })
 
   // Camera

--- a/packages/core/src/lib/three/Three.svelte
+++ b/packages/core/src/lib/three/Three.svelte
@@ -62,7 +62,7 @@
   setContext<ThrelteThreeParentContext>('threlte-hierarchical-parent-context', objectStore)
 
   // Plugins
-  const plugins = usePlugins(ref, $$props)
+  const plugins = usePlugins({ ref, props: $$props })
   const pluginsProps = plugins?.pluginsProps ?? []
   $: plugins?.updateRef(ref)
   $: plugins?.updateProps($$props)

--- a/packages/core/src/lib/three/Three.svelte
+++ b/packages/core/src/lib/three/Three.svelte
@@ -10,6 +10,7 @@
   import { useEvents } from './lib/useEvents'
   import { usePlugins } from './lib/usePlugins'
   import { useProps } from './lib/useProps'
+  import { useRootPlugins } from './lib/useRootPlugins'
   import type { AnyClass, MaybeInstance, Props } from './types'
 
   type Type = $$Generic
@@ -63,13 +64,18 @@
 
   // Plugins
   const plugins = usePlugins({ ref, props: $$props })
-  const pluginsProps = plugins?.pluginsProps ?? []
+  const pluginsProps = plugins?.pluginsProps
+
+  // Root Plugins
+  const rootPlugins = useRootPlugins({ ref, props: $$props })
+  const rootPluginsProps = rootPlugins?.rootPluginsProps
 
   // Props
   const props = useProps()
   $: props.updateProps(ref, $$restProps, {
     manualCamera: manual,
-    pluginsProps
+    pluginsProps,
+    rootPluginsProps
   })
 
   // Camera
@@ -85,10 +91,15 @@
   const events = useEvents()
   $: events.updateRef(ref)
 
-  // update plugins after all other updates
+  // update plugins
   $: plugins?.updateRef(ref)
   $: plugins?.updateProps($$props)
   $: plugins?.updateRestProps($$restProps)
+
+  // update root plugins after all other updates
+  $: rootPlugins?.updateRef(ref)
+  $: rootPlugins?.updateProps($$props)
+  $: rootPlugins?.updateRestProps($$restProps)
 
   const extendsObject3D = (object: any): object is Object3D => {
     return !!(object as any).isObject3D

--- a/packages/core/src/lib/three/lib/usePlugins.ts
+++ b/packages/core/src/lib/three/lib/usePlugins.ts
@@ -1,14 +1,14 @@
 import { getContext, onDestroy, onMount } from 'svelte'
 import type { Plugin, PluginContext, PluginContextName } from '../../plugins/types'
 
-export const usePlugins = (ref: any, props: Record<string, any>) => {
+export const usePlugins = (params: Parameters<Plugin>[0]) => {
   const pluginContextName: PluginContextName = 'threlte-plugin-context'
   const plugins = getContext<PluginContext | undefined>(pluginContextName)
 
   if (!plugins) return
 
   const pluginsReturns = Object.values(plugins)
-    .map((plugin) => plugin(ref, props))
+    .map((plugin) => plugin(params))
     .filter(Boolean) as Exclude<ReturnType<Plugin>, void>[]
 
   const pluginsProps = pluginsReturns.flatMap((callback) => callback.pluginProps ?? [])

--- a/packages/core/src/lib/three/lib/usePlugins.ts
+++ b/packages/core/src/lib/three/lib/usePlugins.ts
@@ -1,4 +1,4 @@
-import { getContext, onDestroy, onMount } from 'svelte'
+import { getContext, onDestroy } from 'svelte'
 import type { Plugin, PluginContext, PluginContextName } from '../../plugins/types'
 
 export const usePlugins = (params: Parameters<Plugin>[0]) => {
@@ -12,14 +12,6 @@ export const usePlugins = (params: Parameters<Plugin>[0]) => {
     .filter(Boolean) as Exclude<ReturnType<Plugin>, void>[]
 
   const pluginsProps = pluginsReturns.flatMap((callback) => callback.pluginProps ?? [])
-
-  onMount(() => {
-    pluginsReturns.forEach((callback) => callback.onMount?.())
-  })
-
-  onDestroy(() => {
-    pluginsReturns.forEach((callback) => callback.onDestroy?.())
-  })
 
   let refCleanupCallbacks: (() => void)[] = []
   onDestroy(() => {

--- a/packages/core/src/lib/three/lib/usePlugins.ts
+++ b/packages/core/src/lib/three/lib/usePlugins.ts
@@ -1,0 +1,57 @@
+import { getContext, onDestroy, onMount } from 'svelte'
+import type { Plugin, PluginContext, PluginContextName } from '../../plugins/types'
+
+export const usePlugins = (ref: any, props: Record<string, any>) => {
+  const pluginContextName: PluginContextName = 'threlte-plugin-context'
+  const plugins = getContext<PluginContext | undefined>(pluginContextName)
+
+  if (!plugins) return
+
+  const pluginsReturns = Object.values(plugins)
+    .map((plugin) => plugin(ref, props))
+    .filter(Boolean) as Exclude<ReturnType<Plugin>, void>[]
+
+  const pluginsProps = pluginsReturns.flatMap((callback) => callback.pluginProps ?? [])
+
+  onMount(() => {
+    pluginsReturns.forEach((callback) => callback.onMount?.())
+  })
+
+  onDestroy(() => {
+    pluginsReturns.forEach((callback) => callback.onDestroy?.())
+  })
+
+  let refCleanupCallbacks: (() => void)[] = []
+  onDestroy(() => {
+    refCleanupCallbacks.forEach((callback) => callback())
+  })
+  const updateRef = (ref: any) => {
+    refCleanupCallbacks.forEach((callback) => callback())
+    refCleanupCallbacks = []
+    pluginsReturns.forEach((callback) => {
+      const cleanupCallback = callback.onRefChange?.(ref)
+      if (cleanupCallback) {
+        refCleanupCallbacks.push(cleanupCallback)
+      }
+    })
+  }
+
+  const updateProps = (props: Record<string, any>) => {
+    pluginsReturns.forEach((callback) => {
+      callback.onPropsChange?.(props)
+    })
+  }
+
+  const updateRestProps = (restProps: Record<string, any>) => {
+    pluginsReturns.forEach((callback) => {
+      callback.onRestPropsChange?.(restProps)
+    })
+  }
+
+  return {
+    updateRef,
+    updateProps,
+    updateRestProps,
+    pluginsProps
+  }
+}

--- a/packages/core/src/lib/three/lib/useProps.ts
+++ b/packages/core/src/lib/three/lib/useProps.ts
@@ -36,6 +36,7 @@ export const memoizeProp = (value: unknown): boolean => {
 
 type PropOptions = {
   manualCamera?: boolean
+  pluginsProps?: string[]
 }
 
 export const useProps = () => {
@@ -94,7 +95,7 @@ export const useProps = () => {
 
   const updateProps = <T>(instance: T, props: Record<string, any>, options: PropOptions) => {
     for (const key in props) {
-      if (!ignoredProps.includes(key)) {
+      if (!ignoredProps.includes(key) && !options.pluginsProps?.includes(key)) {
         setProp(instance, key, props[key], options)
       }
       invalidate()

--- a/packages/core/src/lib/three/lib/useProps.ts
+++ b/packages/core/src/lib/three/lib/useProps.ts
@@ -37,6 +37,7 @@ export const memoizeProp = (value: unknown): boolean => {
 type PropOptions = {
   manualCamera?: boolean
   pluginsProps?: string[]
+  rootPluginsProps?: string[]
 }
 
 export const useProps = () => {
@@ -95,7 +96,11 @@ export const useProps = () => {
 
   const updateProps = <T>(instance: T, props: Record<string, any>, options: PropOptions) => {
     for (const key in props) {
-      if (!ignoredProps.includes(key) && !options.pluginsProps?.includes(key)) {
+      if (
+        !ignoredProps.includes(key) &&
+        !options.pluginsProps?.includes(key) &&
+        !options.rootPluginsProps?.includes(key)
+      ) {
         setProp(instance, key, props[key], options)
       }
       invalidate()

--- a/packages/core/src/lib/three/lib/useRootPlugins.ts
+++ b/packages/core/src/lib/three/lib/useRootPlugins.ts
@@ -1,0 +1,78 @@
+import { getContext, onDestroy } from 'svelte'
+import type { RootPlugin, RootPluginContext, RootPluginContextName } from '../../plugins/types'
+
+export const useRootPlugins = (params: Parameters<RootPlugin>[0]) => {
+  const pluginContextName: RootPluginContextName = 'threlte-root-plugin-context'
+  const pluginsContext = getContext<RootPluginContext | undefined>(pluginContextName)
+
+  if (!pluginsContext) return
+
+  let currentRef = params.ref
+  let currentProps = params.props
+  let currentRootPlugins: Record<string, RootPlugin> = {}
+  const activeRootPlugins: Record<string, Exclude<ReturnType<RootPlugin>, void>> = {}
+
+  const rootPluginsProps: string[] = []
+
+  const getRootPluginsProps = () => {
+    return Object.values(activeRootPlugins).flatMap((callback) => callback.pluginProps ?? [])
+  }
+
+  const updateRef = (ref: any) => {
+    currentRef = ref
+    Object.values(activeRootPlugins).forEach((callback) => callback.onRefChange?.(ref))
+  }
+
+  const updateProps = (props: Record<string, any>) => {
+    currentProps = props
+    Object.values(activeRootPlugins).forEach((callback) => callback.onPropsChange?.(props))
+  }
+
+  const updateRestProps = (restProps: Record<string, any>) => {
+    Object.values(activeRootPlugins).forEach((callback) => callback.onRestPropsChange?.(restProps))
+  }
+
+  const onPluginMount = (name: string, newPlugin: RootPlugin) => {
+    const callbacks = newPlugin({ props: currentProps, ref: currentRef })
+    if (callbacks) {
+      callbacks.onMount?.()
+      activeRootPlugins[name] = callbacks
+      rootPluginsProps.length = 0
+      rootPluginsProps.push(...getRootPluginsProps())
+    }
+  }
+
+  const onPluginDestroy = (name: string) => {
+    activeRootPlugins[name]?.onDestroy?.()
+    delete activeRootPlugins[name]
+    rootPluginsProps.length = 0
+    rootPluginsProps.push(...getRootPluginsProps())
+  }
+
+  const unsubscribePluginsContext = pluginsContext.subscribe((plugins) => {
+    const newRootPluginsKeys = Object.keys(plugins)
+    const currentRootPluginsKeys = Object.keys(currentRootPlugins)
+    newRootPluginsKeys.forEach((key) => {
+      if (!currentRootPluginsKeys.includes(key)) {
+        onPluginMount(key, plugins[key])
+      }
+    })
+    currentRootPluginsKeys.forEach((key) => {
+      if (!newRootPluginsKeys.includes(key)) {
+        onPluginDestroy(key)
+      }
+    })
+    currentRootPlugins = plugins
+  })
+  onDestroy(() => {
+    unsubscribePluginsContext()
+    Object.values(activeRootPlugins).forEach((callback) => callback.onDestroy?.())
+  })
+
+  return {
+    updateRef,
+    updateProps,
+    rootPluginsProps,
+    updateRestProps
+  }
+}


### PR DESCRIPTION
# RFC: Plugin API

## Injecting a Plugin

### What it looks like

This PR opens up the component `<Three>` (`<T>` with preprocessing) to external code that can be injected via context into every child instance of a `<Three>` component.

```ts
import { injectPlugin } from '@threlte/core'

injectPlugin('plugin-name', ({ ref, props }) => {
  console.log(ref, props)
})
```

If a plugin decides via `ref` or `props` analysis that it doesn't need to act in the context of a certain `<Three>` component, it can return early.

```ts
import { injectPlugin } from '@threlte/core'
import type { Object3D } from 'three'

const refIsObject3D = (ref: any): ref is Object3D => ref.isObject3D

injectPlugin('raycast-plugin', ({ ref, props }) => {
  if (!refIsObject3D(ref) || !props.raycast) return
})
```

The code of a plugin acts as if it would be part of the `<Three>` component itself and has access to all properties. A plugin is notified about property or `ref` changes and can run code in lifecycle functions such as `onMount` or `onDestroy`.

```ts
import { injectPlugin } from '@threlte/core'
import { onMount } from 'svelte'

injectPlugin('plugin-name', () => {
  
  // Use lifecycle hooks as if it would run inside a <Three> component.
  onMount(() => {
    console.log('onMount')
  })

  return {
    // This is called when the ref changes and on initialization.
    onRefChange(ref) {
      console.log(ref)

      // You can return a cleanup function that will be called when the ref
      // changes again or when the component is destroyed.
      return () => {
        console.log('cleanup')
      }
    },

    // This is called when the props change and on initialization. This includes
    // props like "args", "manual" and other base props of <Three> but also
    // props that are not part of the base props.
    onPropsChange(props) {
      console.log(props)
    },

    // This is called when the props change that are not part of the <Three>
    // components base props and on initialization.
    onRestPropsChange(restProps) {
      console.log(restProps)
    }
  }
})
```

It can also *claim properties* so that the component `<Three>` does not act on it.

```ts
import { injectPlugin } from '@threlte/core'

injectPlugin('ecs', () => {
  return {
    // without claiming the property "position", <Three> would apply the
    // property to the object
    pluginProps: ['entity', 'health', 'velocity', 'position']
  }
})
```

Plugins are passed down by context and can be overridden to prevent the effects of a plugin for a certain tree.

```ts
import { injectPlugin } from '@threlte/core'

// this overrides the plugin with the name "plugin-name" for all child components.
injectPlugin('plugin-name', () => {})
```

### Creating a Plugin

Plugins can also be *created* for external consumption:

```ts
import { createPlugin } from '@threlte/core'

export const layersPlugin = createPlugin('layers', () => {
  // ... Plugin Code
})
```

```ts
// somewhere else, e.g. in a component

import { injectPlugin } from '@threlte/core'
import { layersPlugin } from '$plugins'

injectPlugin(layersPlugin)
```

## Root Plugins

Regular Plugins act on all child `<Three>` components. Sometimes a component might want to inject Plugin Code also to components further up the tree. One example would be a component that needs to enable/disable another component upon interaction, such as `TransformControls` that disable/enable `OrbitControls`. *Root Plugins* are injected into every component that is a child of `<Canvas>`. These Plugins __do not__ have access to component lifecycle hooks and variables because they need to injected into components that are already mounted.

```ts
import { injectRootPlugin } from '@threlte/core'

injectRootPlugin('controls', () => {
  // Plugin Code
})
```

*Root Plugins* __do not__ have access to component lifecycle hooks but they can return the functions `onMount` and `onDestroy`.

```ts
import { injectRootPlugin } from '@threlte/core'

injectRootPlugin('controls', ({ ref, props }) => {

  // props are all props passed to a component
  console.log(props)

  // the reference to the THREE object the component is representing
  console.log(ref)

  return {
    // will be called when the plugin is mounted to a component (the component
    // might already be mounted)
    onMount: () => {},

    // will be called when the plugin is removed or the component is destroyed
    onDestroy: () => {}
  }
})
```

## Examples

### Interactivity Plugin

This is en example implementation that adds interactivity to all `<Three>` components, so that `<T.Mesh on:click={() => console.log('click')} />` is possible:

```html
<script lang="ts">
  import { useThrelteRoot, injectPlugin, type ThreltePointerEvent } from '@threlte/core'
  import { createEventDispatcher } from 'svelte'
  import type { Object3D } from 'three'

  injectPlugin('interactivity', () => {
    const getThrelteUserData = (object: any): any => {
      return object.userData as any
    }

    const eventDispatcher = createEventDispatcher<{
      click: ThreltePointerEvent
      contextmenu: ThreltePointerEvent
      pointerup: ThreltePointerEvent
      pointerdown: ThreltePointerEvent
      pointerenter: ThreltePointerEvent
      pointerleave: ThreltePointerEvent
      pointermove: ThreltePointerEvent
    }>()

    const {
      addInteractiveObject,
      removeInteractiveObject,
      addRaycastableObject,
      removeRaycastableObject
    } = useThrelteRoot()

    const removeObjectInteractivity = (object: Object3D) => {
      removeRaycastableObject(object)
      removeInteractiveObject(object)
      delete getThrelteUserData(object).eventDispatcher
    }

    const setupObjectInteractivity = (object: Object3D) => {
      getThrelteUserData(object).eventDispatcher = eventDispatcher
      addRaycastableObject(object)
      addInteractiveObject(object)
    }

    return {
      onRefChange: (ref) => {
        if (!ref.raycast) return
        setupObjectInteractivity(ref)
        return () => {
          removeObjectInteractivity(ref)
        }
      },
      pluginProps: ['entity']
    }
  })
</script>

<slot />
```

Implementing it in your app would be as easy as:

```html
<script lang="ts">
  import { Canvas } from '@threlte/core'
  import Interactivity from './plugins/Interactivity.svelte'
  import Scene from './Scene.svelte'
</script>

<Canvas>
  <Interactivity>
    <Scene />
  </Interactivity>
</Canvas>
```

### BVH Raycast Plugin

A Plugin that implements [BVH raycasting](https://github.com/gkjohnson/three-mesh-bvh) on all child meshes and geometries.

```html
<script lang="ts">
  import { injectPlugin } from '@threlte/core'
  import type { BufferGeometry, Mesh } from 'three'
  import { computeBoundsTree, disposeBoundsTree, acceleratedRaycast } from 'three-mesh-bvh'

  const isBufferGeometry = (ref: any): ref is BufferGeometry => {
    return ref.isBufferGeometry
  }

  const isMesh = (ref: any): ref is Mesh => {
    return ref.isMesh
  }

  injectPlugin('bvh-raycast', () => {
    return {
      onRefChange(ref) {
        if (isBufferGeometry(ref)) {
          ;(ref as any).computeBoundsTree = computeBoundsTree
          ;(ref as any).disposeBoundsTree = disposeBoundsTree
          ;(ref as any).computeBoundsTree()
        }
        if (isMesh(ref)) {
          ;(ref as any).raycast = acceleratedRaycast
        }
        return () => {
          if (isBufferGeometry(ref)) {
            ;(ref as any).disposeBoundsTree()
          }
        }
      }
    }
  })
</script>

<slot />
```

Implementing this plugin in your Scene:

```html
<script lang="ts">
  import { Canvas } from '@threlte/core'
  import BvhRaycast from './plugins/BvhRaycast.svelte'
  import Scene from './Scene.svelte'
</script>

<Canvas>
  <BvhRaycast>
    <Scene />
  </BvhRaycast>
</Canvas>
```

### TransformControls

`TransformControls` interfere with `OrbitControls` because dragging the axes of the `TransformControls` also alters the view. We can make use of the `TransformControls` events and a *Root Plugin* that fetches all instances of `OrbitControls` that should pause when the `TransformControls` are dragged. This also makes the `TransformControls` self-contained.

```html
<script lang="ts">
  import { injectRootPlugin, useParent, useThrelte } from '@threlte/core'
  import { onDestroy } from 'svelte'
  import { Object3D } from 'three'
  import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
  import { TransformControls } from 'three/examples/jsm/controls/TransformControls'

  const parent = useParent()
  const { renderer, camera, scene } = useThrelte()
  const orbitControlsInstances = new Set<OrbitControls>()
  injectRootPlugin('transform-controls', ({ ref }) => {
    if (!(ref instanceof OrbitControls)) return
    orbitControlsInstances.add(ref)
    return {
      onDestroy: () => {
        orbitControlsInstances.delete(ref)
      }
    }
  })

  const tc = new TransformControls($camera, renderer?.domElement)
  if ($parent instanceof Object3D) tc.attach($parent)
  scene.add(tc)
  tc.addEventListener('mouseDown', () => {
    orbitControlsInstances.forEach((oc) => (oc.enabled = false))
  })
  tc.addEventListener('mouseUp', () => {
    orbitControlsInstances.forEach((oc) => (oc.enabled = true))
  })
  onDestroy(() => {
    if (tc) {
      tc.detach()
      tc.dispose()
    }
  })
</script>
```

## Effects

In the components prior to version 5 render components (such as `<Mesh>`) all functionality was baked in. This Plugin API makes it possible to write safe and performant code that runs in every instance of `<Three>`/`<T>` and is able to provide generic features such as interactivity or implementing an ECS (such as [miniplex](https://github.com/hmans/miniplex)) or use-case specific plugin code.