### PR TITLE
Rename GroundProjectedEnv to GroundProjectedSkybox

### DIFF
--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -33,7 +33,7 @@
     "svelte-preprocess": "^4.10.5",
     "svelte-sequential-preprocessor": "^0.0.7",
     "svelte2tsx": "^0.5.9",
-    "three": "^0.145.0",
+    "three": "^0.151.0",
     "ts-node": "^10.8.2",
     "tsafe": "^0.9.0",
     "tslib": "^2.3.1",

--- a/packages/extras/src/lib/components/Environment/Environment.svelte
+++ b/packages/extras/src/lib/components/Environment/Environment.svelte
@@ -16,7 +16,7 @@
   import { HDRCubeTextureLoader } from 'three/examples/jsm/loaders/HDRCubeTextureLoader'
   import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 
-  import GroundProjectedEnv from './GroundProjectedEnv.svelte'
+  import GroundProjectedSkybox from './GroundProjectedSkybox.svelte'
 
   export let path: EnvironmentProperties['path'] = undefined
   export let files: EnvironmentProperties['files']
@@ -103,7 +103,7 @@
 </script>
 
 {#if groundProjection}
-  <GroundProjectedEnv
+  <GroundProjectedSkybox
     {groundProjection}
     currentEnvMap={previousEnvMap}
   />

--- a/packages/extras/src/lib/components/Environment/GroundProjectedSkybox.svelte
+++ b/packages/extras/src/lib/components/Environment/GroundProjectedSkybox.svelte
@@ -3,7 +3,7 @@
   import { useThrelte } from '@threlte/core'
   import { onDestroy } from 'svelte'
   import type { Texture } from 'three'
-  import { GroundProjectedEnv } from 'three/examples/jsm/objects/GroundProjectedEnv'
+  import { GroundProjectedSkybox } from 'three/examples/jsm/objects/GroundProjectedSkybox'
 
   export let groundProjection: EnvironmentProperties['groundProjection']
   export let currentEnvMap: Texture
@@ -40,13 +40,13 @@
   }
 
   const toggleGroundEnv = (
-    groundEnv: GroundProjectedEnv | undefined,
+    groundEnv: GroundProjectedSkybox | undefined,
     groundEnvProps: EnvironmentProperties['groundProjection'],
     envMap: Texture
   ) => {
     if (groundEnv && previousEnvMap != envMap) removeGroundEnv()
     if ((!groundEnv || previousEnvMap != envMap) && groundEnvProps && envMap) {
-      currentGroundEnv = new GroundProjectedEnv(envMap)
+      currentGroundEnv = new GroundProjectedSkybox(envMap)
 
       scene.add(currentGroundEnv)
       previousEnvMap = envMap


### PR DESCRIPTION
three.js version 0.151.0 renamed GroundProjectedEnv to GroundProjectedSkybox   [#25645](https://github.com/mrdoob/three.js/pull/25645)  

This breaks @threlte/extras when it attempts to import GroundProjectedEnv.  
I renamed the file and the import to work with newer versions of three.js