### PR TITLE
Canvas resize observer

### DIFF
--- a/.changeset/quiet-chairs-grow.md
+++ b/.changeset/quiet-chairs-grow.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Use a resize observer for handling parent size

--- a/packages/core/src/lib/hooks/useParentSize.ts
+++ b/packages/core/src/lib/hooks/useParentSize.ts
@@ -20,7 +20,7 @@ export const useParentSize = (): {
   // Only observe childList changes of the parent
   const mutationOptions = { childList: true, subtree: false, attributes: false }
 
-  let el: HTMLElement
+  let el: HTMLElement | undefined
 
   const observeParent = (parent: HTMLElement) => {
     resizeObserver.disconnect()

--- a/packages/core/src/lib/hooks/useParentSize.ts
+++ b/packages/core/src/lib/hooks/useParentSize.ts
@@ -17,6 +17,7 @@ export const useParentSize = (): {
     }
   }
 
+  // Only observe childList changes of the parent
   const mutationOptions = { childList: true, subtree: false, attributes: false }
 
   let el: HTMLElement
@@ -28,6 +29,7 @@ export const useParentSize = (): {
     mutationObserver.observe(parent, mutationOptions)
   }
 
+  // The canvas should match the contentRect of its parent
   const resizeObserver = new ResizeObserver(([entry]) => {
     const { contentRect } = entry
 
@@ -38,6 +40,7 @@ export const useParentSize = (): {
     })
   })
 
+  // Use a mutation observer to detect reparenting
   const mutationObserver = new MutationObserver((mutationsList) => {
     for (const mutation of mutationsList) {
       for (const node of mutation.removedNodes) {

--- a/packages/core/src/lib/hooks/useParentSize.ts
+++ b/packages/core/src/lib/hooks/useParentSize.ts
@@ -13,7 +13,9 @@ export const useParentSize = (): {
   if (!browser) {
     return {
       parentSize,
-      parentSizeAction: () => { /* do nothing */ }
+      parentSizeAction: () => {
+        /* do nothing */
+      }
     }
   }
 
@@ -65,6 +67,6 @@ export const useParentSize = (): {
 
   return {
     parentSize,
-    parentSizeAction,
+    parentSizeAction
   }
 }


### PR DESCRIPTION
This PR moves from using an `onresize` listener to a `ResizeObserver` in the `useParentSize` hook. A `MutationObserver` was added to the parent to account for reparenting. Let me know if there are any issues with this solution and I can update it 😎 

Note: there is still one case that I don't think this handles: if a user removes the canvas, waits some period of time, and then re-adds it to the document. I can't think of a clean browser API that handles this. Polling the canvas for a parent or adding a mutation observer to the entire document are solutions I can think of but seem potentially expensive.