### PR TITLE
Improve use gltf docs

### DIFF
--- a/apps/docs-next/src/content/reference/extras/use-gltf.mdx
+++ b/apps/docs-next/src/content/reference/extras/use-gltf.mdx
@@ -92,7 +92,7 @@ The hook provides a map of all objects and materials in the loaded glTF.
 </script>
 ```
 
-Provide types to use your IDEs autocompletion. Use [gltfjsx](https://github.com/pmndrs/gltfjsx) to extract types from glTF files.
+Provide types and you will gain autocompletion for these objects and materials.
 
 ```svelte
 <script lang="ts">
@@ -117,7 +117,16 @@ Provide types to use your IDEs autocompletion. Use [gltfjsx](https://github.com/
 </script>
 ```
 
-An alternative to keeping your GLTF types within your component is to import then from a types file instead. Types can be easily generated via the `@threlte/gltf` cli tool [hello world](/docs/learn/basics/loading-assets#reusing-models)
+<Tip
+  type="tip"
+  title="How to get the types?"
+>
+  On the [loading-assets](/docs/learn/basics/loading-assets) page, threlte provides the
+  `@threlte/gltf` cli tool that can be used to generate a reusable svelte component for your gltf as
+  well as it's types
+</Tip>
+
+Types can be separated into a typescript file and imported like so if you feel the need.
 
 ```ts title=“SomeGltf.ts”
 export type SomeGltf = {
@@ -130,7 +139,8 @@ export type SomeGltf = {
 
 ```svelte title=“MyComponent.svelte”
 <script lang="ts">
-  import { SomeGltf } from './types'
+  import { useGltf } from '@threlte/extras'
+  import type { SomeGltf } from './SomeGltf.ts'
 
   useGltf<SomeGltf>('model.glb')
 </script>

--- a/apps/docs-next/src/content/reference/extras/use-gltf.mdx
+++ b/apps/docs-next/src/content/reference/extras/use-gltf.mdx
@@ -121,14 +121,14 @@ Provide types and you will gain autocompletion for these objects and materials.
   type="tip"
   title="How to get the types?"
 >
-  On the [loading-assets](/docs/learn/basics/loading-assets) page, threlte provides the
-  `@threlte/gltf` cli tool that can be used to generate a reusable svelte component for your gltf as
-  well as it's types
+  On the [loading-assets](/docs/learn/basics/loading-assets) page, Threlte provides the
+  `@threlte/gltf` CLI tool that can be used to generate a reusable Svelte component for your gltf as
+  well as its types.
 </Tip>
 
 Types can be separated into a typescript file and imported like so if you feel the need.
 
-```ts title=“SomeGltf.ts”
+```ts title=SomeGltf.ts
 export type SomeGltf = {
   nodes: {
     Suzanne: THREE.Mesh
@@ -137,7 +137,7 @@ export type SomeGltf = {
 }
 ```
 
-```svelte title=“MyComponent.svelte”
+```svelte title=MyComponent.svelte
 <script lang="ts">
   import { useGltf } from '@threlte/extras'
   import type { SomeGltf } from './SomeGltf.ts'

--- a/apps/docs-next/src/content/reference/extras/use-gltf.mdx
+++ b/apps/docs-next/src/content/reference/extras/use-gltf.mdx
@@ -116,3 +116,22 @@ Provide types to use your IDEs autocompletion. Use [gltfjsx](https://github.com/
   }
 </script>
 ```
+
+An alternative to keeping your GLTF types within your component is to import then from a types file instead. Types can be easily generated via the `@threlte/gltf` cli tool [hello world](/docs/learn/basics/loading-assets#reusing-models)
+
+```ts title=“SomeGltf.ts”
+export type SomeGltf = {
+  nodes: {
+    Suzanne: THREE.Mesh
+  }
+  materials: {}
+}
+```
+
+```svelte title=“MyComponent.svelte”
+<script lang="ts">
+  import { SomeGltf } from './types'
+
+  useGltf<SomeGltf>('model.glb')
+</script>
+```


### PR DESCRIPTION
Decided to change tack a little and insert a tip linking back to the `loading assets` page. I think it reads better and the tip guides someone in the right direction for making types for their gltf. Still added the example of importing types from a separate file.