### PR TITLE
fix: use copy on props

### DIFF
--- a/packages/core/src/lib/components/T/utils/useProps.ts
+++ b/packages/core/src/lib/components/T/utils/useProps.ts
@@ -74,11 +74,13 @@ export const useProps = () => {
     } else {
       if (typeof target[key]?.set === 'function') {
         // if the property has a "set" function, we can use it
-        if (Array.isArray(value)) {
+				if (target[key].constructor === value.constructor || (value.constructor === Object && !Object.keys(value).some(k => !(k in target[key])))) {
+          target[key].copy(value)
+        } else if (Array.isArray(value)) {
           target[key].set(...value)
         } else {
-          target[key].set(value)
-        }
+					target[key].set(value)
+				}
       } else {
         // otherwise, we just set the value
         target[key] = value

--- a/packages/core/src/lib/components/T/utils/useProps.ts
+++ b/packages/core/src/lib/components/T/utils/useProps.ts
@@ -72,11 +72,13 @@ export const useProps = () => {
       // edge case of setScalar setters
       target[key].setScalar(value)
     } else {
-      if (typeof target[key]?.set === 'function') {
+			// copy if available
+			if (typeof target[key]?.clone === 'function' && (target[key].constructor === value.constructor || (value.constructor === Object && !Object.keys(value).some(k => !(k in target[key]))))) {
+				target[key].copy(value)
+			}
+      else if (typeof target[key]?.set === 'function') {
         // if the property has a "set" function, we can use it
-				if (target[key].constructor === value.constructor || (value.constructor === Object && !Object.keys(value).some(k => !(k in target[key])))) {
-          target[key].copy(value)
-        } else if (Array.isArray(value)) {
+				if (Array.isArray(value)) {
           target[key].set(...value)
         } else {
 					target[key].set(value)

--- a/packages/core/src/lib/components/T/utils/useProps.ts
+++ b/packages/core/src/lib/components/T/utils/useProps.ts
@@ -73,7 +73,7 @@ export const useProps = () => {
       target[key].setScalar(value)
     } else {
 			// copy if available
-			if (typeof target[key]?.clone === 'function' && (target[key].constructor === value.constructor || (value.constructor === Object && !Object.keys(value).some(k => !(k in target[key]))))) {
+			if (typeof target[key]?.copy === 'function' && (target[key].constructor === value.constructor || (value.constructor === Object && !Object.keys(value).some(k => !(k in target[key]))))) {
 				target[key].copy(value)
 			}
       else if (typeof target[key]?.set === 'function') {


### PR DESCRIPTION
Summary: This PR improves compatibility by improving the logic of `useProps`.

In the @next version, threlte dynamically binds all the props. However, this creates significant compatibility issues. The problem is that the value of the three.js object cannot be applied to the element as it is. This was addressed in #427, and to sum up the problem, if you put a value such as `new Vector3(0, 0, 0)` in `position`, this `Vector3` is substituted in `position.x`, resulting in strange behavior.
This PR modifies the logic to use a `copy` function, not a `set`, where appropriate. This allows objects such as `Vector3`, `Color` to be substituted directly.