### PR TITLE
fix (docs): maintain scroll position on  page change

### DIFF
--- a/.changeset/silver-books-kneel.md
+++ b/.changeset/silver-books-kneel.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs-next': patch
+---
+
+maintain left sidebar scroll position on page change

--- a/apps/docs-next/src/components/Menu/LeftSidebar/LeftSidebar.astro
+++ b/apps/docs-next/src/components/Menu/LeftSidebar/LeftSidebar.astro
@@ -17,3 +17,19 @@ const activeUrlPathName = Astro.url.pathname
   activeSidebarTab={activeSidebarTab}
   activeUrlPathName={activeUrlPathName}
 />
+
+<!-- Preserve sidebar scroll across page loads -->
+<script is:inline>
+{
+  debugger
+  const leftSidebar = document.querySelector('#sidebar-scrollwindow')
+  const leftSidebarScroll = localStorage.getItem('sidebar-scroll')
+  if (leftSidebarScroll !== null) {
+    leftSidebar.scrollTop = parseInt(leftSidebarScroll, 10)
+  }
+  window.addEventListener('beforeunload', () => {
+    debugger
+    localStorage.setItem('sidebar-scroll', leftSidebar.scrollTop)
+  })
+}
+</script>

--- a/apps/docs-next/src/components/Menu/LeftSidebar/LeftSidebar.svelte
+++ b/apps/docs-next/src/components/Menu/LeftSidebar/LeftSidebar.svelte
@@ -38,7 +38,7 @@
     <div class="pointer-events-none absolute top-full left-0 z-20 h-4 w-full" />
   </div>
 
-  <ul class={c('overflow-y-auto mt-0 overflow-auto pt-6 pb-24 block px-2 h-full scrollbar-hide')}>
+  <ul id="sidebar-scrollwindow" class={c('overflow-y-auto mt-0 overflow-auto pt-6 pb-24 block px-2 h-full scrollbar-hide')}>
     {#each menu[activeSidebarTab].categories as category}
       <li class="mb-6 text-sm">
         <LeftSidebarCategory


### PR DESCRIPTION
The new docs are great! thank you

But I was getting frustrated with my scroll position in the left sidebar being lost after each page change.
So I copied [the code from the Astro docs](https://github.com/withastro/docs/blob/main/src/components/LeftSidebar/LeftSidebar.astro#L87) to fix it


P.S. it seems like all the files in the repo have indentation set to 2 spaces, but the editorconfig file has "indent_style=tab", rather than "indent_style=space", so vscode was automatically converting all the 2-spaces into tabs for me.
Seems a mismatch between editorconfig setting and what is actually in code?