### PR TITLE
Use three.js REVISION export for breaking api changes

### DIFF
--- a/.changeset/friendly-tigers-wait.md
+++ b/.changeset/friendly-tigers-wait.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Use three.js REVISION export for breaking api changes

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -1,6 +1,7 @@
 import { onDestroy } from 'svelte'
 import { writable } from 'svelte/store'
 import {
+  REVISION,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   ColorManagement,
@@ -109,21 +110,21 @@ export const useRenderer = (ctx: ThrelteContext) => {
       } else if (shadows === true) {
         renderer.shadowMap.type = PCFSoftShadowMap
       }
+
+      const revision = Number.parseInt(REVISION)
       const cm = ColorManagement as any
-      if (cm.enabled !== undefined) {
+      if (revision >= 150) {
         // since three.js r150 the color management prop is
         // called "enabled", but the types are not up to date :/
         cm.enabled = colorManagementEnabled
-      } else if (cm.legacyMode !== undefined) {
+      } else {
         cm.legacyMode = !colorManagementEnabled
       }
 
       const anyRenderer = renderer as any
-      // > r150
-      if (useLegacyLights && anyRenderer.useLegacyLights !== undefined) {
+      if (revision >= 150 && useLegacyLights) {
         anyRenderer.useLegacyLights = useLegacyLights
-      } else if (anyRenderer.physicallyCorrectLights !== undefined) {
-        // < r150
+      } else if (revision < 150) {
         anyRenderer.physicallyCorrectLights = !useLegacyLights
       }
     }

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -111,7 +111,8 @@ export const useRenderer = (ctx: ThrelteContext) => {
         renderer.shadowMap.type = PCFSoftShadowMap
       }
 
-      const revision = Number.parseInt(REVISION)
+      // REVISION can be '{number}' or '{number}dev'
+      const revision = Number.parseInt(REVISION.replace('dev', ''))
       const cm = ColorManagement as any
       if (revision >= 150) {
         // since three.js r150 the color management prop is


### PR DESCRIPTION
This PR is a small quality-of-life tweak: it updates Threlte to use the three.js `REVISION` export to decide which properties to use if a breaking change has happened in a past revision. Properties are currently accessed if they aren't undefined, which can still cause deprecation warnings in the console:

<img width="315" alt="Screenshot 2023-07-21 at 11 28 36 AM" src="https://github.com/threlte/threlte/assets/3834780/a0def28e-94a9-4180-af4a-55b677ec7764">

This can be confusing or distracting to developers. By using `REVISION` these warnings are no more! 🎉 