### PR TITLE
Remove unnecessary store get calls

### DIFF
--- a/.changeset/five-buckets-search.md
+++ b/.changeset/five-buckets-search.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Remove unnecessary get(store) calls

--- a/packages/core/src/lib/lib/interactivity.ts
+++ b/packages/core/src/lib/lib/interactivity.ts
@@ -1,5 +1,4 @@
 import { onDestroy } from 'svelte'
-import { get } from 'svelte/store'
 import type { Camera, Event, Intersection, Object3D, Vector2 } from 'three'
 import type {
   ThrelteContext,
@@ -61,10 +60,10 @@ export const useEventRaycast = (
   onPointerDown: (e: MouseEvent | PointerEvent) => void
   onPointerMove: (e: MouseEvent | PointerEvent) => void
 } => {
-  let camera = get(ctx.camera)
+  let camera: Camera
   const unsubscribeCamera = ctx.camera.subscribe((value) => (camera = value))
   onDestroy(unsubscribeCamera)
-  let pointer = get(ctx.pointer)
+  let pointer: Vector2
   const unsubscribePointer = ctx.pointer.subscribe((value) => (pointer = value))
   onDestroy(unsubscribePointer)
 
@@ -156,15 +155,15 @@ export const useFrameloopRaycast = (
   raycast: () => void
 } => {
   // unwrapping stores
-  let pointerOverCanvas = get(ctx.pointerOverCanvas)
+  let pointerOverCanvas: boolean
   const unsubscribePointerOverCanvas = ctx.pointerOverCanvas.subscribe(
     (value) => (pointerOverCanvas = value)
   )
   onDestroy(unsubscribePointerOverCanvas)
-  let camera = get(ctx.camera)
+  let camera: Camera
   const unsubscribeCamera = ctx.camera.subscribe((value) => (camera = value))
   onDestroy(unsubscribeCamera)
-  let pointer = get(ctx.pointer)
+  let pointer: Vector2
   const unsubscribePointer = ctx.pointer.subscribe((value) => (pointer = value))
   onDestroy(unsubscribePointer)
 


### PR DESCRIPTION
Follow-up to the discussion: https://discord.com/channels/985983540804091964/986233334747254854/1064575611332473019

Given that `store.subscribe()` synchronously runs its callback, it's not necessary to call `get(store)` immediately beforehand.