### PR TITLE
Proposal: @threlte/extras `<RoundedBoxGeometry>` component

### DIFF
--- a/.changeset/plenty-peas-promise.md
+++ b/.changeset/plenty-peas-promise.md
@@ -1,0 +1,6 @@
+---
+'@threlte/docs-next': patch
+'@threlte/extras': patch
+---
+
+Add RoundedBoxGeometry component

--- a/apps/docs-next/src/content/reference/extras/rounded-box-geometry.mdx
+++ b/apps/docs-next/src/content/reference/extras/rounded-box-geometry.mdx
@@ -1,0 +1,69 @@
+---
+{
+  order: 2,
+  category: '@threlte/extras',
+  name: <RoundedBoxGeometry>,
+  type: 'component',
+  componentSignature:
+    {
+      extends:
+        {
+          type: 'ExtrudeGeometry',
+          url: 'https://threejs.org/docs/index.html?q=extrud#api/en/geometries/ExtrudeGeometry'
+        },
+      props:
+        [
+          {
+            name: 'args',
+            type: '[number, number, number]',
+            required: false,
+            default: '[1, 1, 1]',
+            description: 'Width, height, depth'
+          },
+          {
+            name: 'radius',
+            type: 'number',
+            required: false,
+            default: '0.05',
+            description: 'Radius of the rounded corners.'
+          },
+          {
+            name: 'smoothness',
+            type: 'number',
+            required: false,
+            description: 'The number of curve segments.'
+          },
+          {
+            name: 'creaseAngle',
+            type: 'number',
+            required: false,
+            description: 'Smooth normals everywhere except faces that meet at an angle greater than the crease angle.'
+          },
+        ],
+    }
+}
+---
+
+Creates a rounded box geometry.
+
+### Example
+
+```svelte
+<script>
+  import { T, Canvas } from '@threlte/core'
+  import { RoundedBoxGeometry } from '@threlte/extras'
+</script>
+
+<Canvas>
+  <T.PerspectiveCamera
+    makeDefault
+    position={[3, 3, 3]}
+    lookAt={[0, 0, 0]}
+  />
+
+  <T.Mesh>
+    <RoundedBoxGeometry />
+    <T.MeshPhongMaterial color='hotpink' />
+  </T.Mesh>
+</Canvas>
+```

--- a/apps/docs-next/src/content/reference/extras/rounded-box-geometry.mdx
+++ b/apps/docs-next/src/content/reference/extras/rounded-box-geometry.mdx
@@ -6,11 +6,6 @@
   type: 'component',
   componentSignature:
     {
-      extends:
-        {
-          type: 'ExtrudeGeometry',
-          url: 'https://threejs.org/docs/index.html?q=extrud#api/en/geometries/ExtrudeGeometry'
-        },
       props:
         [
           {
@@ -44,7 +39,7 @@
           {
             name: 'steps',
             type: 'number',
-            required: 'false',
+            required: false,
             default: '1',
             description: 'Number of points used for subdividing segments along the depth of the extruded spline.'
           }
@@ -53,7 +48,7 @@
 }
 ---
 
-Creates a rounded box geometry.
+Creates a rounded box geometry with a Three.js ExtrudeGeometry.
 
 ### Example
 

--- a/apps/docs-next/src/content/reference/extras/rounded-box-geometry.mdx
+++ b/apps/docs-next/src/content/reference/extras/rounded-box-geometry.mdx
@@ -31,14 +31,23 @@
             name: 'smoothness',
             type: 'number',
             required: false,
+            default: '4',
             description: 'The number of curve segments.'
           },
           {
             name: 'creaseAngle',
             type: 'number',
             required: false,
+            default: '0.4',
             description: 'Smooth normals everywhere except faces that meet at an angle greater than the crease angle.'
           },
+          {
+            name: 'steps',
+            type: 'number',
+            required: 'false',
+            default: '1',
+            description: 'Number of points used for subdividing segments along the depth of the extruded spline.'
+          }
         ],
     }
 }

--- a/packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte
+++ b/packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte
@@ -1,0 +1,50 @@
+<script lang='ts'>
+
+import { Shape } from 'three'
+import { T } from '@threlte/core'
+import { toCreasedNormals } from './toCreasedNormals'
+
+export let args: [width?: number, height?: number, depth?: number] | [] = []
+export let radius = 0.05
+export let smoothness = 4
+export let steps = 1
+export let creaseAngle = 0.4
+
+const eps = 0.00001
+
+const createShape = (width: number, height: number, radius0: number) => {
+  const shape = new Shape()
+  const radius = radius0 - eps
+  shape.absarc(eps, eps, eps, -Math.PI / 2, -Math.PI, true)
+  shape.absarc(eps, height - radius * 2, eps, Math.PI, Math.PI / 2, true)
+  shape.absarc(width - radius * 2, height - radius * 2, eps, Math.PI / 2, 0, true)
+  shape.absarc(width - radius * 2, eps, eps, 0, -Math.PI / 2, true)
+  return shape
+}
+
+let width = 0
+let height = 0
+let depth = 0
+
+$: [width = 1, height = 1, depth = 1] = args
+$: shape = createShape(width, height, radius)
+
+$: params = {
+  depth: depth - radius * 2,
+  bevelEnabled: true,
+  bevelSegments: smoothness * 2,
+  steps,
+  bevelSize: radius - eps,
+  bevelThickness: radius,
+  curveSegments: smoothness,
+}
+
+</script>
+
+<T.ExtrudeGeometry
+  args={[shape, params]}
+  on:create={({ ref }) => {
+    ref.center()
+    toCreasedNormals(ref, creaseAngle)
+  }}
+/>

