### PR TITLE
Threlte v6 Interactivity Plugin

### DIFF
--- a/apps/docs-next/src/examples/test/App.svelte
+++ b/apps/docs-next/src/examples/test/App.svelte
@@ -3,11 +3,13 @@
   import Scene from './Scene.svelte'
 </script>
 
-<Canvas debugFrameloop>
-  <Scene />
-</Canvas>
+<div class="w-full h-full relative">
+  <Canvas debugFrameloop>
+    <Scene />
+  </Canvas>
 
-<div
-  class="bg-red-500 w-[200px] h-[200px] absolute top-0 left-0"
-  id="int-target"
-/>
+  <div
+    class="bg-red-500/20 absolute top-0 left-0 w-full h-full"
+    id="int-target"
+  />
+</div>

--- a/apps/docs-next/src/examples/test/App.svelte
+++ b/apps/docs-next/src/examples/test/App.svelte
@@ -6,3 +6,8 @@
 <Canvas debugFrameloop>
   <Scene />
 </Canvas>
+
+<div
+  class="bg-red-500 w-[200px] h-[200px] absolute top-0 left-0"
+  id="int-target"
+/>

--- a/apps/docs-next/src/examples/test/App.svelte
+++ b/apps/docs-next/src/examples/test/App.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { Canvas } from '@threlte/core'
+  import Scene from './Scene.svelte'
+</script>
+
+<Canvas debugFrameloop>
+  <Scene />
+</Canvas>

--- a/apps/docs-next/src/examples/test/Scene.svelte
+++ b/apps/docs-next/src/examples/test/Scene.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import { T } from '@threlte/core'
-  import { interactivity } from '@threlte/extras'
+  import { EventMap, interactivity } from '@threlte/extras'
+  import { spring } from 'svelte/motion'
 
   interactivity()
+
+  let color = 'blue'
+
+  const scale = spring(1)
 </script>
 
 <T.OrthographicCamera
@@ -17,20 +22,20 @@
 <T.DirectionalLight position={[1, 2, 5]} />
 
 <T.Mesh
