### PR TITLE
Resolving the dependencies whenever we create a new Threlte app

### DIFF
--- a/packages/create-threlte/package.json
+++ b/packages/create-threlte/package.json
@@ -25,11 +25,12 @@
   "dependencies": {
     "@clack/prompts": "^0.6.3",
     "@expo/spawn-async": "^1.7.2",
-    "create-svelte": "^5.0.2",
+    "create-svelte": "^5.0.5",
     "execa": "^7.1.1",
     "fs-extra": "^9.0.1",
     "json-merger": "^1.1.10",
     "kleur": "^4.1.5",
+    "undici": "^5.23.0",
     "which-pm-runs": "^1.1.0"
   }
 }

--- a/packages/create-threlte/src/bin.ts
+++ b/packages/create-threlte/src/bin.ts
@@ -8,6 +8,7 @@ import { bold, cyan, grey, red } from 'kleur/colors'
 import fs from 'node:fs'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { request } from 'undici'
 import detectPackageManager from 'which-pm-runs'
 
 const print = console.log
@@ -138,6 +139,22 @@ const create = async () => {
     { onCancel: () => process.exit(1) }
   )
 
+  const resolvePackageVersion = async (packageName: string, range = 'latest') => {
+    try {
+      const response = await request(
+        `https://cdn.jsdelivr.net/npm/${packageName}@${range}/package.json`
+      )
+      const packageJson = (await response.body.json()) as { version: string }
+      return `^${packageJson.version}`
+    } catch (error) {
+      print(
+        bold(red(`✘ Failed to resolve package version for ${packageName}, using ${range} instead`))
+      )
+      return range
+    } finally {
+    }
+  }
+
   const types = (options.types === 'null' ? null : options.types) as Parameters<
     typeof createSvelteKitApp
   >[1]['types']
