### PR TITLE
<T> refactoring

### DIFF
--- a/.changeset/strong-dogs-fail.md
+++ b/.changeset/strong-dogs-fail.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Fixed a bug which could lead to memory leaks, removed unused type import

--- a/packages/core/src/lib/components/T/T.ts
+++ b/packages/core/src/lib/components/T/T.ts
@@ -27,7 +27,7 @@ export const extend = (extensions: Extensions) => {
 }
 
 const augmentConstructorArgs = (
-  args: ComponentConstructorOptions<ComponentProps<TComp<any>>>,
+  args: ComponentConstructorOptions<ComponentProps<TComp>>,
   is: keyof typeof THREE
 ) => {
   const module = catalogue[is] || THREE[is]
@@ -46,7 +46,7 @@ const augmentConstructorArgs = (
 const proxyTConstructor = (is: keyof typeof THREE) => {
   return new Proxy(class {}, {
     construct(_, [args]) {
-      const castedArgs = args as ComponentConstructorOptions<ComponentProps<TComp<any>>>
+      const castedArgs = args as ComponentConstructorOptions<ComponentProps<TComp>>
       return new TComp(augmentConstructorArgs(castedArgs, is))
     }
   })
@@ -74,7 +74,7 @@ const proxyTConstructor = (is: keyof typeof THREE) => {
  */
 export const T = new Proxy(class {}, {
   construct(_, [args]) {
-    const castedArgs = args as ComponentConstructorOptions<ComponentProps<TComp<any>>>
+    const castedArgs = args as ComponentConstructorOptions<ComponentProps<TComp>>
     return new TComp(castedArgs)
   },
   get(_, is: keyof typeof THREE) {

--- a/packages/core/src/lib/components/T/types.ts
+++ b/packages/core/src/lib/components/T/types.ts
@@ -1,5 +1,4 @@
 import type { ConditionalKeys, Primitive } from 'type-fest'
-import type CameraControls from 'camera-controls'
 
 /**
  * We hold a list of prop keys that should be ommited from the object props


### PR DESCRIPTION
An issue I was seeing is that the `create` event on `<T>` components would sometimes be emitted also when the `ref` would not actually change. This was due to the fact that if the `ref` was used as a binding in the parent component and mutated in e.g. a `useFrame` hook, Svelte's reactivity would kick in and recreate `ref` on every frame leading to potential memory leaks and a generally bad performance.

This PR should fix this issue as the `ref` being exposed by the component `<T>` is now its own variable and mutations on it will not spill into the reactive statements inside the component `<T>`.