-  on:pointerover={(e) => {
-    console.log('over red!!!')
+  on:pointerenter={(e) => {
+    color = 'red'
   }}
+  on:pointerleave={(e) => {
+    color = 'blue'
+  }}
+  on:pointerdown={(e) => {
+    $scale = 2
+  }}
+  on:pointerup={(e) => {
+    $scale = 1
+  }}
+  scale={$scale}
 >
   <T.BoxGeometry />
-  <T.MeshStandardMaterial color="red" />
-
-  <T.Mesh
-    on:pointerover={(e) => {
-      console.log('over green!!!')
-    }}
-    position.x={1}
-  >
-    <T.BoxGeometry />
-    <T.MeshStandardMaterial color="green" />
-  </T.Mesh>
+  <T.MeshStandardMaterial {color} />
 </T.Mesh>

--- a/apps/docs-next/src/examples/test/Scene.svelte
+++ b/apps/docs-next/src/examples/test/Scene.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
-  import { T } from '@threlte/core'
+  import { T, useThrelte } from '@threlte/core'
   import { Grid, interactivity } from '@threlte/extras'
   import { spring } from 'svelte/motion'
 
-  interactivity()
+  const { camera } = useThrelte()
+
+  const { connect } = interactivity({
+    compute: (event, state) => {
+      state.pointer.set(
+        (event.offsetX / (state.target?.clientWidth ?? 0)) * 2 - 1,
+        -(event.offsetY / (state.target?.clientHeight ?? 0)) * 2 + 1
+      )
+      state.raycaster.setFromCamera(state.pointer, $camera)
+    }
+  })
+
+  connect(document.querySelector('#int-target')!)
 
   let color = 'blue'
 

--- a/apps/docs-next/src/examples/test/Scene.svelte
+++ b/apps/docs-next/src/examples/test/Scene.svelte
@@ -1,21 +1,11 @@
 <script lang="ts">
-  import { T, useThrelte } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { Grid, interactivity } from '@threlte/extras'
   import { spring } from 'svelte/motion'
 
-  const { camera } = useThrelte()
+  const { target } = interactivity()
 
-  const { connect } = interactivity({
-    compute: (event, state) => {
-      state.pointer.set(
-        (event.offsetX / (state.target?.clientWidth ?? 0)) * 2 - 1,
-        -(event.offsetY / (state.target?.clientHeight ?? 0)) * 2 + 1
-      )
-      state.raycaster.setFromCamera(state.pointer, $camera)
-    }
-  })
-
-  connect(document.querySelector('#int-target')!)
+  target.set(document.getElementById('int-target') ?? undefined)
 
   let color = 'blue'
 

--- a/apps/docs-next/src/examples/test/Scene.svelte
+++ b/apps/docs-next/src/examples/test/Scene.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { T } from '@threlte/core'
-  import { EventMap, interactivity } from '@threlte/extras'
+  import { Grid, interactivity } from '@threlte/extras'
   import { spring } from 'svelte/motion'
 
   interactivity()
@@ -23,9 +23,11 @@
 
 <T.Mesh
   on:pointerenter={(e) => {
+    e.stopPropagation()
     color = 'red'
   }}
   on:pointerleave={(e) => {
+    $scale = 1
     color = 'blue'
   }}
   on:pointerdown={(e) => {
@@ -38,4 +40,11 @@
 >
   <T.BoxGeometry />
   <T.MeshStandardMaterial {color} />
+
+  <T.Mesh position.x={2}>
+    <T.BoxGeometry />
+    <T.MeshStandardMaterial />
+  </T.Mesh>
 </T.Mesh>
+
+<Grid />

--- a/apps/docs-next/src/examples/test/Scene.svelte
+++ b/apps/docs-next/src/examples/test/Scene.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+  import { interactivity } from '@threlte/extras'
+
+  interactivity()
+</script>
+
+<T.OrthographicCamera
+  zoom={80}
+  position={[5, 5, 5]}
+  makeDefault
+  on:create={({ ref }) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[1, 2, 5]} />
+
+<T.Mesh
+  on:pointerover={(e) => {
+    console.log('over red!!!')
+  }}
+>
+  <T.BoxGeometry />
+  <T.MeshStandardMaterial color="red" />
+
+  <T.Mesh
+    on:pointerover={(e) => {
+      console.log('over green!!!')
+    }}
+    position.x={1}
+  >
+    <T.BoxGeometry />
+    <T.MeshStandardMaterial color="green" />
+  </T.Mesh>
+</T.Mesh>

--- a/apps/docs-next/src/pages/test.astro
+++ b/apps/docs-next/src/pages/test.astro
@@ -1,0 +1,8 @@
+---
+import Example from '$components/Example/Example.astro'
+import MainLayout from '$layouts/MainLayout.astro'
+---
+
+<MainLayout>
+  <Example path="test" />
+</MainLayout>

--- a/packages/core/src/lib/lib/createRawEventDispatcher.ts
+++ b/packages/core/src/lib/lib/createRawEventDispatcher.ts
@@ -7,12 +7,14 @@ import { get_current_component } from 'svelte/internal'
  * @returns
  */
 
-export function createRawEventDispatcher<EventMap extends Record<string, unknown> = any>(): <
+export function createRawEventDispatcher<EventMap extends Record<string, unknown> = any>(): (<
   EventKey extends Extract<keyof EventMap, string>
 >(
   type: EventKey,
   value?: EventMap[EventKey]
-) => void {
+) => void) & {
+  hasEventListener: <EventKey extends Extract<keyof EventMap, string>>(type: EventKey) => boolean
+} {
   const component = get_current_component()
 
   const dispatchRawEvent = (type: string, value: any) => {
@@ -24,5 +26,11 @@ export function createRawEventDispatcher<EventMap extends Record<string, unknown
     }
   }
 
-  return dispatchRawEvent
+  const hasEventListener = <EventKey extends Extract<keyof EventMap, string>>(type: EventKey) => {
+    return Boolean(component.$$.callbacks[type])
+  }
+
+  dispatchRawEvent.hasEventListener = hasEventListener
+
+  return dispatchRawEvent as ReturnType<typeof createRawEventDispatcher>
 }

--- a/packages/core/src/lib/three/types.ts
+++ b/packages/core/src/lib/three/types.ts
@@ -119,4 +119,4 @@ type CreateEvent<Type extends any> = {
   }
 }
 
-export type Events<Type extends any> = Record<string, unknown> & CreateEvent<Type>
+export type Events<Type extends any> = Record<string, any> & CreateEvent<Type>

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -30,6 +30,12 @@ export { useThrelteAudio } from './audio/useThrelteAudio'
 export type { GLTFProperties } from './types/components'
 
 // plugins
-export { interactivity } from './plugins/interactivity'
+export {
+  interactivity,
+  type DomEvent,
+  type EventMap,
+  type Intersection,
+  type IntersectionEvent
+} from './plugins/interactivity'
 
 export type { ThrelteGltf } from './types/types'

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -32,6 +32,7 @@ export type { GLTFProperties } from './types/components'
 // plugins
 export {
   interactivity,
+  useInteractivity,
   type DomEvent,
   type EventMap,
   type Intersection,

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -29,4 +29,7 @@ export { useThrelteAudio } from './audio/useThrelteAudio'
 
 export type { GLTFProperties } from './types/components'
 
+// plugins
+export { interactivity } from './plugins/interactivity'
+
 export type { ThrelteGltf } from './types/types'

--- a/packages/extras/src/lib/lib/storeUtils.ts
+++ b/packages/extras/src/lib/lib/storeUtils.ts
@@ -36,3 +36,29 @@ export const watch = <S extends Stores>(
     if (cleanupFn) cleanupFn()
   })
 }
+
+/**
+ * Use a single store or multiple stores and return the value(s) as an object.
+ * This is useful for using stores in a non-reactive way e.g. in loops.
+ * @param stores
+ * @param transform
+ */
+export function memoize<U, S extends Stores>(stores: S): { current: StoresValues<S> }
+export function memoize<U, S extends Stores>(
+  stores: S,
+  transform: (values: StoresValues<S>) => U
+): { current: U }
+export function memoize<U, S extends Stores>(
+  stores: S,
+  transform?: (values: StoresValues<S>) => U
+): { current: U | StoresValues<S> } {
+  const obj = {
+    current: undefined
+  } as any
+
+  watch(stores, (v) => {
+    obj.current = transform ? transform(v) : v
+  })
+
+  return obj
+}

--- a/packages/extras/src/lib/lib/watch.ts
+++ b/packages/extras/src/lib/lib/watch.ts
@@ -1,0 +1,38 @@
+import { onDestroy } from 'svelte'
+import { derived, type Readable } from 'svelte/store'
+
+type Stores = Readable<any> | [Readable<any>, ...Array<Readable<any>>] | Array<Readable<any>>
+
+type StoresValues<T> = T extends Readable<infer U>
+  ? U
+  : {
+      [K in keyof T]: T[K] extends Readable<infer U> ? U : never
+    }
+
+/**
+ * Watch a single store or multiple stores and call a callback when they change.
+ * The callback can return a cleanup function that will be called when the stores change again.
+ * @param stores
+ * @param callback
+ */
+export const watch = <S extends Stores>(
+  stores: S,
+  callback: (values: StoresValues<S>) => (() => void) | void
+): void => {
+  const d = derived(stores, (values) => {
+    return values
+  })
+
+  let cleanupFn: () => void
+
+  const unsubscribe = d.subscribe((values) => {
+    if (cleanupFn) cleanupFn()
+    const fn = callback(values)
+    if (fn) cleanupFn = fn
+  })
+
+  onDestroy(() => {
+    unsubscribe()
+    if (cleanupFn) cleanupFn()
+  })
+}

--- a/packages/extras/src/lib/plugins/interactivity/defaults.ts
+++ b/packages/extras/src/lib/plugins/interactivity/defaults.ts
@@ -1,15 +1,9 @@
 import { useThrelte } from '@threlte/core'
-import type { Camera } from 'three'
-import { watch } from '../../lib/watch'
+import { memoize, watch } from '../../lib/storeUtils'
 import type { ComputeFunction, State } from './types'
 
 export const getDefaultComputeFunction = (state: State): ComputeFunction => {
-  const { camera: cameraStore } = useThrelte()
-
-  let camera: Camera
-  watch(cameraStore, (value) => {
-    camera = value
-  })
+  const camera = memoize(useThrelte().camera)
 
   let width = 0
   let height = 0
@@ -30,6 +24,6 @@ export const getDefaultComputeFunction = (state: State): ComputeFunction => {
 
   return (event, state) => {
     state.pointer.set((event.offsetX / width) * 2 - 1, -(event.offsetY / height) * 2 + 1)
-    state.raycaster.setFromCamera(state.pointer, camera)
+    state.raycaster.setFromCamera(state.pointer, camera.current)
   }
 }

--- a/packages/extras/src/lib/plugins/interactivity/defaults.ts
+++ b/packages/extras/src/lib/plugins/interactivity/defaults.ts
@@ -1,19 +1,35 @@
 import { useThrelte } from '@threlte/core'
-import { onDestroy } from 'svelte'
-import { get } from 'svelte/store'
-import type { ComputeFunction } from './types'
+import type { Camera } from 'three'
+import { watch } from '../../lib/watch'
+import type { ComputeFunction, State } from './types'
 
-export const getDefaultComputeFunction: () => ComputeFunction = () => {
-  const { camera: cameraStore, size: SizeStore } = useThrelte()
+export const getDefaultComputeFunction = (state: State): ComputeFunction => {
+  const { camera: cameraStore } = useThrelte()
 
-  let camera = get(cameraStore)
-  onDestroy(cameraStore.subscribe((value) => (camera = value)))
+  let camera: Camera
+  watch(cameraStore, (value) => {
+    camera = value
+  })
 
-  let size = get(SizeStore)
-  onDestroy(SizeStore.subscribe((value) => (size = value)))
+  let width = 0
+  let height = 0
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      width = entry.contentRect.width
+      height = entry.contentRect.height
+    }
+  })
+
+  watch(state.target, (target) => {
+    if (target) resizeObserver.observe(target)
+    return () => {
+      if (target) resizeObserver.unobserve(target)
+    }
+  })
 
   return (event, state) => {
-    state.pointer.set((event.offsetX / size.width) * 2 - 1, -(event.offsetY / size.height) * 2 + 1)
+    state.pointer.set((event.offsetX / width) * 2 - 1, -(event.offsetY / height) * 2 + 1)
     state.raycaster.setFromCamera(state.pointer, camera)
   }
 }

