### PR TITLE
Docs: Fix core-transition docs to match preprocessThrelte configuration docs

### DIFF
--- a/.changeset/short-houses-protect.md
+++ b/.changeset/short-houses-protect.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': patch
+---
+
+Fix core-transition docs to match preprocessThrelte configuration docs

--- a/apps/docs/src/routes/core-transition/index.md
+++ b/apps/docs/src/routes/core-transition/index.md
@@ -108,13 +108,13 @@ const config = {
 	preprocess: preprocessThrelte({
 		extensions: {
 			// import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
-			'three/examples/jsm/controls/OrbitControls': [OrbitControls],
+			'three/examples/jsm/controls/OrbitControls': ['OrbitControls'],
 
 			// import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
-			'three/examples/jsm/controls/TransformControls': [TransformControls],
+			'three/examples/jsm/controls/TransformControls': ['TransformControls'],
 
 			// import { CustomGrid } from '$lib/CustomGrid'
-			'$lib/CustomGrid': [CustomGrid]
+			'$lib/CustomGrid': ['CustomGrid']
 		}
 	})
 }


### PR DESCRIPTION
The [core-transition #extending-the-processor](https://threlte.xyz/core-transition#extending-the-preprocessor) docs are incorrect, omitting quotes for import names. I've updated the core-transition docs to match the [preprocessThrelte #configuration](https://threlte.xyz/preprocess/preprocessThrelte#configuration) docs, which are accurate.

Before:
<img src="https://user-images.githubusercontent.com/67887553/222061520-0a6b6f9c-133d-4c92-a5c3-d81e7b1a3a9e.png" width="500">

After:
<img src="https://user-images.githubusercontent.com/67887553/222061599-8866de83-06b0-4979-a594-663c3b953158.png" width="500">