### PR TITLE
Performance: sort render and frame handlers when added instead of during each frame

### DIFF
--- a/.changeset/rude-guests-bathe.md
+++ b/.changeset/rude-guests-bathe.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Sort render and frame handlers on add instead of during each frame

--- a/.changeset/rude-guests-bathe.md
+++ b/.changeset/rude-guests-bathe.md
@@ -2,4 +2,4 @@
 '@threlte/core': patch
 ---
 
-Sort render and frame handlers on add instead of during each frame
+Sort render and frame handlers only when new ordered callbacks are introduced

--- a/packages/core/src/lib/hooks/useFrame.ts
+++ b/packages/core/src/lib/hooks/useFrame.ts
@@ -88,7 +88,7 @@ export const useFrame = (
     }
 
     renderCtx.allFrameHandlers.add(handler)
-    renderCtx.allFrameHandlersNeedSort = Array.from(renderCtx.allFrameHandlers).some((h) => h.order)
+    renderCtx.allFrameHandlersNeedSortCheck = true
 
     started.set(true)
   }

--- a/packages/core/src/lib/hooks/useFrame.ts
+++ b/packages/core/src/lib/hooks/useFrame.ts
@@ -87,19 +87,8 @@ export const useFrame = (
       renderCtx.manualFrameHandlers.add(handler)
     }
 
-    const anyHasOrder = Array.from(renderCtx.allFrameHandlers).reduce(
-      (acc, h) => (h.order ? true : acc),
-      false
-    )
-
-    if (anyHasOrder) {
-      const sorted = Array.from(renderCtx.allFrameHandlers)
-        .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
-      renderCtx.allFrameHandlers.clear()
-      sorted.forEach((handler) => renderCtx.allFrameHandlers.add(handler))
-    } else {
-      renderCtx.allFrameHandlers.add(handler)
-    }
+    renderCtx.allFrameHandlers.add(handler)
+    renderCtx.allFrameHandlersNeedSort = Array.from(renderCtx.allFrameHandlers).some((h) => h.order)
 
     started.set(true)
   }

--- a/packages/core/src/lib/hooks/useFrame.ts
+++ b/packages/core/src/lib/hooks/useFrame.ts
@@ -86,7 +86,20 @@ export const useFrame = (
     } else {
       renderCtx.manualFrameHandlers.add(handler)
     }
-    renderCtx.allFrameHandlers.add(handler)
+
+    const anyHasOrder = Array.from(renderCtx.allFrameHandlers).reduce(
+      (acc, h) => (h.order ? true : acc),
+      false
+    )
+
+    if (anyHasOrder) {
+      const sorted = Array.from(renderCtx.allFrameHandlers)
+        .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
+      renderCtx.allFrameHandlers.clear()
+      sorted.forEach((handler) => renderCtx.allFrameHandlers.add(handler))
+    } else {
+      renderCtx.allFrameHandlers.add(handler)
+    }
 
     started.set(true)
   }

--- a/packages/core/src/lib/hooks/useRender.ts
+++ b/packages/core/src/lib/hooks/useRender.ts
@@ -33,7 +33,19 @@ export const useRender = (
     order: options?.order
   }
 