--- a/packages/extras/src/lib/plugins/interactivity/defaults.ts
+++ b/packages/extras/src/lib/plugins/interactivity/defaults.ts
@@ -1,0 +1,19 @@
+import { useThrelte } from '@threlte/core'
+import { onDestroy } from 'svelte'
+import { get } from 'svelte/store'
+import type { ComputeFunction } from './types'
+
+export const getDefaultComputeFunction: () => ComputeFunction = () => {
+  const { camera: cameraStore, size: SizeStore } = useThrelte()
+
+  let camera = get(cameraStore)
+  onDestroy(cameraStore.subscribe((value) => (camera = value)))
+
+  let size = get(SizeStore)
+  onDestroy(SizeStore.subscribe((value) => (size = value)))
+
+  return (event, state) => {
+    state.pointer.set((event.offsetX / size.width) * 2 - 1, -(event.offsetY / size.height) * 2 + 1)
+    state.raycaster.setFromCamera(state.pointer, camera)
+  }
+}

--- a/packages/extras/src/lib/plugins/interactivity/hook.ts
+++ b/packages/extras/src/lib/plugins/interactivity/hook.ts
@@ -1,0 +1,26 @@
+import { createRawEventDispatcher } from '@threlte/core'
+import { getContext } from 'svelte'
+import type { Object3D } from 'three'
+import type { State } from './types'
+
+export const useInteractivity = () => {
+  const state = getContext<State>('threlte-interactivity-context')
+  if (!state) throw new Error('useInteractivity must be used within a <Interactivity> component')
+
+  const eventDispatcher = createRawEventDispatcher()
+
+  const addInteractiveObject = (object: Object3D) => {
+    object.userData._threlte_interactivity_dispatcher = eventDispatcher
+    state.interactiveObjects.push(object)
+  }
+
+  const removeInteractiveObject = (object: Object3D) => {
+    state.interactiveObjects = state.interactiveObjects.filter((obj) => obj.uuid !== object.uuid)
+    delete object.userData._threlte_interactivity_dispatcher
+  }
+
+  return {
+    addInteractiveObject,
+    removeInteractiveObject
+  }
+}

