### PR TITLE
Fix docs link in terrain physics example

### DIFF
--- a/.changeset/little-jars-compare.md
+++ b/.changeset/little-jars-compare.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': patch
+---
+
+Fix: bad link in Rapier terrain example

--- a/apps/docs/src/content/examples/geometry/terrain-physics.mdx
+++ b/apps/docs/src/content/examples/geometry/terrain-physics.mdx
@@ -12,7 +12,7 @@ This is an adaption of Rapier's [own demo](https://rapier.rs/demos3d/index.html)
 
 ### How does it work
 
-1. Similar to the [3D noise example](/terrain), loop over the vertices of a PlaneGeometry, and use a noise map to create a heightfield array `heights`.
+1. Similar to the [3D noise example](/docs/examples/geometry/terrain), loop over the vertices of a PlaneGeometry, and use a noise map to create a heightfield array `heights`.
 2. Attach the heightfield to a rapier `<Collider>`
 
 ```


### PR DESCRIPTION
Described in https://github.com/threlte/threlte/issues/526. Went with the full path instead of `.` since it seems that's what you're doing for other links in the docs