### PR TITLE
Fix @threlte/core useRender postprocessing example

### DIFF
--- a/apps/docs/src/content/reference/core/use-render.mdx
+++ b/apps/docs/src/content/reference/core/use-render.mdx
@@ -62,7 +62,7 @@ This example demonstrates how to use `useRender` to implement post processing ef
     KernelSize
   } from 'postprocessing'
 
-  const { scene, renderer, camera } = useThrelte()
+  const { scene, renderer, camera, size } = useThrelte()
 
   // To use the EffectComposer we need to pass arguments to the
   // default WebGLRenderer: https://github.com/pmndrs/postprocessing#usage
@@ -97,6 +97,7 @@ This example demonstrates how to use `useRender` to implement post processing ef
 
   // We need to set up the passes according to the camera in use
   $: setupEffectComposer($camera)
+  $: composer.setSize($size.width, $size.height)
 
   useRender((_, delta) => {
     composer.render(delta)

--- a/apps/docs/src/examples/core/use-render/Scene.svelte
+++ b/apps/docs/src/examples/core/use-render/Scene.svelte
@@ -10,7 +10,7 @@
   } from 'postprocessing'
   import { DEG2RAD } from 'three/src/math/MathUtils'
 
-  const { renderer, scene, camera } = useThrelte()
+  const { renderer, scene, camera, size } = useThrelte()
 
   const composer = new EffectComposer(renderer)
 
@@ -38,6 +38,8 @@
       invalidate: true
     }
   )
+
+  $: composer.setSize($size.width, $size.height)
 
   useRender(() => {
     composer.render()


### PR DESCRIPTION
Not sure if the example in apps/docs/src/examples/core/use-render is being used. 😅