### PR TITLE
Add outline demo to docs

### DIFF
--- a/.changeset/afraid-parrots-smoke.md
+++ b/.changeset/afraid-parrots-smoke.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs-next': patch
+---
+
+add outline example to docs

--- a/apps/docs-next/src/content/learn/examples/index.mdx
+++ b/apps/docs-next/src/content/learn/examples/index.mdx
@@ -20,6 +20,10 @@ There are a ton of different things to do in a 3D project. Below is some recipes
 - [Terrain with 3D noise](/docs/learn/examples/geometry/terrain)
 - [Terrain with Rapier physics collider](/docs/learn/examples/geometry/terrain-physics)
 
+## Postprocessing
+
+- [Outline](/docs/learn/examples/postprocessing/outline)
+
 <Tip
   type="note"
   title="Help Wanted"

--- a/apps/docs-next/src/content/learn/examples/postprocessing/outline.mdx
+++ b/apps/docs-next/src/content/learn/examples/postprocessing/outline.mdx
@@ -1,0 +1,7 @@
+---
+category: Examples
+title: Postprocessing
+showInSidebar: false
+---
+
+<Example path="postprocessing/outline" />

--- a/apps/docs-next/src/examples/postprocessing/outline/App.svelte
+++ b/apps/docs-next/src/examples/postprocessing/outline/App.svelte
@@ -1,22 +1,8 @@
 <script lang="ts">
   import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
-  import { useTweakpane } from '../../utils/useTweakpane'
-  import { animationPlaying } from './state'
 
-  // add tweakpane to show or hide the terrain collision mesh
-  const { action, addButton } = useTweakpane()
-
-  addButton({
-    title: 'toggle',
-    label: 'Animation',
-    onClick: () => {
-      $animationPlaying = !$animationPlaying
-    }
-  })
 </script>
-
-<div use:action />
 
 <Canvas>
   <Scene />

--- a/apps/docs-next/src/examples/postprocessing/outline/App.svelte
+++ b/apps/docs-next/src/examples/postprocessing/outline/App.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { Canvas } from '@threlte/core'
+  import Scene from './Scene.svelte'
+  import { useTweakpane } from '../../utils/useTweakpane'
+  import { animationPlaying } from './state'
+
+  // add tweakpane to show or hide the terrain collision mesh
+  const { action, addButton } = useTweakpane()
+
+  addButton({
+    title: 'toggle',
+    label: 'Animation',
+    onClick: () => {
+      $animationPlaying = !$animationPlaying
+    }
+  })
+</script>
+
+<div use:action />
+
+<Canvas>
+  <Scene />
+</Canvas>

--- a/apps/docs-next/src/examples/postprocessing/outline/CustomRenderer.svelte
+++ b/apps/docs-next/src/examples/postprocessing/outline/CustomRenderer.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { useThrelte, useRender } from '@threlte/core';
+	import {
+		EffectComposer,
+		EffectPass,
+		RenderPass,
+		OutlineEffect,
+		BlendFunction
+	} from 'postprocessing';
+
+	export let selectedMesh;
+
+	const { scene, renderer, camera } = useThrelte();
+
+	const composer = new EffectComposer(renderer);
+
+	const setupEffectComposer = (camera, selectedMesh) => {
+		composer.addPass(new RenderPass(scene, camera));
+
+		const outlineEffect = new OutlineEffect(scene, camera, {
+			blendFunction: BlendFunction.ALPHA,
+			edgeStrength: 100,
+			pulseSpeed: 0.0,
+			visibleEdgeColor: 'white',
+			hiddenEdgeColor: 0x9900ff,
+			xRay: true,
+			blur: true
+		});
+		if (selectedMesh !== undefined) {
+			outlineEffect.selection.set([selectedMesh]);
+		}
+		composer.addPass(new EffectPass(camera, outlineEffect));
+	};
+
+	$: setupEffectComposer($camera, selectedMesh);
+
+	useRender((_, delta) => {
+		composer.render(delta);
+	});
+</script>

--- a/apps/docs-next/src/examples/postprocessing/outline/Maze.svelte
+++ b/apps/docs-next/src/examples/postprocessing/outline/Maze.svelte
@@ -1,0 +1,33 @@
+<script>
+	import { T } from '@threlte/core';
+</script>
+
+<T.Mesh position={[6, 2, 4]} rotation.y={Math.PI / 2}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[7, 4, 1]} />
+</T.Mesh>
+<T.Mesh position={[-6, 2, 4]} rotation.y={Math.PI / 2}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[7, 4, 1]} />
+</T.Mesh>
+
+<T.Mesh position={[-4, 2, 0]}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[5, 4, 1]} />
+</T.Mesh>
+<T.Mesh position={[4, 2, 0]}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[5, 4, 1]} />
+</T.Mesh>
+<T.Mesh position={[-3, 2, 7]}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[7, 4, 1]} />
+</T.Mesh>
+<T.Mesh position={[5, 2, 7]}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[3, 4, 1]} />
+</T.Mesh>
+<T.Mesh position={[-1, 2, 3.5]}>
+	<T.MeshStandardMaterial color="silver" />
+	<T.BoxGeometry args={[10, 4, 1]} />
+</T.Mesh>

