### PR TITLE
Add LOD documentation for Threlte 6

### DIFF
--- a/apps/docs-next/src/content/examples/geometry/LOD.mdx
+++ b/apps/docs-next/src/content/examples/geometry/LOD.mdx
@@ -1,0 +1,38 @@
+---
+category: Geometry
+title: LOD in Threlte
+showInSidebar: false
+---
+
+This is a practical example showing a best-practice method of implementing LOD in Threlte. The example is a great demonstration of the power of [ref](../../reference/core/t) bindings.
+
+This is an adaption of Three.js [own documentation](https://threejs.org/docs/#api/en/objects/LOD), and therefore it's also a great way to learn how to translate what you already know how to do with imperative three.js, into declerative Threlte code.
+
+<Example path="geometry/LOD" />
+
+### How does it work
+
+1. First `<T>` creates the geometry and material
+2. Then it attaches those to the mesh
+3. `on:create` will run later, but we remember to use a reference to the mesh itself `ref` and a reference `lod` to the parent LOD object.
+
+... which happens 3 times due to the `#each` block
+
+```svelte
+<T.LOD let:ref={lod}>
+  {#each ["red","green","blue"] as color, i}
+    <T.Mesh
+      on:create={ ({ref}) => {
+        lod.addLevel(ref, i * 75) // i * 75 = distance
+      }}
+    >
+      <T.IcosahedronGeometry args={[10, 3-i]} />
+      <T.MeshStandardMaterial {color} wireframe />
+    </T.Mesh>
+  {/each}
+</T.LOD>
+```
+
+5. `<T>` now creates the LOD parent and internally calls the three.js function `lod.add(child)` on each mesh, since they are defined inside the `<T.LOD>` object.
+6. However, in three.js we need the `lod.addLevel(child, distance)` as well to register the children as LOD levels and not just attached children.
+7. This is where our `on:create` function comes in - upon creation of each mesh, we are able to call `lod.addLevel(child, distance)`

--- a/apps/docs-next/src/examples/geometry/LOD/App.svelte
+++ b/apps/docs-next/src/examples/geometry/LOD/App.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { Canvas } from '@threlte/core'
+	import Scene from './Scene.svelte'
+	import { useTweakpane } from '../../utils/useTweakpane'
+
+	let reset: (() => void) | undefined
+
+	const { action, addButton } = useTweakpane()
+
+	addButton({
+		title: 'Reset Camera',
+		onClick: () => {
+			reset?.()
+		}
+	})
+</script>
+
+<div use:action />
+
+<Canvas>
+	<Scene bind:reset />
+</Canvas>

--- a/apps/docs-next/src/examples/geometry/LOD/Scene.svelte
+++ b/apps/docs-next/src/examples/geometry/LOD/Scene.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { T, useThrelte } from '@threlte/core'
+  import { OrbitControls } from '@threlte/extras'
+
+  let controls
+  export const reset = () => controls.reset()
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[0,0,25]}
+  lookAt.y={0}
+>
+  <OrbitControls enableZoom={true} bind:ref={controls} />
+</T.PerspectiveCamera>
+
+<T.DirectionalLight position={[3, 10, 10]} />
+<T.HemisphereLight intensity={0.2} />
+
+<T.LOD let:ref={lod}>
+  {#each ["red","green","blue"] as color, i}
+    <T.Group on:create={({ref}) => {
+      lod.addLevel(ref, i*75)
+    }}>
+      <T.Mesh>
+        <T.IcosahedronGeometry args={[10,3-i]} />
+        <T.MeshStandardMaterial {color} wireframe />
+      </T.Mesh>
+      <T.Mesh>
+        <T.IcosahedronGeometry args={[10,3-i]} />
+        <T.MeshStandardMaterial {color} transparent opacity={0.3} />
+      </T.Mesh>
+    </T.Group>
+  {/each}
+</T.LOD>


### PR DESCRIPTION
I was able to easily understand the three.js documentation on LODs, but i found it quite hard to implement LODs in Threlte without shooting myself in the foot. After diving deeper into how Threlte really works though, i was able to figure it out, but it was far from immediately obvious for someone new to the declarative way of thinking.

I looked in the documentation examples, but they all seemed very ambitious - which is great- but i was lacking some simpler examples to really make me understand how refs work in Threlte.

So - I created a really nice example for LODs, and the best practice to do them in Threlte in a declarative way.

This is basically the snippet, but the documentation i added goes into greater detail, and explaining what Threlte is really doing on the hood, and how it relates to the original three.js documentation on LODs.

```svelte
<T.LOD let:ref={lod}>
  {#each ["red","green","blue"] as color, i}
    <T.Mesh
      on:create={ ({ref}) => {
        lod.addLevel(ref, i * 75) // i * 75 = distance
      }}
    >
      <T.IcosahedronGeometry args={[10, 3-i]} />
      <T.MeshStandardMaterial {color} wireframe />
    </T.Mesh>
  {/each}
</T.LOD>
```

<img width="1440" alt="image" src="https://github.com/threlte/threlte/assets/33785363/b33ac6b0-db8b-4073-a8b7-3d22e95ae774">
