### PR TITLE
Theatre import fix

### DIFF
--- a/.changeset/blue-beds-lay.md
+++ b/.changeset/blue-beds-lay.md
@@ -1,0 +1,5 @@
+---
+'@threlte/theatre': patch
+---
+
+fix: imported theatre/core from own named exports

--- a/packages/theatre/scripts/tsconfig.json
+++ b/packages/theatre/scripts/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": [
-      "node"
-    ]
-  },
+    "types": ["node"]
+  }
 }

--- a/packages/theatre/src/app.html
+++ b/packages/theatre/src/app.html
@@ -1,12 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    %sveltekit.head%
+  </head>
 
-<head>
-  %sveltekit.head%
-</head>
-
-<body>
-  %sveltekit.body%
-</body>
-
+  <body>
+    %sveltekit.body%
+  </body>
 </html>

--- a/packages/theatre/src/lib/sequence/Sequence.svelte
+++ b/packages/theatre/src/lib/sequence/Sequence.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { IRafDriver, ISequence } from '@theatre/core'
-  import { getContext, onDestroy, onMount, setContext } from 'svelte'
+  import { getContext, onDestroy, setContext } from 'svelte'
   import type { SheetContext } from '../sheet/types'
   import type {
     Autoreset,

--- a/packages/theatre/src/lib/sequence/SequenceController.ts
+++ b/packages/theatre/src/lib/sequence/SequenceController.ts
@@ -1,8 +1,7 @@
-import { onChange, val, type ISequence } from '@theatre/core'
-
-import { get } from 'svelte/store'
+import type { ISequence } from '@theatre/core'
 import type { Readable, Subscriber, Writable } from 'svelte/store'
-
+import { get } from 'svelte/store'
+import { onChange, val } from '../theatre'
 import type { SequenceOptions } from './types'
 
 /**
@@ -20,10 +19,7 @@ export class SequenceController {
   private options: SequenceOptions
   private sequence: ISequence
 
-  constructor(
-    sequence: ISequence,
-    options: SequenceOptions = {}
-  ) {
+  constructor(sequence: ISequence, options: SequenceOptions = {}) {
     // api
     this.key = options?.key ?? 'default' // not in use - for future proofing
     this.sequence = sequence // theatre native object
@@ -37,7 +33,6 @@ export class SequenceController {
     this.play = this.play.bind(this)
     this.pause = this.pause.bind(this)
     this.reset = this.reset.bind(this)
-
   }
   public config(options: SequenceOptions): void {
     // update options

--- a/packages/theatre/src/lib/sheetObject/sync/Sync.svelte.d.ts
+++ b/packages/theatre/src/lib/sheetObject/sync/Sync.svelte.d.ts
@@ -2,7 +2,7 @@ import type { SvelteComponent } from 'svelte'
 import type { Transformer } from '../transfomers/types'
 import type { ConditionalKeys, Primitive } from 'type-fest'
 
-/* COPIED FROM @theatre/core START */
+/* COPIED FROM @threlte/core START */
 type OmittedPropKeys =
   | 'type'
   | 'args'
@@ -36,7 +36,7 @@ type InstanceProps<Type extends any> = Partial<
     ConditionalKeys<MaybeInstance<Type>, AnyFn> | OmittedPropKeys
   >
 >
-/* COPIED FROM @theatre/core END */
+/* COPIED FROM @threlte/core END */
 
 type ObjectProp<T> = {
   type?: T

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/color.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/color.ts
@@ -1,4 +1,4 @@
-import { types } from '@theatre/core'
+import { types } from '../../../theatre'
 import { createTransformer } from '../createTransformer'
 
 export const color = createTransformer({

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/degrees.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/degrees.ts
@@ -1,6 +1,6 @@
 import { DEG2RAD, RAD2DEG } from 'three/src/math/MathUtils'
 import { createTransformer } from '../createTransformer'
-import { types } from '@theatre/core'
+import { types } from '../../../theatre'
 
 export const degrees = createTransformer({
   transform(target) {

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/euler.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/euler.ts
@@ -1,6 +1,6 @@
-import { types } from '@theatre/core'
 import { DEG2RAD, RAD2DEG } from 'three/src/math/MathUtils'
 import { createTransformer } from '../createTransformer'
+import { types } from '../../../theatre'
 
 export const euler = createTransformer({
   transform(value) {

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/generic.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/generic.ts
@@ -1,4 +1,4 @@
-import { types } from '@theatre/core'
+import { types } from '../../../theatre'
 import { isPrimitive } from '../../sync/utils/isPrimitive'
 import { createTransformer } from '../createTransformer'
 

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/normalized.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/normalized.ts
@@ -1,4 +1,4 @@
-import { types } from '@theatre/core'
+import { types } from '../../../theatre'
 import { createTransformer } from '../createTransformer'
 
 export const normalized = createTransformer({

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/side.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/side.ts
@@ -1,4 +1,4 @@
-import { types } from '@theatre/core'
+import { types } from '../../../theatre'
 import { createTransformer } from '../createTransformer'
 import { BackSide, DoubleSide, FrontSide } from 'three'
 

--- a/packages/theatre/src/lib/sheetObject/transform/Transform.svelte
+++ b/packages/theatre/src/lib/sheetObject/transform/Transform.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { types, type ISheetObject, type UnknownShorthandCompoundProps } from '@theatre/core'
+  import { types } from '../../theatre'
+  import type { ISheetObject, UnknownShorthandCompoundProps } from '@theatre/core'
   import type { IScrub } from '@theatre/studio'
   import { T, watch, type CurrentWritable } from '@threlte/core'
   import { TransformControls } from '@threlte/extras'

--- a/packages/theatre/src/lib/studio/InnerStudio.svelte
+++ b/packages/theatre/src/lib/studio/InnerStudio.svelte
@@ -1,4 +1,7 @@
-<script lang="ts" context="module">
+<script
+  lang="ts"
+  context="module"
+>
   import Studio from '@theatre/studio'
   import { studio } from '../consts'
 

--- a/packages/theatre/src/lib/studio/Studio.svelte
+++ b/packages/theatre/src/lib/studio/Studio.svelte
@@ -7,7 +7,10 @@
 
 {#if browser && enabled}
   {#await import('./InnerStudio.svelte') then Component}
-    <svelte:component this={Component.default} {hide}>
+    <svelte:component
+      this={Component.default}
+      {hide}
+    >
       <slot />
     </svelte:component>
   {/await}

--- a/packages/theatre/src/lib/theatre/Theatre.svelte
+++ b/packages/theatre/src/lib/theatre/Theatre.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { IProjectConfig } from '@theatre/core'
-
   import { Project, Sheet, Studio } from '..'
 
   export let studio: {

--- a/packages/theatre/src/routes/scene.svelte
+++ b/packages/theatre/src/routes/scene.svelte
@@ -24,7 +24,7 @@
       position.y={0.5}
     >
       <T.BoxGeometry />
-      <T.MeshStandardMaterial color='hotpink' >
+      <T.MeshStandardMaterial color="hotpink">
         <Sync
           color
           roughness


### PR DESCRIPTION
`@theatre/core` is a commonjs module and as such does not support named exports. We need to import the whole package and make our own named exports otherwise rollup cannot bundle it.