--- a/apps/docs-next/src/examples/postprocessing/outline/Scene.svelte
+++ b/apps/docs-next/src/examples/postprocessing/outline/Scene.svelte
@@ -1,23 +1,59 @@
 <script lang="ts">
-  import { PlaneGeometry } from 'three'
+	import { onMount } from 'svelte';
+	import { quadInOut } from 'svelte/easing';
+	import { tweened } from 'svelte/motion';
+
   import { T } from '@threlte/core'
   import { OrbitControls, Grid, ContactShadows } from '@threlte/extras'
-  import { animationPlaying } from './state'
+
+  import { PlaneGeometry } from 'three'
+
   import Maze from './Maze.svelte'
   import CustomRenderer from './CustomRenderer.svelte'
 
+  const route = [
+		[0, 1, -3],
+		[0, 1, 1.5],
+		[4.7, 1, 1.5],
+		[4.7, 1, 5],
+		[2, 1, 5],
+		[2, 1, 9],
+		[8, 1, 9],
+		[8, 1, -3]
+	];
+	let routeIndex = 0;
+	let cubePosition = tweened(route[routeIndex], {
+		duration: 400,
+		easing: quadInOut,
+	});
 	let outlinedCube;
+
+	onMount(() => {
+		const interval = setInterval(nextCubePosition, 500);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
+
+	const nextCubePosition = () => {
+		if (routeIndex < route.length - 1) {
+			routeIndex++;
+		} else {
+			routeIndex = 0;
+		}
+		cubePosition.set(route[routeIndex]);
+	};
 </script>
 
 <Maze />
 
-<T.Mesh position={[1.8,1,1]} bind:ref={outlinedCube}>
+<T.Mesh position={$cubePosition} bind:ref={outlinedCube}>
   <T.MeshToonMaterial color="gold" />
   <T.BoxGeometry />
 </T.Mesh>
 
 <CustomRenderer selectedMesh={outlinedCube} />
-
 
 <T.PerspectiveCamera
   makeDefault
@@ -25,7 +61,7 @@
   fov={15}
   zoom={0.2}
 >
-  <OrbitControls enableZoom={true} enableDamping target.y={0} />
+  <OrbitControls enableZoom={true} enableDamping target={[0, 0, 5]}/>
 </T.PerspectiveCamera>
 
 <T.DirectionalLight
@@ -36,13 +72,10 @@
 <T.AmbientLight intensity={0.2} />
 
 <Grid
-  position.y={-0.001}
+  gridSize={18}
+  position={[0, -0.001, 5]}
   cellColor="#ffffff"
   sectionColor="#ffffff"
   sectionThickness={0}
-  fadeDistance={75}
-  cellSize={2}
+  fadeDistance={25}
 />
-
-<ContactShadows scale={12} blur={2} far={5} opacity={0.5} />
-

--- a/apps/docs-next/src/examples/postprocessing/outline/Scene.svelte
+++ b/apps/docs-next/src/examples/postprocessing/outline/Scene.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { PlaneGeometry } from 'three'
+  import { T } from '@threlte/core'
+  import { OrbitControls, Grid, ContactShadows } from '@threlte/extras'
+  import { animationPlaying } from './state'
+  import Maze from './Maze.svelte'
+  import CustomRenderer from './CustomRenderer.svelte'
+
+	let outlinedCube;
+</script>
+
+<Maze />
+
+<T.Mesh position={[1.8,1,1]} bind:ref={outlinedCube}>
+  <T.MeshToonMaterial color="gold" />
+  <T.BoxGeometry />
+</T.Mesh>
+
+<CustomRenderer selectedMesh={outlinedCube} />
+
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[0, 6, -10]}
+  fov={15}
+  zoom={0.2}
+>
+  <OrbitControls enableZoom={true} enableDamping target.y={0} />
+</T.PerspectiveCamera>
+
+<T.DirectionalLight
+  intensity={0.8}
+  position.x={5}
+  position.y={10}
+/>
+<T.AmbientLight intensity={0.2} />
+
+<Grid
+  position.y={-0.001}
+  cellColor="#ffffff"
+  sectionColor="#ffffff"
+  sectionThickness={0}
+  fadeDistance={75}
+  cellSize={2}
+/>
+
+<ContactShadows scale={12} blur={2} far={5} opacity={0.5} />
+

--- a/apps/docs-next/src/examples/postprocessing/outline/state.ts
+++ b/apps/docs-next/src/examples/postprocessing/outline/state.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store'
-
-export let animationPlaying = writable(true)

--- a/apps/docs-next/src/examples/postprocessing/outline/state.ts
+++ b/apps/docs-next/src/examples/postprocessing/outline/state.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store'
+
+export let animationPlaying = writable(true)


### PR DESCRIPTION
Wanted to contribute an example to the docs.
Decided to do a "thing moving behind other thing" demo, a la teammate outlines in Left 4 Dead.
Animated with svelte/motion instead of theatrejs, to keep it as simple as possible.

Compared to R3F, this example is less elegant, because R3F can use the `react/post-processing` and the <Selection> helper, so when those equivalent things are in the threlte ecosystem, then this example could be updated.