### PR TITLE
Rapier heightfield fix?

### DIFF
--- a/apps/docs/src/examples/terrain-heightfield/App.svelte
+++ b/apps/docs/src/examples/terrain-heightfield/App.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Canvas } from '@threlte/core'
+	import { World } from '@threlte/rapier'
+	import Scene from './Scene.svelte'
+</script>
+
+<Canvas>
+	<World>
+		<Scene />
+	</World>
+</Canvas>

--- a/apps/docs/src/examples/terrain-heightfield/Scene.svelte
+++ b/apps/docs/src/examples/terrain-heightfield/Scene.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { PlaneGeometry, MeshStandardMaterial } from 'three'
+	import { DEG2RAD } from 'three/src/math/MathUtils'
+	import { createNoise2D } from 'simplex-noise'
+	import { T, OrbitControls } from '@threlte/core'
+	import RAPIER from '@dimforge/rapier3d-compat'
+	import { Collider, Debug, RigidBody, useRapier } from '@threlte/rapier'
+
+	let nsubdivs = 10
+	let heights = generateHeightfield(nsubdivs)
+
+	const geometry = new PlaneGeometry(10, 10, nsubdivs, nsubdivs)
+	const material = new MeshStandardMaterial()
+
+	const noise = createNoise2D()
+	const vertices = geometry.getAttribute('position').array
+
+	for (let x = 0; x <= nsubdivs; x++) {
+		for (let y = 0; y <= nsubdivs; y++) {
+			let height = noise(x, y)
+			const vertIndex = (x + (nsubdivs + 1) * y) * 3
+
+			//@ts-ignore
+			vertices[vertIndex + 2] = height
+			const heightIndex = y + (nsubdivs + 1) * x
+			heights[heightIndex] = height
+		}
+	}
+
+	let flippedHeights = new Float32Array(heights.length)
+
+	for (let x = 0; x <= nsubdivs; x++) {
+		for (let y = 0; y <= nsubdivs; y++) {
+			const indexOriginal = x + (nsubdivs + 1) * y
+			// const indexFlipped = x * nsubdivs + (11 - y)
+			// console.log(indexFlipped)
+			flippedHeights[indexOriginal] = heights[indexOriginal]
+		}
+	}
+
+	// needed for lighting
+	geometry.computeVertexNormals()
+
+	const scale = new RAPIER.Vector3(10.0, 1, 10)
+
+	function generateHeightfield(nsubdivs: number) {
+		let heights = []
+
+		const rng = Math.random() * 3
+
+		let i, j
+		for (i = 0; i <= nsubdivs; ++i) {
+			for (j = 0; j <= nsubdivs; ++j) {
+				heights.push(rng)
+			}
+		}
+
+		return new Float32Array(heights)
+	}
+
+	// TODO - cleanup
+	// unnecessary, without this PR the only way to make heightfields is vanilla rapier?
+	// const { world } = useRapier()
+
+	// const bodyDesc = RAPIER.RigidBodyDesc.fixed()
+	// const body = world.createRigidBody(bodyDesc)
+	// const colliderDesc = RAPIER.ColliderDesc.heightfield(nsubdivs, nsubdivs, heights, scale)
+	// world.createCollider(colliderDesc, body)
+</script>
+
+<T.PerspectiveCamera makeDefault position.y={10} position.z={10} lookAt.y={0}>
+	<OrbitControls enableZoom={true} />
+</T.PerspectiveCamera>
+
+<T.DirectionalLight position={[3, 10, 10]} />
+<T.HemisphereLight intensity={0.2} />
+
+<T.Mesh receiveShadow {material} {geometry} rotation.x={DEG2RAD * -90} rotation.z={DEG2RAD * 0} />
+
+<RigidBody type={'fixed'}>
+	<Collider shape={'heightfield'} args={[nsubdivs, nsubdivs, heights, scale]} />
+</RigidBody>
+
+<Debug />

--- a/apps/docs/src/routes/examples/index.md
+++ b/apps/docs/src/routes/examples/index.md
@@ -18,6 +18,7 @@ Find useful recipes and inspiration for your next project.
 ## Geometry
 
 - [Terrain with 3D noise](./terrain.md)
+- [Terrain with Rapier physics collider](./terrain-heightfield.md)
 
 <!-- - [portals](https://threejs.org/examples/#webgl_portal) (WIP - three.js example) -->
 

--- a/apps/docs/src/routes/examples/terrain-heightfield.md
+++ b/apps/docs/src/routes/examples/terrain-heightfield.md
@@ -1,0 +1,20 @@
+---
+title: Terrain with Rapier heightfield collider
+---
+
+<script lang="ts">
+import Example from '$examples/terrain-heightfield/App.svelte'
+</script>
+
+# Terrain with Rapier heightfield collider
+
+<ExampleWrapper playgroundHref="/terrain-heightfield">
+<Example />
+
+<div slot="code">
+
+@[code svelte|title=App.svelte](../../examples/terrain-heightfield/App.svelte)
+@[code svelte|title=Scene.svelte](../../examples/terrain-heightfield/Scene.svelte)
+
+</div>
+</ExampleWrapper>

--- a/packages/rapier/src/lib/components/Colliders/Collider.svelte
+++ b/packages/rapier/src/lib/components/Colliders/Collider.svelte
@@ -78,6 +78,7 @@
   onMount(async () => {
     await tick()
     const scale = object.getWorldScale(new Vector3())
+
     const scaledArgs = scaleColliderArgs(shape, args, scale)
 
     // @ts-ignore

--- a/packages/rapier/src/lib/lib/scaleColliderArgs.ts
+++ b/packages/rapier/src/lib/lib/scaleColliderArgs.ts
@@ -21,9 +21,9 @@ export const scaleColliderArgs = <Shape extends ColliderShapes>(
 ): Parameters<typeof ColliderDesc[Shape]> => {
   // Heightfield only scales the last arg
   const newArgs = args.slice()
-
   if (shape === 'heightfield') {
-    ;(newArgs[3] as number) *= scale.x
+    // Is this for auto scaling heightfield to THREE scale of the object?
+    // ;(newArgs[3] as number) = scale.x
     return newArgs as Parameters<typeof ColliderDesc[Shape]>
   }
 


### PR DESCRIPTION
I tried to make a heightfield today and I had a lot of issues initializing it (error below).  I thought our <Debug/> is incorrect but it seems there is a problem with a function that makes Collider constructor args.

I commented out one line that was setting scale.x in  `packages/rapier/src/lib/lib/scaleColliderArgs.ts`. I also made an example to debug. 

Without this PR this code didn't run.
```
<RigidBody type={'fixed'}>
	<Collider shape={'heightfield'} args={[nsubdivs, nsubdivs, heights, scale]} />
</RigidBody>
```

![image](https://user-images.githubusercontent.com/16734228/209721600-baf58cd7-22f6-40a8-acf9-bec7abca80a5.png)


packages/rapier/src/lib/lib/scaleColliderArgs.ts