### PR TITLE
Iframe based examples

### DIFF
--- a/apps/docs-next/src/components/Example/Example.astro
+++ b/apps/docs-next/src/components/Example/Example.astro
@@ -11,6 +11,7 @@ interface Props {
   path: string
   hideCode?: boolean
   hidePreview?: boolean
+  iframe?: boolean
 }
 
 const allModules = import.meta.glob('../../examples/**/*', {
@@ -45,6 +46,7 @@ const hidePreview = Astro.props.hidePreview ?? false
         path={Astro.props.path}
         client:load
         files={files}
+        iframe={Astro.props.iframe ?? false}
       />
     )
   }

--- a/apps/docs-next/src/components/Example/SvelteWrapper.svelte
+++ b/apps/docs-next/src/components/Example/SvelteWrapper.svelte
@@ -6,6 +6,7 @@
   export let path: string
   export let files: Record<string, string>
   export let hideCode: boolean
+  export let iframe: boolean
 
   const allAppModules = import.meta.glob('../../examples/**/App.svelte') as Record<
     string,
@@ -33,7 +34,13 @@
     _class
   )}
 >
-  {#if mounted && AppModule}
+  {#if iframe}
+    <iframe
+      src="/examples/{path}"
+      title={path}
+      class="w-full h-full border-none"
+    />
+  {:else if mounted && AppModule}
     {#await AppModule() then Mod}
       <Mod.default />
     {/await}

--- a/apps/docs-next/src/content/reference/docs/docs.mdx
+++ b/apps/docs-next/src/content/reference/docs/docs.mdx
@@ -186,3 +186,30 @@ The component `<Example>` renders an example that is defined in the `src/example
 renders as:
 
 <Example path="core/use-frame" />
+
+Hide the code:
+
+```mdx title="example.mdx"
+<Example
+  path="core/use-frame"
+  hideCode
+/>
+```
+
+Hide the preview:
+
+```mdx title="example.mdx"
+<Example
+  path="core/use-frame"
+  hidePreview
+/>
+```
+
+Embed the example preview as an iframe, which helps when third party UI libraries are used that overlay the whole page like Theatre.js Studio:
+
+```mdx title="example.mdx"
+<Example
+  path="core/use-frame"
+  iframe
+/>
+```

--- a/apps/docs-next/src/content/reference/extras/float.mdx
+++ b/apps/docs-next/src/content/reference/extras/float.mdx
@@ -47,7 +47,10 @@
 
 This component is a port of [drei's `<Float>` component](https://github.com/pmndrs/drei#float) and makes its contents float or hover.
 
-<Example path="extras/float" />
+<Example
+  path="extras/float"
+  iframe
+/>
 
 ## Examples
 

--- a/apps/docs-next/src/content/reference/extras/float.mdx
+++ b/apps/docs-next/src/content/reference/extras/float.mdx
@@ -47,10 +47,7 @@
 
 This component is a port of [drei's `<Float>` component](https://github.com/pmndrs/drei#float) and makes its contents float or hover.
 
-<Example
-  path="extras/float"
-  iframe
-/>
+<Example path="extras/float" />
 
 ## Examples
 

--- a/apps/docs-next/src/pages/examples/[...slug]/Loader.svelte
+++ b/apps/docs-next/src/pages/examples/[...slug]/Loader.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  export let slug: string
+
+  const allAppModules = import.meta.glob('../../../examples/**/App.svelte') as Record<
+    string,
+    () => Promise<any>
+  >
+
+  let mounted = false
+
+  const AppModule = Object.entries(allAppModules).find(
+    ([key]) => key === '../../../examples/' + slug + '/App.svelte'
+  )?.[1]
+
+  onMount(() => {
+    mounted = true
+  })
+</script>
+
+<div class="w-full h-full absolute">
+  {#if mounted && AppModule}
+    {#await AppModule() then Mod}
+      <Mod.default />
+    {/await}
+  {/if}
+</div>

--- a/apps/docs-next/src/pages/examples/[...slug]/index.astro
+++ b/apps/docs-next/src/pages/examples/[...slug]/index.astro
@@ -1,0 +1,28 @@
+---
+import Loader from './Loader.svelte'
+
+export async function getStaticPaths() {
+  const examples = import.meta.glob('../../../examples/**/App.svelte')
+  const keys = Object.keys(examples) as string[]
+  const slugs = keys.map((key) => key.replace('../../../examples/', '').replace('/App.svelte', ''))
+
+  return slugs.map((slug) => {
+    return {
+      params: { slug }
+    }
+  })
+}
+
+// const AppComponent = import.meta.glob('../../../examples/' + Astro.params.slug + '/App.svelte', {
+//   eager: true
+// })
+
+const slug = Astro.params.slug
+---
+
+<div class="absolute h-full w-full">
+  <Loader
+    client:load
+    slug={slug}
+  />
+</div>


### PR DESCRIPTION
Solves the issue that some examples implement third party libraries which overlay the whole page.

You can now add the flag `iframe` to the component `<Example>` in content .mdx files to indicate that the preview of an Example should be displayed in an iframe. This PR introduces a new docs route "/examples/…" that the iframe is displaying.