-  renderCtx.renderHandlers.add(handler)
+  const anyHasOrder = Array.from(renderCtx.renderHandlers).reduce(
+    (acc, h) => (h.order ? true : acc),
+    false
+  )
+
+  if (anyHasOrder) {
+    const sorted = Array.from(renderCtx.renderHandlers)
+      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
+    renderCtx.renderHandlers.clear()
+    sorted.forEach((handler) => renderCtx.renderHandlers.add(handler)) 
+  } else {
+    renderCtx.renderHandlers.add(handler)
+  }
 
   onDestroy(() => {
     renderCtx.renderHandlers.delete(handler)

--- a/packages/core/src/lib/hooks/useRender.ts
+++ b/packages/core/src/lib/hooks/useRender.ts
@@ -33,19 +33,8 @@ export const useRender = (
     order: options?.order
   }
 
-  const anyHasOrder = Array.from(renderCtx.renderHandlers).reduce(
-    (acc, h) => (h.order ? true : acc),
-    false
-  )
-
-  if (anyHasOrder) {
-    const sorted = Array.from(renderCtx.renderHandlers)
-      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
-    renderCtx.renderHandlers.clear()
-    sorted.forEach((handler) => renderCtx.renderHandlers.add(handler)) 
-  } else {
-    renderCtx.renderHandlers.add(handler)
-  }
+  renderCtx.renderHandlers.add(handler)
+  renderCtx.renderHandlersNeedSort = Array.from(renderCtx.renderHandlers).some((h) => h.order)
 
   onDestroy(() => {
     renderCtx.renderHandlers.delete(handler)

--- a/packages/core/src/lib/hooks/useRender.ts
+++ b/packages/core/src/lib/hooks/useRender.ts
@@ -34,7 +34,7 @@ export const useRender = (
   }
 
   renderCtx.renderHandlers.add(handler)
-  renderCtx.renderHandlersNeedSort = Array.from(renderCtx.renderHandlers).some((h) => h.order)
+  renderCtx.renderHandlersNeedSortCheck = true
 
   onDestroy(() => {
     renderCtx.renderHandlers.delete(handler)

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -149,7 +149,9 @@ export const createContexts = (options: {
     manualFrameHandlers: new Set(),
     autoFrameHandlers: new Set(),
     allFrameHandlers: new Set(),
+    allFrameHandlersNeedSort: false,
     renderHandlers: new Set(),
+    renderHandlersNeedSort: false,
     advance: false,
     dispose: async (force = false) => {
       await tick()

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -67,7 +67,9 @@ export type ThrelteInternalContext = {
   manualFrameHandlers: Set<ThrelteFrameHandler>
   autoFrameHandlers: Set<ThrelteFrameHandler>
   allFrameHandlers: Set<ThrelteFrameHandler>
+  allFrameHandlersNeedSort: boolean
   renderHandlers: Set<ThrelteRenderHandler>
+  renderHandlersNeedSort: boolean
   advance: boolean
 
   /**

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -67,9 +67,9 @@ export type ThrelteInternalContext = {
   manualFrameHandlers: Set<ThrelteFrameHandler>
   autoFrameHandlers: Set<ThrelteFrameHandler>
   allFrameHandlers: Set<ThrelteFrameHandler>
-  allFrameHandlersNeedSort: boolean
+  allFrameHandlersNeedSortCheck: boolean
   renderHandlers: Set<ThrelteRenderHandler>
-  renderHandlersNeedSort: boolean
+  renderHandlersNeedSortCheck: boolean
   advance: boolean
 
   /**
@@ -149,9 +149,9 @@ export const createContexts = (options: {
     manualFrameHandlers: new Set(),
     autoFrameHandlers: new Set(),
     allFrameHandlers: new Set(),
-    allFrameHandlersNeedSort: false,
+    allFrameHandlersNeedSortCheck: false,
     renderHandlers: new Set(),
-    renderHandlersNeedSort: false,
+    renderHandlersNeedSortCheck: false,
     advance: false,
     dispose: async (force = false) => {
       await tick()

--- a/packages/core/src/lib/lib/startFrameloop.ts
+++ b/packages/core/src/lib/lib/startFrameloop.ts
@@ -7,12 +7,17 @@ const runUseFrameCallbacks = (
 ): void => {
   if (internalCtx.allFrameHandlers.size === 0) return
 
-  if (internalCtx.allFrameHandlersNeedSort) {
-    const sorted = Array.from(internalCtx.allFrameHandlers)
-      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
-    internalCtx.allFrameHandlers.clear()
-    sorted.forEach((h) => internalCtx.allFrameHandlers.add(h))
-    internalCtx.allFrameHandlersNeedSort = false
+  if (internalCtx.allFrameHandlersNeedSortCheck) {
+    const arr = Array.from(internalCtx.allFrameHandlers)
+    const needsSort = arr.some((h) => h.order)
+
+    if (needsSort) {
+      const sorted = arr.sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
+      internalCtx.allFrameHandlers.clear()
+      sorted.forEach((h) => internalCtx.allFrameHandlers.add(h))
+    }
+
+    internalCtx.allFrameHandlersNeedSortCheck = false
   }
 
   if (internalCtx.debugFrameloop) {
@@ -41,12 +46,17 @@ const runUseRenderCallbacks = (
 ): void => {
   if (internalCtx.renderHandlers.size === 0) return
 
-  if (internalCtx.renderHandlersNeedSort) {
-    const sorted = Array.from(internalCtx.renderHandlers)
-      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
-    internalCtx.renderHandlers.clear()
-    sorted.forEach((h) => internalCtx.renderHandlers.add(h))
-    internalCtx.renderHandlersNeedSort = false
+  if (internalCtx.renderHandlersNeedSortCheck) {
+    const arr = Array.from(internalCtx.renderHandlers)
+    const needsSort = arr.some((h) => h.order)
+
+    if (needsSort) {
+      const sorted = arr.sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
+      internalCtx.renderHandlers.clear()
+      sorted.forEach((h) => internalCtx.renderHandlers.add(h))
+    }
+
+    internalCtx.renderHandlersNeedSortCheck = false
   }
 
   internalCtx.renderHandlers.forEach((h) => h.fn(ctx, delta))

--- a/packages/core/src/lib/lib/startFrameloop.ts
+++ b/packages/core/src/lib/lib/startFrameloop.ts
@@ -23,17 +23,7 @@ const runUseFrameCallbacks = (
       internalCtx.invalidations['useFrame'] = internalCtx.autoFrameHandlers.size
   }
 
-  const anyHasOrder = Array.from(internalCtx.allFrameHandlers).reduce(
-    (acc, h) => (h.order ? true : acc),
-    false
-  )
-  if (anyHasOrder) {
-    Array.from(internalCtx.allFrameHandlers)
-      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
-      .forEach((h) => h.fn(ctx, delta))
-  } else {
-    internalCtx.allFrameHandlers.forEach((h) => h.fn(ctx, delta))
-  }
+  internalCtx.allFrameHandlers.forEach((h) => h.fn(ctx, delta))
 }
 
 const runUseRenderCallbacks = (
@@ -43,17 +33,7 @@ const runUseRenderCallbacks = (
 ): void => {
   if (internalCtx.renderHandlers.size === 0) return
 
-  const anyHasOrder = Array.from(internalCtx.renderHandlers).reduce(
-    (acc, h) => (h.order ? true : acc),
-    false
-  )
-  if (anyHasOrder) {
-    Array.from(internalCtx.renderHandlers)
-      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
-      .forEach((h) => h.fn(ctx, delta))
-  } else {
-    internalCtx.renderHandlers.forEach((h) => h.fn(ctx, delta))
-  }
+  internalCtx.renderHandlers.forEach((h) => h.fn(ctx, delta))
 }
 
 const debugFrame = (internalCtx: ThrelteInternalContext): void => {

--- a/packages/core/src/lib/lib/startFrameloop.ts
+++ b/packages/core/src/lib/lib/startFrameloop.ts
@@ -7,6 +7,14 @@ const runUseFrameCallbacks = (
 ): void => {
   if (internalCtx.allFrameHandlers.size === 0) return
 
+  if (internalCtx.allFrameHandlersNeedSort) {
+    const sorted = Array.from(internalCtx.allFrameHandlers)
+      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
+    internalCtx.allFrameHandlers.clear()
+    sorted.forEach((h) => internalCtx.allFrameHandlers.add(h))
+    internalCtx.allFrameHandlersNeedSort = false
+  }
+
   if (internalCtx.debugFrameloop) {
     let genericFrameHandlers = 0
     internalCtx.autoFrameHandlers.forEach((h) => {
@@ -32,6 +40,13 @@ const runUseRenderCallbacks = (
   delta: number
 ): void => {
   if (internalCtx.renderHandlers.size === 0) return
+
+  if (internalCtx.renderHandlersNeedSort) {
+    const sorted = Array.from(internalCtx.renderHandlers)
+      .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
+    internalCtx.renderHandlers.clear()
+    sorted.forEach((h) => internalCtx.renderHandlers.add(h))
+  }
 
   internalCtx.renderHandlers.forEach((h) => h.fn(ctx, delta))
 }

--- a/packages/core/src/lib/lib/startFrameloop.ts
+++ b/packages/core/src/lib/lib/startFrameloop.ts
@@ -46,6 +46,7 @@ const runUseRenderCallbacks = (
       .sort((a, b) => ((a.order ?? 0) > (b.order ?? 0) ? 1 : -1))
     internalCtx.renderHandlers.clear()
     sorted.forEach((h) => internalCtx.renderHandlers.add(h))
+    internalCtx.renderHandlersNeedSort = false
   }
 
   internalCtx.renderHandlers.forEach((h) => h.fn(ctx, delta))


### PR DESCRIPTION
### Overview

This PR contains a tiny optimization: it moves sorting of frame and render handlers out of the frame loop to only when these handlers are added to their respective `Set`. This change brings a few benefits:

* New arrays are not created on every frame with array methods that copy: `Array.from`, which may ease pressure a little on the garbage collector.
* Sorting is now "cached" and removed from a hot path. This probably doesn't matter much until many `useFrame` calls exist, but probably still worth doing.

As far as I can tell this doesn't change the behavior of the `order` param since it's only relevant to execution order of handlers, but I very well may have missed something important so calling that out!
 