--- a/packages/extras/src/lib/plugins/interactivity/index.ts
+++ b/packages/extras/src/lib/plugins/interactivity/index.ts
@@ -9,12 +9,12 @@ import type { InteractivityOptions, State } from './types'
 
 const interactivity = (options?: InteractivityOptions) => {
   const state: State = {
-    enabled: options?.enabled ?? true,
+    enabled: writable(options?.enabled ?? true),
     pointer: new Vector2(),
     lastEvent: undefined,
     raycaster: new Raycaster(),
     initialClick: [0, 0],
-    lastPointerDownHits: [],
+    initialHits: [],
     hovered: new Map(),
     interactiveObjects: [],
     target: writable(options?.target ?? useThrelte().renderer?.domElement),

--- a/packages/extras/src/lib/plugins/interactivity/index.ts
+++ b/packages/extras/src/lib/plugins/interactivity/index.ts
@@ -1,0 +1,10 @@
+import type { Object3D } from 'three'
+import { setupInteractivity } from './setupInteractivity'
+import { injectInteractivityPlugin } from './plugin'
+
+export const interactivity = () => {
+  const interactiveObjects = new Set<Object3D>()
+
+  injectInteractivityPlugin(interactiveObjects)
+  setupInteractivity(interactiveObjects)
+}

--- a/packages/extras/src/lib/plugins/interactivity/index.ts
+++ b/packages/extras/src/lib/plugins/interactivity/index.ts
@@ -1,12 +1,36 @@
-import type { Object3D } from 'three'
-import { setupInteractivity } from './setupInteractivity'
+import { setContext } from 'svelte'
+import { Raycaster, Vector2 } from 'three'
 import { injectInteractivityPlugin } from './plugin'
+import { setupInteractivity } from './setupInteractivity'
+import type { InteractivityOptions, State } from './types'
 
-export const interactivity = () => {
-  const interactiveObjects = new Set<Object3D>()
+const interactivity = (options?: InteractivityOptions) => {
+  const state: State = {
+    enabled: options?.enabled ?? true,
+    pointer: new Vector2(),
+    lastEvent: undefined,
+    raycaster: new Raycaster(),
+    initialClick: [0, 0],
+    lastPointerDownHits: [],
+    hovered: new Map(),
+    interactiveObjects: [],
+    target: undefined,
+    compute: options?.compute
+  }
 
-  injectInteractivityPlugin(interactiveObjects)
-  setupInteractivity(interactiveObjects)
+  setContext<State>('threlte-interactivity-context', state)
+
+  injectInteractivityPlugin(state)
+
+  const { connect, disconnect } = setupInteractivity(state)
+
+  return {
+    connect,
+    disconnect
+  }
 }
 
-export type { EventMap, Intersection, IntersectionEvent, DomEvent } from './types'
+// exports
+export { useInteractivity } from './hook'
+export type { DomEvent, EventMap, Intersection, IntersectionEvent } from './types'
+export { interactivity }

--- a/packages/extras/src/lib/plugins/interactivity/index.ts
+++ b/packages/extras/src/lib/plugins/interactivity/index.ts
@@ -1,8 +1,10 @@
-import { setContext } from 'svelte'
+import { useThrelte } from '@threlte/core'
+import { onDestroy, setContext } from 'svelte'
 import { Raycaster, Vector2 } from 'three'
+import { getDefaultComputeFunction } from './defaults'
 import { injectInteractivityPlugin } from './plugin'
 import { setupInteractivity } from './setupInteractivity'
-import type { InteractivityOptions, State } from './types'
+import type { ComputeFunction, InteractivityOptions, State } from './types'
 
 const interactivity = (options?: InteractivityOptions) => {
   const state: State = {
@@ -15,7 +17,7 @@ const interactivity = (options?: InteractivityOptions) => {
     hovered: new Map(),
     interactiveObjects: [],
     target: undefined,
-    compute: options?.compute
+    compute: options?.compute ?? getDefaultComputeFunction()
   }
 
   setContext<State>('threlte-interactivity-context', state)
@@ -32,5 +34,5 @@ const interactivity = (options?: InteractivityOptions) => {
 
 // exports
 export { useInteractivity } from './hook'
-export type { DomEvent, EventMap, Intersection, IntersectionEvent } from './types'
+export type { DomEvent, ThrelteEvents as EventMap, Intersection, IntersectionEvent } from './types'
 export { interactivity }

--- a/packages/extras/src/lib/plugins/interactivity/index.ts
+++ b/packages/extras/src/lib/plugins/interactivity/index.ts
@@ -8,3 +8,5 @@ export const interactivity = () => {
   injectInteractivityPlugin(interactiveObjects)
   setupInteractivity(interactiveObjects)
 }
+
+export type { EventMap, Intersection, IntersectionEvent, DomEvent } from './types'

--- a/packages/extras/src/lib/plugins/interactivity/plugin.ts
+++ b/packages/extras/src/lib/plugins/interactivity/plugin.ts
@@ -1,10 +1,10 @@
 import { injectPlugin } from '@threlte/core'
 import { Object3D } from 'three'
 import { useInteractivity } from './hook'
-import type { EventMap, State } from './types'
+import type { ThrelteEvents, State } from './types'
 import { useComponentEvents } from './useComponentEvents'
 
-export const interactivityEventNames: (keyof EventMap)[] = [
+export const interactivityEventNames: (keyof ThrelteEvents)[] = [
   'click',
   'contextmenu',
   'dblclick',

--- a/packages/extras/src/lib/plugins/interactivity/plugin.ts
+++ b/packages/extras/src/lib/plugins/interactivity/plugin.ts
@@ -1,0 +1,75 @@
+import { createRawEventDispatcher, injectPlugin } from '@threlte/core'
+import { onDestroy } from 'svelte'
+import { writable } from 'svelte/store'
+import { Object3D } from 'three'
+import { useComponentEvents } from './useComponentEvents'
+
+export const eventNames = [
+  'click',
+  'contextmenu',
+  'doubleclick',
+  'wheel',
+  'pointerup',
+  'pointerdown',
+  'pointerover',
+  'pointerout',
+  'pointerenter',
+  'pointerleave',
+  'pointermove',
+  'pointermissed'
+]
+
+export const injectInteractivityPlugin = (interactiveObjects: Set<Object3D>) => {
+  injectPlugin('interactivity', ({ ref }) => {
+    if (!(ref instanceof Object3D)) return
+
+    let currentRef = ref
+
+    let isListeningToEvents = false
+    const isListeningToEventsStore = writable(false)
+
+    const { eventNames: componentEventNames } = useComponentEvents()
+
+    onDestroy(
+      componentEventNames.subscribe((componentEventNames) => {
+        isListeningToEventsStore.set(
+          componentEventNames.filter((value) => eventNames.includes(value)).length > 0
+        )
+      })
+    )
+
+    onDestroy(
+      isListeningToEventsStore.subscribe((isListening) => {
+        isListeningToEvents = isListening
+        if (isListening) {
+          interactiveObjects.add(currentRef)
+        }
+      })
+    )
+
+    const setupEventDispatcher = (ref: Object3D) => {
+      ref.userData._threlte_interactivity_dispatcher = createRawEventDispatcher()
+    }
+
+    const deleteEventDispatcher = (ref: Object3D) => {
+      delete ref.userData._threlte_interactivity_dispatcher
+    }
+
+    setupEventDispatcher(currentRef)
+
+    return {
+      onRefChange(ref: Object3D) {
+        if (!isListeningToEvents) return
+        if (ref.uuid !== currentRef.uuid) return
+
+        currentRef = ref
+
+        deleteEventDispatcher(currentRef)
+        interactiveObjects.delete(currentRef)
+
+        setupEventDispatcher(ref)
+        interactiveObjects.add(ref)
+      }
+    }
+  })
+}

--- a/packages/extras/src/lib/plugins/interactivity/setupInteractivity.ts
+++ b/packages/extras/src/lib/plugins/interactivity/setupInteractivity.ts
@@ -2,31 +2,29 @@ import { createRawEventDispatcher, useThrelte } from '@threlte/core'
 import { onDestroy } from 'svelte'
 import { get } from 'svelte/store'
 import type * as THREE from 'three'
-
-export type DomEvent = PointerEvent | MouseEvent | WheelEvent
-
-export interface Intersection extends THREE.Intersection {
-  /** The event source (the object which registered the handler) */
-  eventObject: THREE.Object3D
-}
+import { Raycaster, Vector2 } from 'three'
+import type { DomEvent, EventMap, Intersection, IntersectionEvent, State } from './types'
 
 const getRawEventDispatcher = (object: THREE.Object3D) => {
   return object.userData._threlte_interactivity_dispatcher as
-    | ReturnType<typeof createRawEventDispatcher>
+    | ReturnType<typeof createRawEventDispatcher<EventMap>>
     | undefined
+}
+
+function getIntersectionId(event: Intersection) {
+  return (event.eventObject || event.object).uuid + '/' + event.index + event.instanceId
 }
 
 const DOM_EVENTS = [
   ['click', false],
   ['contextmenu', false],
   ['dblclick', false],
-  ['wheel', true],
+  ['wheel', false],
   ['pointerdown', true],
   ['pointerup', true],
   ['pointerleave', true],
   ['pointermove', true],
-  ['pointercancel', true],
-  ['lostpointercapture', true]
+  ['pointercancel', true]
 ] as const
 
 type DomEventName = typeof DOM_EVENTS[number][0]
@@ -44,11 +42,92 @@ export const setupInteractivity = (interactiveObjects: Set<THREE.Object3D>) => {
     throw new Error('No renderer found. Make sure to call interactivity in a child of <Canvas>.')
   }
 
+  const state: State = {
+    pointer: new Vector2(),
+    lastEvent: undefined,
+    raycaster: new Raycaster(),
+    initialClick: [0, 0],
+    lastPointerDownHits: [],
+    hovered: new Map()
+  }
+
+  function calculateDistance(event: DomEvent) {
+    const dx = event.offsetX - state.initialClick[0]
+    const dy = event.offsetY - state.initialClick[1]
+    return Math.round(Math.sqrt(dx * dx + dy * dy))
+  }
+
   const target = renderer.domElement
 
   function cancelPointer(intersections: Intersection[]) {
-    // cancel pointer
-    console.log('cancel pointer')
+    for (const hoveredObj of state.hovered.values()) {
+      // When no objects were hit or the the hovered object wasn't found underneath the cursor
+      // we call onPointerOut and delete the object from the hovered-elements map
+      if (
+        !intersections.length ||
+        !intersections.find(
+          (hit) =>
+            hit.object === hoveredObj.object &&
+            hit.index === hoveredObj.index &&
+            hit.instanceId === hoveredObj.instanceId
+        )
+      ) {
+        const eventObject = hoveredObj.eventObject
+        state.hovered.delete(getIntersectionId(hoveredObj))
+        const eventDispatcher = getRawEventDispatcher(eventObject)
+        if (eventDispatcher) {
+          // Clear out intersects, they are outdated by now
+          const data = { ...hoveredObj, intersections }
+          eventDispatcher('pointerout', data as IntersectionEvent<PointerEvent>)
+          eventDispatcher('pointerleave', data as IntersectionEvent<PointerEvent>)
+        }
+      }
+    }
+  }
+
+  const setPointer = (event: DomEvent) => {
+    state.pointer.set((event.offsetX / size.width) * 2 - 1, -(event.offsetY / size.height) * 2 + 1)
+  }
+
+  const getHits = (event: DomEvent): Intersection[] => {
+    const duplicates = new Set<string>()
+
+    const intersections: Intersection[] = []
+
+    // setup raycaster
+    state.raycaster.setFromCamera(state.pointer, camera)
+
+    const hits = [...interactiveObjects]
+      .flatMap((obj) => state.raycaster.intersectObject(obj, true))
+      // Sort by distance
+      .sort((a, b) => a.distance - b.distance)
+      // Filter out duplicates
+      .filter((item) => {
+        const id = getIntersectionId(item as Intersection)
+        if (duplicates.has(id)) return false
+        duplicates.add(id)
+        return true
+      })
+
+    // Bubble up the events, find the event source (eventObject)
+    for (const hit of hits) {
+      let eventObject: THREE.Object3D | null = hit.object
+      // Bubble event up
+      while (eventObject) {
+        if (getRawEventDispatcher(eventObject)) intersections.push({ ...hit, eventObject })
+        eventObject = eventObject.parent
+      }
+    }
+
+    return intersections
+  }
+
+  function pointerMissed(event: MouseEvent, objects: THREE.Object3D[]) {
+    for (let i = 0; i < objects.length; i++) {
+      const eventDispatcher = getRawEventDispatcher(objects[i])
+      if (!eventDispatcher) continue
+      eventDispatcher('pointermissed', event)
+    }
   }
 
   const getEventHandler = (name: DomEventName): ((event: DomEvent) => void) => {
@@ -60,13 +139,116 @@ export const setupInteractivity = (interactiveObjects: Set<THREE.Object3D>) => {
     return (event: DomEvent) => {
       const isPointerMove = name === 'pointermove'
       const isClickEvent = name === 'click' || name === 'contextmenu' || name === 'dblclick'
-      // do stuff
-      console.log('do pointer stuff')
-    }
-  }
 
-  const setPointer = (event: DomEvent) => {
-    // pointer.set((event.offsetX / size.width) * 2 - 1, -(event.offsetY / size.height) * 2 + 1)
+      setPointer(event)
+
+      const hits = getHits(event)
+      const delta = isClickEvent ? calculateDistance(event) : 0
+
+      // Save initial coordinates on pointer-down
+      if (name === 'pointerdown') {
+        state.initialClick = [event.offsetX, event.offsetY]
+        state.lastPointerDownHits = hits.map((hit) => hit.eventObject)
+      }
+
+      // If a click yields no results, pass it back to the user as a miss
+      // Missed events have to come first in order to establish user-land side-effect clean up
+      if (isClickEvent && !hits.length) {
+        if (delta <= 2) {
+          pointerMissed(event, [...interactiveObjects])
+        }
+      }
+
+      // Take care of unhover
+      if (isPointerMove) cancelPointer(hits)
+
+      let stopped = false
+
+      eventloop: for (const hit of hits) {
+        const intersectionEvent: IntersectionEvent<DomEvent> = {
+          stopped,
+          ...hit,
+          intersections: hits,
+          stopPropagation() {
+            stopped = true
+            intersectionEvent.stopped = true
+            if (
+              state.hovered.size &&
+              Array.from(state.hovered.values()).find((i) => i.eventObject === hit.eventObject)
+            ) {
+              // Objects cannot flush out higher up objects that have already caught the event
+              const higher = hits.slice(0, hits.indexOf(hit))
+              cancelPointer([...higher, hit])
+            }
+          },
+          camera,
+          delta,
+          nativeEvent: event,
+          pointer: state.pointer,
+          ray: state.raycaster.ray
+        }
+
+        const eventDispatcher = getRawEventDispatcher(hit.eventObject)
+        if (!eventDispatcher) return
+
+        if (isPointerMove) {
+          // Move event ...
+
+          if (
+            eventDispatcher.hasEventListener('pointerover') ||
+            eventDispatcher.hasEventListener('pointerenter') ||
+            eventDispatcher.hasEventListener('pointerout') ||
+            eventDispatcher.hasEventListener('pointerleave')
+          ) {
+            const id = getIntersectionId(intersectionEvent)
+            const hoveredItem = state.hovered.get(id)
+            if (!hoveredItem) {
+              // If the object wasn't previously hovered, book it and call its handler
+              state.hovered.set(id, intersectionEvent)
+              eventDispatcher('pointerover', intersectionEvent as IntersectionEvent<PointerEvent>)
+              eventDispatcher('pointerenter', intersectionEvent as IntersectionEvent<PointerEvent>)
+            } else if (hoveredItem.stopped) {
+              // If the object was previously hovered and stopped, we shouldn't allow other items to proceed
+              intersectionEvent.stopPropagation()
+            }
+          }
+
+          // Call pointer move
+          eventDispatcher('pointermove', intersectionEvent as IntersectionEvent<PointerEvent>)
+        } else {
+          // All other events
+
+          const hasEventListener = eventDispatcher.hasEventListener(name)
+
+          if (hasEventListener) {
+            if (!isClickEvent || state.lastPointerDownHits.includes(hit.eventObject)) {
+              // Missed events have to come first
+              pointerMissed(
+                event,
+                [...interactiveObjects].filter(
+                  (object) => !state.lastPointerDownHits.includes(object)
+                )
+              )
+
+              // Call the event
+              eventDispatcher(name, intersectionEvent)
+            }
+          } else {
+            // "Real" click event
+            if (isClickEvent && state.lastPointerDownHits.includes(hit.eventObject)) {
+              pointerMissed(
+                event,
+                [...interactiveObjects].filter(
+                  (object) => !state.lastPointerDownHits.includes(object)
+                )
+              )
+            }
+          }
+        }
+
+        if (stopped) break eventloop
+      }
+    }
   }
 
   DOM_EVENTS.forEach(([eventName, passive]) => {

--- a/packages/extras/src/lib/plugins/interactivity/setupInteractivity.ts
+++ b/packages/extras/src/lib/plugins/interactivity/setupInteractivity.ts
@@ -1,0 +1,81 @@
+import { createRawEventDispatcher, useThrelte } from '@threlte/core'
+import { onDestroy } from 'svelte'
+import { get } from 'svelte/store'
+import type * as THREE from 'three'
+
+export type DomEvent = PointerEvent | MouseEvent | WheelEvent
+
+export interface Intersection extends THREE.Intersection {
+  /** The event source (the object which registered the handler) */
+  eventObject: THREE.Object3D
+}
+
+const getRawEventDispatcher = (object: THREE.Object3D) => {
+  return object.userData._threlte_interactivity_dispatcher as
+    | ReturnType<typeof createRawEventDispatcher>
+    | undefined
+}
+
+const DOM_EVENTS = [
+  ['click', false],
+  ['contextmenu', false],
+  ['dblclick', false],
+  ['wheel', true],
+  ['pointerdown', true],
+  ['pointerup', true],
+  ['pointerleave', true],
+  ['pointermove', true],
+  ['pointercancel', true],
+  ['lostpointercapture', true]
+] as const
+
+type DomEventName = typeof DOM_EVENTS[number][0]
+
+export const setupInteractivity = (interactiveObjects: Set<THREE.Object3D>) => {
+  const { camera: cameraStore, renderer, size: SizeStore } = useThrelte()
+
+  let camera = get(cameraStore)
+  onDestroy(cameraStore.subscribe((value) => (camera = value)))
+
+  let size = get(SizeStore)
+  onDestroy(SizeStore.subscribe((value) => (size = value)))
+
+  if (!renderer) {
+    throw new Error('No renderer found. Make sure to call interactivity in a child of <Canvas>.')
+  }
+
+  const target = renderer.domElement
+
+  function cancelPointer(intersections: Intersection[]) {
+    // cancel pointer
+    console.log('cancel pointer')
+  }
+
+  const getEventHandler = (name: DomEventName): ((event: DomEvent) => void) => {
+    // Deal with cancelation
+    if (name === 'pointerleave' || name === 'pointercancel') {
+      return () => cancelPointer([])
+    }
+
+    return (event: DomEvent) => {
+      const isPointerMove = name === 'pointermove'
+      const isClickEvent = name === 'click' || name === 'contextmenu' || name === 'dblclick'
+      // do stuff
+      console.log('do pointer stuff')
+    }
+  }
+
+  const setPointer = (event: DomEvent) => {
+    // pointer.set((event.offsetX / size.width) * 2 - 1, -(event.offsetY / size.height) * 2 + 1)
+  }
+
+  DOM_EVENTS.forEach(([eventName, passive]) => {
+    target.addEventListener(eventName, getEventHandler(eventName), { passive })
+  })
+
+  onDestroy(() => {
+    DOM_EVENTS.forEach(([eventName]) => {
+      target.removeEventListener(eventName, getEventHandler(eventName))
+    })
+  })
+}

--- a/packages/extras/src/lib/plugins/interactivity/types.ts
+++ b/packages/extras/src/lib/plugins/interactivity/types.ts
@@ -47,13 +47,13 @@ export interface PointerCaptureTarget {
 export type ComputeFunction = (event: DomEvent, state: State) => void
 
 export type State = {
-  enabled: boolean
+  enabled: Writable<boolean>
   target: Writable<HTMLElement | undefined>
   pointer: Vector2
   lastEvent: DomEvent | undefined
   raycaster: Raycaster
   initialClick: [x: number, y: number]
-  lastPointerDownHits: THREE.Object3D[]
+  initialHits: THREE.Object3D[]
   hovered: Map<string, IntersectionEvent<DomEvent>>
   interactiveObjects: THREE.Object3D[]
   compute: ComputeFunction

--- a/packages/extras/src/lib/plugins/interactivity/types.ts
+++ b/packages/extras/src/lib/plugins/interactivity/types.ts
@@ -45,7 +45,7 @@ export interface PointerCaptureTarget {
  * It needs to set up the raycaster and the pointer vector. If no compute function is provided,
  * the plugin will use the default compute function.
  */
-export type ComputeFunction = (event: DomEvent, state: State, context: ThrelteContext) => void
+export type ComputeFunction = (event: DomEvent, state: State) => void
 
 export type State = {
   enabled: boolean
@@ -57,10 +57,10 @@ export type State = {
   lastPointerDownHits: THREE.Object3D[]
   hovered: Map<string, IntersectionEvent<DomEvent>>
   interactiveObjects: THREE.Object3D[]
-  compute: ComputeFunction | undefined
+  compute: ComputeFunction
 }
 
-export type EventMap = {
+export type ThrelteEvents = {
   click: IntersectionEvent<MouseEvent>
   contextmenu: IntersectionEvent<MouseEvent>
   dblclick: IntersectionEvent<MouseEvent>

--- a/packages/extras/src/lib/plugins/interactivity/types.ts
+++ b/packages/extras/src/lib/plugins/interactivity/types.ts
@@ -1,0 +1,63 @@
+import type { Camera, Raycaster, Vector2 } from 'three'
+
+export type DomEvent = PointerEvent | MouseEvent | WheelEvent
+
+export interface Intersection extends THREE.Intersection {
+  /** The event source (the object which registered the handler) */
+  eventObject: THREE.Object3D
+}
+
+export interface IntersectionEvent<NativeEvent> extends Intersection {
+  /** The event source (the object which registered the handler) */
+  eventObject: THREE.Object3D
+  /** An array of intersections */
+  intersections: Intersection[]
+  /** Normalized event coordinates */
+  pointer: THREE.Vector2
+  /** Delta between first click and this event */
+  delta: number
+  /** The ray that pierced it */
+  ray: THREE.Ray
+  /** The camera that was used by the raycaster */
+  camera: Camera
+  /** stopPropagation will stop underlying handlers from firing */
+  stopPropagation: () => void
+  /** The original host event */
+  nativeEvent: NativeEvent
+  /** If the event was stopped by calling stopPropagation */
+  stopped: boolean
+}
+
+export type Properties<T> = Pick<
+  T,
+  { [K in keyof T]: T[K] extends (_: any) => any ? never : K }[keyof T]
+>
+
+export interface PointerCaptureTarget {
+  intersection: Intersection
+  target: Element
+}
+
+export type State = {
+  pointer: Vector2
+  lastEvent: DomEvent | undefined
+  raycaster: Raycaster
+  initialClick: [x: number, y: number]
+  lastPointerDownHits: THREE.Object3D[]
+  hovered: Map<string, IntersectionEvent<DomEvent>>
+}
+
+export type EventMap = {
+  click: IntersectionEvent<MouseEvent>
+  contextmenu: IntersectionEvent<MouseEvent>
+  dblclick: IntersectionEvent<MouseEvent>
+  wheel: IntersectionEvent<WheelEvent>
+  pointerup: IntersectionEvent<PointerEvent>
+  pointerdown: IntersectionEvent<PointerEvent>
+  pointerover: IntersectionEvent<PointerEvent>
+  pointerout: IntersectionEvent<PointerEvent>
+  pointerenter: IntersectionEvent<PointerEvent>
+  pointerleave: IntersectionEvent<PointerEvent>
+  pointermove: IntersectionEvent<PointerEvent>
+  pointermissed: MouseEvent
+}

--- a/packages/extras/src/lib/plugins/interactivity/types.ts
+++ b/packages/extras/src/lib/plugins/interactivity/types.ts
@@ -1,4 +1,3 @@
-import type { ThrelteContext } from '@threlte/core'
 import type { Writable } from 'svelte/store'
 import type { Camera, Raycaster, Vector2 } from 'three'
 
@@ -49,7 +48,7 @@ export type ComputeFunction = (event: DomEvent, state: State) => void
 
 export type State = {
   enabled: boolean
-  target: HTMLElement | undefined
+  target: Writable<HTMLElement | undefined>
   pointer: Vector2
   lastEvent: DomEvent | undefined
   raycaster: Raycaster
@@ -78,4 +77,5 @@ export type ThrelteEvents = {
 export type InteractivityOptions = {
   enabled?: boolean
   compute?: ComputeFunction
+  target?: HTMLElement
 }

--- a/packages/extras/src/lib/plugins/interactivity/types.ts
+++ b/packages/extras/src/lib/plugins/interactivity/types.ts
@@ -1,3 +1,5 @@
+import type { ThrelteContext } from '@threlte/core'
+import type { Writable } from 'svelte/store'
 import type { Camera, Raycaster, Vector2 } from 'three'
 
 export type DomEvent = PointerEvent | MouseEvent | WheelEvent
@@ -38,13 +40,24 @@ export interface PointerCaptureTarget {
   target: Element
 }
 
+/**
+ * The compute function is responsible for updating the state of the interactivity plugin.
+ * It needs to set up the raycaster and the pointer vector. If no compute function is provided,
+ * the plugin will use the default compute function.
+ */
+export type ComputeFunction = (event: DomEvent, state: State, context: ThrelteContext) => void
+
 export type State = {
+  enabled: boolean
+  target: HTMLElement | undefined
   pointer: Vector2
   lastEvent: DomEvent | undefined
   raycaster: Raycaster
   initialClick: [x: number, y: number]
   lastPointerDownHits: THREE.Object3D[]
   hovered: Map<string, IntersectionEvent<DomEvent>>
+  interactiveObjects: THREE.Object3D[]
+  compute: ComputeFunction | undefined
 }
 
 export type EventMap = {
@@ -60,4 +73,9 @@ export type EventMap = {
   pointerleave: IntersectionEvent<PointerEvent>
   pointermove: IntersectionEvent<PointerEvent>
   pointermissed: MouseEvent
+}
+
+export type InteractivityOptions = {
+  enabled?: boolean
+  compute?: ComputeFunction
 }

--- a/packages/extras/src/lib/plugins/interactivity/useComponentEvents.ts
+++ b/packages/extras/src/lib/plugins/interactivity/useComponentEvents.ts
@@ -2,18 +2,54 @@ import { onMount } from 'svelte'
 import { get_current_component } from 'svelte/internal'
 import { writable } from 'svelte/store'
 
-export const useComponentEvents = () => {
+type EventCallback = (...args: any[]) => void
+type EventCallbackMap = Record<string, EventCallback[]>
+
+/**
+ * A hook that returns the events of a component and a callback that will be invoked as soon as the component has events to listen to.
+ * This callback will be called on mount and only if the demanded events are present.
+ * @param callback A callback that will be invoked as soon as the component has events to listen to. This callback will be called on mount and only if the demanded events are present.
+ * @param eventNames An array of event names to listen to. If not passed, all events will be listened to.
+ * @returns
+ */
+export const useComponentEvents = (
+  /**
+   * @param callback Pass a callback to get the event names and callbacks of a
+   * component. The callback will be called on mount and only if the demanded
+   * events are present.
+   */
+  callback?: (params: { eventNames: string[]; callbacks: EventCallbackMap }) => void,
+  /**
+   * @param eventNames Pass an array of event names to listen to
+   */
+  eventNames?: string[]
+) => {
   const component = get_current_component()
-  const eventNames = writable<string[]>([])
+  const eventNamesStore = writable<string[]>([])
   const callbacks = writable<Record<string, ((...args: any[]) => void)[]>>({})
 
   onMount(() => {
-    eventNames.set(Object.keys(component.$$.callbacks))
-    callbacks.set(component.$$.callbacks)
+    const filteredEventNames = Object.keys(component.$$.callbacks).filter((value) =>
+      eventNames ? eventNames.includes(value) : true
+    )
+    eventNamesStore.set(filteredEventNames)
+    const filteredCallbacks = Object.fromEntries(
+      Object.entries(component.$$.callbacks).filter(([key]) =>
+        eventNames ? eventNames.includes(key) : true
+      )
+    ) as EventCallbackMap
+    callbacks.set(filteredCallbacks)
+
+    if (filteredEventNames.length) {
+      callback?.({
+        callbacks: filteredCallbacks,
+        eventNames: filteredEventNames
+      })
+    }
   })
 
   return {
-    eventNames,
+    eventNames: eventNamesStore,
     callbacks
   }
 }

--- a/packages/extras/src/lib/plugins/interactivity/useComponentEvents.ts
+++ b/packages/extras/src/lib/plugins/interactivity/useComponentEvents.ts
@@ -1,0 +1,19 @@
+import { onMount } from 'svelte'
+import { get_current_component } from 'svelte/internal'
+import { writable } from 'svelte/store'
+
+export const useComponentEvents = () => {
+  const component = get_current_component()
+  const eventNames = writable<string[]>([])
+  const callbacks = writable<Record<string, ((...args: any[]) => void)[]>>({})
+
+  onMount(() => {
+    eventNames.set(Object.keys(component.$$.callbacks))
+    callbacks.set(component.$$.callbacks)
+  })
+
+  return {
+    eventNames,
+    callbacks
+  }
+}


### PR DESCRIPTION
# Threlte v6 Interactivity Plugin

Testable at /test with the new docs

Features:
- Basic event handling for these events:
  - `click`
  - `contextmenu`
  - `doubleclick`
  - `wheel`
  - `pointerup`
  - `pointerdown`
  - `pointerover`
  - `pointerout`
  - `pointerenter`
  - `pointerleave`
  - `pointermove`
  - `pointermissed`
- Event bubbling and support for `event.stopPropagation`
- Uses Threlte v6 Plugin API to inject code in components

## Event Bubbling

If the cursor intersects an object, an event is first emitted on the object itself. After that it travels up the scene hierarchy. If it's not stopped, it will be emitted on all objects that the ray also passed. Objects are "transparent" to casted rays by default. Event bubbling can be stopped via `event.stopPropagation()`.