### PR TITLE
Docs: Landing page odd behaviour fix 

### DIFF
--- a/apps/docs/src/components/Hero/HeroWrapper.svelte
+++ b/apps/docs/src/components/Hero/HeroWrapper.svelte
@@ -68,7 +68,8 @@
           powerPreference: 'high-performance',
           antialias: false,
           stencil: false,
-          depth: false
+          depth: false,
+          premultipliedAlpha: false
         }}
       >
         <App />


### PR DESCRIPTION
https://github.com/threlte/threlte/assets/16734228/e1019aa3-1062-4f1c-abd0-c13e338f3813

I ran into this issue some time ago and I decided to take a stab at it. I can only reproduce it on 1 of my 3 mobile devices - 2019ish Honor 10X.

I'm not sure about specifics but it has to do with the implementation of implementation of the Static noise pass and/or Color Dodge blend mode in postprocessing.

Disabling the static noise pass or changing `blendFunction: BlendFunction.COLOR_DODGE` to another one removes this issue as well.

A workaround I found, was to set `premultilpiedAlpha` in the renderer options. As far as I can tell it fixes the issue and doesn't change the visuals.