--- a/packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte
+++ b/packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte
@@ -1,14 +1,16 @@
 <script lang='ts'>
 
 import { Shape } from 'three'
-import { T } from '@threlte/core'
+import { T, forwardEventHandlers } from '@threlte/core'
 import { toCreasedNormals } from './toCreasedNormals'
+
+const component = forwardEventHandlers()
 
 export let args: [width?: number, height?: number, depth?: number] | [] = []
 export let radius = 0.05
 export let smoothness = 4
-export let steps = 1
 export let creaseAngle = 0.4
+export let steps = 1
 
 const eps = 0.00001
 
@@ -22,13 +24,10 @@ const createShape = (width: number, height: number, radius0: number) => {
   return shape
 }
 
-let width = 0
-let height = 0
-let depth = 0
-
-$: [width = 1, height = 1, depth = 1] = args
+$: width = args[0] ?? 1
+$: height = args[1] ?? 1
+$: depth = args[2] ?? 1
 $: shape = createShape(width, height, radius)
-
 $: params = {
   depth: depth - radius * 2,
   bevelEnabled: true,
@@ -42,9 +41,13 @@ $: params = {
 </script>
 
 <T.ExtrudeGeometry
+  let:ref
+  bind:this={$component}
   args={[shape, params]}
   on:create={({ ref }) => {
     ref.center()
     toCreasedNormals(ref, creaseAngle)
   }}
-/>
+>
+  <slot {ref} />  
+</T.ExtrudeGeometry>

--- a/packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte
+++ b/packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte
@@ -1,43 +1,41 @@
-<script lang='ts'>
+<script lang="ts">
+  import { Shape } from 'three'
+  import { T, forwardEventHandlers } from '@threlte/core'
+  import { toCreasedNormals } from './toCreasedNormals'
 
-import { Shape } from 'three'
-import { T, forwardEventHandlers } from '@threlte/core'
-import { toCreasedNormals } from './toCreasedNormals'
+  const component = forwardEventHandlers()
 
-const component = forwardEventHandlers()
+  export let args: [width?: number, height?: number, depth?: number] | [] = []
+  export let radius = 0.05
+  export let smoothness = 4
+  export let creaseAngle = 0.4
+  export let steps = 1
 
-export let args: [width?: number, height?: number, depth?: number] | [] = []
-export let radius = 0.05
-export let smoothness = 4
-export let creaseAngle = 0.4
-export let steps = 1
+  const eps = 0.00001
 
-const eps = 0.00001
+  const createShape = (width: number, height: number, radius0: number) => {
+    const shape = new Shape()
+    const radius = radius0 - eps
+    shape.absarc(eps, eps, eps, -Math.PI / 2, -Math.PI, true)
+    shape.absarc(eps, height - radius * 2, eps, Math.PI, Math.PI / 2, true)
+    shape.absarc(width - radius * 2, height - radius * 2, eps, Math.PI / 2, 0, true)
+    shape.absarc(width - radius * 2, eps, eps, 0, -Math.PI / 2, true)
+    return shape
+  }
 
-const createShape = (width: number, height: number, radius0: number) => {
-  const shape = new Shape()
-  const radius = radius0 - eps
-  shape.absarc(eps, eps, eps, -Math.PI / 2, -Math.PI, true)
-  shape.absarc(eps, height - radius * 2, eps, Math.PI, Math.PI / 2, true)
-  shape.absarc(width - radius * 2, height - radius * 2, eps, Math.PI / 2, 0, true)
-  shape.absarc(width - radius * 2, eps, eps, 0, -Math.PI / 2, true)
-  return shape
-}
-
-$: width = args[0] ?? 1
-$: height = args[1] ?? 1
-$: depth = args[2] ?? 1
-$: shape = createShape(width, height, radius)
-$: params = {
-  depth: depth - radius * 2,
-  bevelEnabled: true,
-  bevelSegments: smoothness * 2,
-  steps,
-  bevelSize: radius - eps,
-  bevelThickness: radius,
-  curveSegments: smoothness,
-}
-
+  $: width = args[0] ?? 1
+  $: height = args[1] ?? 1
+  $: depth = args[2] ?? 1
+  $: shape = createShape(width, height, radius)
+  $: params = {
+    depth: depth - radius * 2,
+    bevelEnabled: true,
+    bevelSegments: smoothness * 2,
+    steps,
+    bevelSize: radius - eps,
+    bevelThickness: radius,
+    curveSegments: smoothness
+  }
 </script>
 
 <T.ExtrudeGeometry
@@ -49,5 +47,5 @@ $: params = {
     toCreasedNormals(ref, creaseAngle)
   }}
 >
-  <slot {ref} />  
+  <slot {ref} />
 </T.ExtrudeGeometry>

--- a/packages/extras/src/lib/components/RoundedBoxGeometry/toCreasedNormals.ts
+++ b/packages/extras/src/lib/components/RoundedBoxGeometry/toCreasedNormals.ts
@@ -1,0 +1,74 @@
+import { Vector3, BufferGeometry } from 'three'
+
+const multiplier = (1 + 1e-10) * 1e2
+const hashVertex = (v: Vector3) => {
+  return `${~~(v.x * multiplier)},${~~(v.y * multiplier)},${~~(v.z * multiplier)}`
+}
+
+/**
+ * Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
+ * an angle greater than the crease angle.
+ * 
+ * Adapted from https://github.com/mrdoob/three.js/blob/master/src/core/BufferGeometry.js but removed unnecessary steps and warnings.
+ */
+export const toCreasedNormals = (geometry: BufferGeometry, creaseAngle = Math.PI): BufferGeometry => {
+  const creaseDot = Math.cos(creaseAngle)
+  const verts = [new Vector3(), new Vector3(), new Vector3()] as const
+  const tempVec1 = new Vector3()
+  const tempVec2 = new Vector3()
+  const tempNorm = new Vector3()
+  const tempNorm2 = new Vector3()
+
+  const posAttr = geometry.getAttribute('position')
+  const normAttr = geometry.getAttribute('normal')
+  const vertexMap: Record<string, Vector3[]> = {}
+
+  // find all the normals shared by commonly located vertices
+  for (let i = 0, l = posAttr.count / 3; i < l; i += 1) {
+    const i3 = 3 * i
+    verts.forEach((vert, n) => vert.fromBufferAttribute(posAttr, i3 + n))
+    tempVec1.subVectors(verts[2], verts[1])
+    tempVec2.subVectors(verts[0], verts[1])
+
+    // add the normal to the map for all vertices
+    const normal = new Vector3().crossVectors(tempVec1, tempVec2).normalize()
+
+    verts.forEach((vert) => {
+      const hash = hashVertex(vert)
+      if (!vertexMap[hash]) {
+        vertexMap[hash] = []
+      }
+      vertexMap[hash]?.push(normal)
+    })
+  }
+
+  // average normals from all vertices that share a common location if they are within the
+  // provided crease threshold
+  for (let i = 0, l = posAttr.count / 3; i < l; i += 1) {
+    // get the face normal for this vertex
+    const i3 = 3 * i
+    verts.forEach((vert, n) => vert.fromBufferAttribute(posAttr, i3 + n))
+    tempVec1.subVectors(verts[2], verts[1])
+    tempVec2.subVectors(verts[0], verts[1])
+
+    tempNorm.crossVectors(tempVec1, tempVec2).normalize()
+
+    // average all normals that meet the threshold and set the normal value
+    verts.forEach((vert, n) => {
+      const hash = hashVertex(vert)
+      tempNorm2.set(0, 0, 0)
+
+      vertexMap[hash]?.forEach((otherNorm) => {
+        if (tempNorm.dot(otherNorm) > creaseDot) {
+          tempNorm2.add(otherNorm)
+        }
+      })
+
+      tempNorm2.normalize()
+      normAttr.setXYZ(i3 + n, tempNorm2.x, tempNorm2.y, tempNorm2.z)
+    })
+  }
+
+  geometry.setAttribute('normal', normAttr)
+  return geometry
+}

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -14,6 +14,7 @@ export { default as Disposables } from './components/Disposables/Disposables.sve
 export { default as ContactShadows } from './components/ContactShadows/ContactShadows.svelte'
 export { default as Environment } from './components/Environment/Environment.svelte'
 export { default as Grid } from './components/Grid/Grid.svelte'
+export { default as RoundedBoxGeometry } from './components/RoundedBoxGeometry/RoundedBoxGeometry.svelte'
 export { default as TransformControls } from './components/controls/TransformControls/TransformControls.svelte'
 export { default as OrbitControls } from './components/controls/OrbitControls/OrbitControls.svelte'
 export { default as InstancedMesh } from './components/Instancing/InstancedMesh.svelte'


### PR DESCRIPTION
### Overview

This PR is a ready-to-merge proposal for `<RoundedBoxGeometry>`, which I discovered I wanted while attempting a [Beatsaber clone](https://github.com/michealparks/threlte-xr/blob/main/src/routes/bonksaber/scene.svelte#L98). It is roughly a port of Drei's [`<RoundedBox>`](https://github.com/pmndrs/drei#roundedbox), but with the component only encapsulating the geometry instead of the mesh so that that instanced meshes may also be used 🎉 

Happy to change any APIs that can be improved and no worries if this doesn't make sense for `@threlte/extras`!