@@ -160,31 +177,33 @@ const create = async () => {
 
   const threltePackageJson = {
     devDependencies: {
-      three: '^0.153.0',
-      '@threlte/core': 'latest'
+      three: await resolvePackageVersion('three', '^0.155.0'),
+      '@threlte/core': await resolvePackageVersion('@threlte/core')
     },
     scripts: {}
   }
 
-  if (options.types === 'typescript') {
-    threltePackageJson.devDependencies['@types/three'] = '^0.152.1'
-  }
-  if (options.threltePackages.includes('@threlte/extras')) {
-    threltePackageJson.devDependencies['@threlte/extras'] = 'latest'
-  }
-  if (options.threltePackages.includes('@threlte/rapier')) {
-    threltePackageJson.devDependencies['@threlte/rapier'] = 'latest'
-    threltePackageJson.devDependencies['@dimforge/rapier3d-compat'] = '^0.11.2'
-  }
-  if (options.threltePackages.includes('@threlte/theatre')) {
-    threltePackageJson.devDependencies['@threlte/theatre'] = 'latest'
-    threltePackageJson.devDependencies['@theatre/core'] = '^0.6.1'
-    threltePackageJson.devDependencies['@theatre/studio'] = '^0.6.1'
-  }
-  if (options.threltePackages.includes('model-pipeline')) {
-    threltePackageJson.devDependencies['@threlte/extras'] = 'latest'
-    threltePackageJson.scripts['model-pipeline:run'] = 'node scripts/model-pipeline.js'
-  }
+  // prettier-ignore
+  {
+		if (options.types === 'typescript') {
+			threltePackageJson.devDependencies['@types/three'] = await resolvePackageVersion('@types/three', '^0.155.0')
+		}
+		if (options.threltePackages.includes('@threlte/extras') || options.threltePackages.includes('model-pipeline')) {
+			threltePackageJson.devDependencies['@threlte/extras'] = await resolvePackageVersion('@threlte/extras')
+		}
+		if (options.threltePackages.includes('@threlte/rapier')) {
+			threltePackageJson.devDependencies['@threlte/rapier'] = await resolvePackageVersion('@threlte/rapier')
+			threltePackageJson.devDependencies['@dimforge/rapier3d-compat'] = await resolvePackageVersion('@dimforge/rapier3d-compat', '^0.11.2')
+		}
+		if (options.threltePackages.includes('@threlte/theatre')) {
+			threltePackageJson.devDependencies['@threlte/theatre'] = await resolvePackageVersion('@threlte/theatre')
+			threltePackageJson.devDependencies['@theatre/core'] = await resolvePackageVersion('@theatre/core', '^0.7.0')
+			threltePackageJson.devDependencies['@theatre/studio'] = await resolvePackageVersion('@theatre/studio', '^0.7.0')
+		}
+		if (options.threltePackages.includes('model-pipeline')) {
+			threltePackageJson.scripts['model-pipeline:run'] = 'node scripts/model-pipeline.js'
+		}
+	}
 
   const mergedPkg = merger.mergeObjects([svelteKitPkg, threltePackageJson])
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^1.7.2
         version: 1.7.2
       create-svelte:
-        specifier: ^5.0.2
-        version: 5.0.2
+        specifier: ^5.0.5
+        version: 5.0.5
       execa:
         specifier: ^7.1.1
         version: 7.1.1
@@ -252,6 +252,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      undici:
+        specifier: ^5.23.0
+        version: 5.23.0
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1234,10 +1237,27 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
+  /@clack/core@0.3.3:
+    resolution: {integrity: sha512-5ZGyb75BUBjlll6eOa1m/IZBxwk91dooBWhPSL67sWcLS0zt9SnswRL0l26TVdBhb0wnWORRxUn//uH6n4z7+A==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+
   /@clack/prompts@0.6.3:
     resolution: {integrity: sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==}
     dependencies:
       '@clack/core': 0.3.2
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+    bundledDependencies:
+      - is-unicode-supported
+
+  /@clack/prompts@0.7.0:
+    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
+    dependencies:
+      '@clack/core': 0.3.3
       picocolors: 1.0.0
       sisteransi: 1.0.5
     dev: false
@@ -3865,11 +3885,11 @@ packages:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
 
-  /create-svelte@5.0.2:
-    resolution: {integrity: sha512-CvDMBk2vqxucAZyIROqrF5IytkE1nReA2hZq2JcPj2LuICZT4WFZJ9U/a9QzW8pvXo3ATdsailzLnoWOYbmISQ==}
+  /create-svelte@5.0.5:
+    resolution: {integrity: sha512-+Pki3j1WjBy4FGxaoz5mrYNYDTFmVX6qLf7MLBEruPFCV1xVQAiUZozvABJneWQojjqTJOriksrDDdoiwTGUAg==}
     hasBin: true
     dependencies:
-      '@clack/prompts': 0.6.3
+      '@clack/prompts': 0.7.0
       kleur: 4.1.5
     dev: false
 
@@ -10032,6 +10052,13 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
+
+  /undici@5.23.0:
+    resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      busboy: 1.6.0
+    dev: false
 
   /unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}


### PR DESCRIPTION
Fixes #523 

@michealparks 

With `npm create threlte` we're dealing with a lot of different package versions:
- installed version of `create-svelte`
- version under our control: `@threlte/core,` `@threlte/extras`, `@threlte/theatre`, `@threlte/rapier`
- versions under external control: `@theatre/core`, `@theatre/studio`, `@dimforge/rapier3d-compat`, `three`, `@types/three`

The idea is that we at least automate updating some of them in the sense that we just fetch the current version from the latest published package via one of the package CDNs. For our packages this is safe, for external packages I limited the range to `^{current_version}` whereas `create-svelte` currently must be updated manually. I'd like to automate that as well as a lot of dependencies (svelte, vite, typescripte, …) come from that package, do you have an idea how?

Does that make sense to you in the first place? 