### PR TITLE
Remove optional type for renderer

### DIFF
--- a/.changeset/fresh-dancers-protect.md
+++ b/.changeset/fresh-dancers-protect.md
@@ -1,0 +1,8 @@
+---
+'@threlte/extras': patch
+'@threlte/rapier': patch
+'@threlte/core': patch
+'@threlte/docs': patch
+---
+
+Remove optional type for renderer

--- a/apps/docs/src/components/Hero/PostProcessing.svelte
+++ b/apps/docs/src/components/Hero/PostProcessing.svelte
@@ -48,8 +48,6 @@
 
   const { renderer, scene, camera } = useThrelte()
 
-  if (!renderer) throw new Error('No renderer')
-
   const composer = new EffectComposer(renderer)
 
   const setup = () => {

--- a/apps/docs/src/content/reference/core/use-threlte.mdx
+++ b/apps/docs/src/content/reference/core/use-threlte.mdx
@@ -39,7 +39,7 @@ const {
   clock, // Clock
   camera, // CurrentWritable<THREE.Camera>
   scene, // THREE.Scene
-  renderer, // THREE.WebGLRenderer | undefined
+  renderer, // THREE.WebGLRenderer
   invalidate, // (debugFrameloopMessage?: string) => void
   advance, // () => void
   colorSpace, // CurrentWritable<THREE.ColorSpace>

--- a/apps/docs/src/examples/camera/pointer-lock-controls/Player.svelte
+++ b/apps/docs/src/examples/camera/pointer-lock-controls/Player.svelte
@@ -25,7 +25,6 @@
   const lockControls = () => lock()
 
   const { renderer } = useThrelte()
-  if (!renderer) throw new Error()
 
   renderer.domElement.addEventListener('click', lockControls)
 

--- a/apps/docs/src/examples/camera/pointer-lock-controls/PointerLockControls.svelte
+++ b/apps/docs/src/examples/camera/pointer-lock-controls/PointerLockControls.svelte
@@ -12,7 +12,7 @@
   let isLocked = false
 
   const { renderer, invalidate } = useThrelte()
-  if (!renderer) throw new Error()
+
   const domElement = renderer.domElement
   const camera = useParent()
   const dispatch = createEventDispatcher()

--- a/apps/docs/src/examples/camera/third-person-camera/Player.svelte
+++ b/apps/docs/src/examples/camera/third-person-camera/Player.svelte
@@ -22,9 +22,6 @@
   let left = 0
   let right = 0
 
-  const { renderer } = useThrelte()
-  if (!renderer) throw new Error()
-
   const temp = new Vector3()
   const dispatch = createEventDispatcher()
 

--- a/apps/docs/src/examples/camera/third-person-camera/ThirdPersonControls.svelte
+++ b/apps/docs/src/examples/camera/third-person-camera/ThirdPersonControls.svelte
@@ -39,15 +39,11 @@
   const rotationQuat = new Quaternion()
 
   const { renderer, invalidate } = useThrelte()
-  if (!renderer) throw new Error()
 
   const domElement = renderer.domElement
   const camera = useParent()
 
   const dispatch = createEventDispatcher()
-
-  if (!renderer)
-    throw new Error('Threlte Context missing: Is <PointerLockControls> a child of <Canvas>?')
 
   const isCamera = (p: any): p is Camera => {
     return p.isCamera

--- a/apps/docs/src/examples/core/t/Scene.svelte
+++ b/apps/docs/src/examples/core/t/Scene.svelte
@@ -14,5 +14,5 @@
 <T.DirectionalLight position.y={5} position.x={3} />
 
 <T.PerspectiveCamera makeDefault let:ref={camera} position.y={10} position.x={10}>
-	<T.OrbitControls args={[camera, renderer?.domElement]} on:change={invalidate} />
+	<T.OrbitControls args={[camera, renderer.domElement]} on:change={invalidate} />
 </T.PerspectiveCamera>

--- a/apps/docs/src/examples/core/three-arcade-game/ArcadeMachineScene.svelte
+++ b/apps/docs/src/examples/core/three-arcade-game/ArcadeMachineScene.svelte
@@ -216,7 +216,9 @@
   $: backgroundColor.set($machineIsOff ? new Color('#020203') : new Color('#020203'))
 
   const { scene, renderer } = useThrelte()
-  if (renderer) renderer.physicallyCorrectLights = true
+  
+  renderer.useLegacyLights = false
+
   $: scene.background = new Color($backgroundColor)
 
   const blueLightIntensity = tweened(2, {
@@ -276,7 +278,7 @@
     >
       <T
         is={OrbitControls}
-        args={[camera, renderer?.domElement]}
+        args={[camera, renderer.domElement]}
       />
     </T.PerspectiveCamera>
   {:else}

--- a/apps/docs/src/examples/core/three-arcade-game/MainScenePostProcessing.svelte
+++ b/apps/docs/src/examples/core/three-arcade-game/MainScenePostProcessing.svelte
@@ -76,7 +76,7 @@
     )
   }
 
-  $: if (renderer && $camera && $arcadeMachineScene) {
+  $: if ($camera && $arcadeMachineScene) {
     addComposerAndPasses()
   }
   onDestroy(() => {

--- a/apps/docs/src/examples/core/three-arcade-game/game/GameSceneRendering.svelte
+++ b/apps/docs/src/examples/core/three-arcade-game/game/GameSceneRendering.svelte
@@ -51,7 +51,7 @@
 	let renderEvery = 2
 	useFrame(() => {
 		frame += 1
-		if (!renderer || !$gameScene || !$gameCamera || frame % renderEvery !== 0) return
+		if (!$gameScene || !$gameCamera || frame % renderEvery !== 0) return
 		renderer.setRenderTarget(gameRenderTarget)
 		renderer.clear()
 		renderer.render($gameScene, $gameCamera)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "author": "Grischa Erbe <hello@legrisch.com> (https://legrisch.com)",
   "license": "MIT",
   "scripts": {
+    "dev": "vite dev",
     "package": "svelte-kit sync && svelte-package && node ./scripts/cleanupPackage.js && publint",
     "prepare": "svelte-kit sync",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/packages/core/src/app.html
+++ b/packages/core/src/app.html
@@ -2,11 +2,11 @@
 <html lang="en">
 
 <head>
-  %svelte.head%
+  %sveltekit.head%
 </head>
 
 <body>
-  %svelte.body%
+  %sveltekit.body%
 </body>
 
 </html>

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -110,7 +110,9 @@
 
   onDestroy(() => {
     contexts.internalCtx.dispose(true)
-    contexts.ctx.renderer?.setAnimationLoop(null)
+
+    // Renderer is marked as optional because it is never defined in SSR
+    contexts.ctx.renderer?.dispose()
   })
 </script>
 

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -110,7 +110,7 @@
 
   onDestroy(() => {
     contexts.internalCtx.dispose(true)
-    contexts.ctx.renderer.setAnimationLoop(null)
+    contexts.ctx.renderer?.setAnimationLoop(null)
   })
 </script>
 

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -61,7 +61,7 @@
    */
   export let useLegacyLights: boolean = true
 
-  let canvas: HTMLCanvasElement | undefined
+  let canvas: HTMLCanvasElement
   let initialized = false
 
   // user size as a store
@@ -103,7 +103,6 @@
   const { createRenderer } = useRenderer(ctx)
 
   onMount(() => {
-    if (!canvas) return
     createRenderer(canvas, rendererParameters)
     startFrameloop(contexts.ctx, contexts.internalCtx)
     initialized = true
@@ -111,7 +110,7 @@
 
   onDestroy(() => {
     contexts.internalCtx.dispose(true)
-    contexts.ctx.renderer?.setAnimationLoop(null)
+    contexts.ctx.renderer.setAnimationLoop(null)
   })
 </script>
 

--- a/packages/core/src/lib/hooks/useThrelte.ts
+++ b/packages/core/src/lib/hooks/useThrelte.ts
@@ -4,8 +4,8 @@ import type { ThrelteContext } from '../lib/contexts'
 export const useThrelte = (): ThrelteContext => {
   const context = getContext<ThrelteContext>('threlte')
 
-  if (context.renderer === undefined) {
-    throw new Error('WebGLRenderer is undefined, is this component a child of <Canvas>?')
+  if (context === undefined) {
+    throw new Error('No Threlte context found, are you using this hook inside of <Canvas>?')
   }
 
   return context

--- a/packages/core/src/lib/hooks/useThrelte.ts
+++ b/packages/core/src/lib/hooks/useThrelte.ts
@@ -2,5 +2,11 @@ import { getContext } from 'svelte'
 import type { ThrelteContext } from '../lib/contexts'
 
 export const useThrelte = (): ThrelteContext => {
-  return getContext<ThrelteContext>('threlte')
+  const context = getContext<ThrelteContext>('threlte')
+
+  if (context.renderer === undefined) {
+    throw new Error('WebGLRenderer is undefined, is this component a child of <Canvas>?')
+  }
+
+  return context
 }

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -31,7 +31,7 @@ export type ThrelteContext = {
   useLegacyLights: CurrentWritable<boolean>
 
   // Rendering Management
-  renderer?: WebGLRenderer
+  renderer: WebGLRenderer
   frameloop: CurrentWritable<'always' | 'demand' | 'never'>
   /**
    * Invalidates the current frame when frameloop === 'demand'
@@ -213,7 +213,7 @@ export const createContexts = (options: {
     clock: new Clock(),
     camera: currentWritable(createDefaultCamera()),
     scene: new Scene(),
-    renderer: undefined,
+    renderer: undefined!,
     invalidate: (debugFrameloopMessage?: string) => {
       internalCtx.frameInvalidated = true
       if (internalCtx.debugFrameloop && debugFrameloopMessage) {

--- a/packages/core/src/lib/lib/startFrameloop.ts
+++ b/packages/core/src/lib/lib/startFrameloop.ts
@@ -93,7 +93,7 @@ const shouldRender = (ctx: ThrelteContext, internalCtx: ThrelteInternalContext) 
  * A global delta is calculated and passed to all `useFrame` and `useRender` callbacks.
  */
 export const startFrameloop = (ctx: ThrelteContext, internalCtx: ThrelteInternalContext): void => {
-  ctx.renderer?.setAnimationLoop(() => {
+  ctx.renderer.setAnimationLoop(() => {
     // dispose all objects that are due to be disposed
     internalCtx.dispose()
 
@@ -109,7 +109,7 @@ export const startFrameloop = (ctx: ThrelteContext, internalCtx: ThrelteInternal
     if (internalCtx.renderHandlers.size > 0) {
       // run all useRender callbacks, or …
       runUseRenderCallbacks(ctx, internalCtx, delta)
-    } else if (ctx.renderer && ctx.camera.current) {
+    } else if (ctx.camera.current) {
       // … render the scene with the default renderer
       ctx.renderer.render(ctx.scene, ctx.camera.current)
     }

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -132,7 +132,7 @@ export const useRenderer = (ctx: ThrelteContext) => {
   )
 
   onDestroy(() => {
-    ctx.renderer?.dispose()
+    ctx.renderer.dispose()
   })
 
   return {

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -132,7 +132,7 @@ export const useRenderer = (ctx: ThrelteContext) => {
   )
 
   onDestroy(() => {
-    ctx.renderer.dispose()
+    ctx.renderer?.dispose()
   })
 
   return {

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -1,4 +1,3 @@
-import { onDestroy } from 'svelte'
 import { writable } from 'svelte/store'
 import {
   REVISION,
@@ -130,10 +129,6 @@ export const useRenderer = (ctx: ThrelteContext) => {
       }
     }
   )
-
-  onDestroy(() => {
-    ctx.renderer?.dispose()
-  })
 
   return {
     createRenderer

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1,14 +1,7 @@
 <script lang='ts'>
   import { T, Canvas } from '$lib'
-
-  let mount = false
-
-  setInterval(() => {
-    mount = !mount
-  }, 1000)
 </script>
 
-{#if mount}
 <main>
   <Canvas>
     <T.PerspectiveCamera
@@ -24,7 +17,6 @@
     <T.AmbientLight />
   </Canvas>
 </main>
-{/if}
 
 <style>
   main {

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1,7 +1,14 @@
 <script lang='ts'>
   import { T, Canvas } from '$lib'
+
+  let mount = false
+
+  setInterval(() => {
+    mount = !mount
+  }, 1000)
 </script>
 
+{#if mount}
 <main>
   <Canvas>
     <T.PerspectiveCamera
@@ -17,6 +24,7 @@
     <T.AmbientLight />
   </Canvas>
 </main>
+{/if}
 
 <style>
   main {

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1,3 +1,25 @@
-<!-- Chirping -->
+<script lang='ts'>
+  import { T, Canvas } from '$lib'
+</script>
 
-<h1>Hello World</h1>
+<main>
+  <Canvas>
+    <T.PerspectiveCamera
+      makeDefault
+      position={[3, 3, 3]}
+      on:create={({ ref }) => ref.lookAt(0, 0, 0)}
+    />
+    <T.Mesh>
+      <T.MeshStandardMaterial color='hotpink' />
+      <T.BoxGeometry />
+    </T.Mesh>
+    <T.DirectionalLight />
+    <T.AmbientLight />
+  </Canvas>
+</main>
+
+<style>
+  main {
+    height: 100vh;
+  }
+</style>

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -1,11 +1,12 @@
 import { resolve } from 'path'
 import { threeMinifier } from '@yushijinhun/three-minifier-rollup'
+import { sveltekit } from '@sveltejs/kit/vite'
 
 /**
  * @type {import('vite').UserConfig}
  */
 const config = {
-  plugins: [{ ...threeMinifier(), enforce: 'pre' }],
+  plugins: [sveltekit(), { ...threeMinifier(), enforce: 'pre' }],
   resolve: {
     alias: {
       threlte: resolve('./src/lib')

--- a/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
+++ b/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
@@ -38,10 +38,6 @@
   export let depthWrite: NonNullable<$$Props['depthWrite']> = false
 
   const { scene, renderer } = useThrelte()
-  if (!renderer)
-    throw new Error(
-      'ContactShadow: WebGLRenderer is undefined, is this component a child of <Canvas>?'
-    )
 
   const scaledWidth = useMemo(() => {
     return width * (Array.isArray(scale) ? scale[0] : scale || 1)

--- a/packages/extras/src/lib/components/Environment/Environment.svelte
+++ b/packages/extras/src/lib/components/Environment/Environment.svelte
@@ -28,7 +28,7 @@
 
   const isScene = (obj: any): obj is Scene => !!obj.isScene
 
-  const { scene: globalScene, invalidate, renderer } = useThrelte()
+  const { scene: globalScene, invalidate } = useThrelte()
   const parent = useParent()
   let scene = globalScene
   if (isScene($parent)) scene = $parent
@@ -57,10 +57,6 @@
   const { remember } = useCache()
 
   const loadEnvironment = async () => {
-    if (!renderer)
-      throw new Error(
-        'Threlte renderer undefined. Component <Environment/> must be a descendant of <Canvas/>.'
-      )
     const LoaderType = pickLoader()
     const loader: any = new LoaderType()
     loader.setDataType?.(FloatType)

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -301,10 +301,6 @@
   }
 
   const portalAction = (el: HTMLElement) => {
-    if (!renderer) {
-      console.warn('HTML: renderer is undefined. Is this component a child to <Canvas>?')
-      return
-    }
     const target = portal ?? renderer.domElement.parentElement
     if (!target) {
       console.warn('HTML: target is undefined.')

--- a/packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte
+++ b/packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte
@@ -21,8 +21,6 @@
 
   const { renderer, invalidate } = useThrelte()
 
-  if (!renderer) throw new Error('Threlte Context missing: Is <OrbitControls> a child of <Canvas>?')
-
   if (!isCamera($parent)) {
     throw new Error('Parent missing: <OrbitControls> need to be a child of a <Camera>')
   }

--- a/packages/extras/src/lib/components/controls/TransformControls/TransformControls.svelte
+++ b/packages/extras/src/lib/components/controls/TransformControls/TransformControls.svelte
@@ -51,12 +51,6 @@
     }
   )
 
-  if (!renderer) {
-    throw new Error(
-      'TransformControls: renderer is undefined, is this component a child of <Canvas>?'
-    )
-  }
-
   export const group = new Group()
 
   const controlsStore = derived(camera, (camera) => {

--- a/packages/extras/src/lib/hooks/useGltf.ts
+++ b/packages/extras/src/lib/hooks/useGltf.ts
@@ -71,7 +71,7 @@ export function useGltf<
         loader.setMeshoptDecoder(MeshoptDecoder)
       }
 
-      if (opts?.ktxTranscoderPath && renderer) {
+      if (opts?.ktxTranscoderPath) {
         const ktx2Loader = new KTX2Loader()
         ktx2Loader.setTranscoderPath(opts?.ktxTranscoderPath)
         ktx2Loader.detectSupport(renderer)

--- a/packages/extras/src/lib/interactivity/index.ts
+++ b/packages/extras/src/lib/interactivity/index.ts
@@ -17,7 +17,7 @@ const interactivity = (options?: InteractivityOptions) => {
     initialHits: [],
     hovered: new Map(),
     interactiveObjects: [],
-    target: currentWritable(options?.target ?? useThrelte().renderer?.domElement),
+    target: currentWritable(options?.target ?? useThrelte().renderer.domElement),
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     compute: () => {}, // will be replaced by the default or the user-provided function
     filter: options?.filter

--- a/packages/rapier/src/lib/recipes/BasicPlayerController.svelte
+++ b/packages/rapier/src/lib/recipes/BasicPlayerController.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
-  import { createRawEventDispatcher, T, useFrame, useThrelte } from '@threlte/core'
+  import { createRawEventDispatcher, T, useFrame } from '@threlte/core'
   import { Vector2, Vector3 } from 'three'
   import Collider from '../components/Colliders/Collider.svelte'
   import CollisionGroups from '../components/CollisionGroups/CollisionGroups.svelte'
@@ -16,9 +16,6 @@
   export let groundCollisionGroups: CollisionGroupsBitMask = [15]
 
   let rigidBody: RapierRigidBody
-
-  const { renderer } = useThrelte()
-  if (!renderer) throw new Error()
 
   type Keys = 'left' | 'right' | 'down' | 'up'
 


### PR DESCRIPTION
This PR changes the type of `renderer` returned by the `useThrelte` hook to be non-optional.

I noticed that a few components in extras were throwing errors with messages if `renderer` was undefined, so I instead moved this error into the `useThrelte` hook itself:

```ts
export const useThrelte = (): ThrelteContext => {
  const context = getContext<ThrelteContext>('threlte')

  if (context.renderer === undefined) {
    throw new Error('WebGLRenderer is undefined, is this component a child of <Canvas>?')
  }

  return context
}
```

This should make it so that users still get clear feedback if they accidentally use this hook outside of the `<Canvas>` component.