### PR TITLE
Mobile nav bug fixes

### DIFF
--- a/apps/docs/src/components/Menu/MobileNav.svelte
+++ b/apps/docs/src/components/Menu/MobileNav.svelte
@@ -13,7 +13,7 @@
   const { action, mounted } = useElementMounted()
 </script>
 
-<div class="fixed top-0 left-0 z-50 flex max-h-screen w-full flex-col md:hidden">
+<div class="fixed top-0 left-0 z-40 flex max-h-screen w-full flex-col md:hidden">
   <header
     class={c(
       'flex h-[70px] w-full flex-shrink-0 flex-row items-center justify-between border-b bg-[#0A0F19] px-6 py-2',

--- a/apps/docs/src/components/Menu/MobileNav.svelte
+++ b/apps/docs/src/components/Menu/MobileNav.svelte
@@ -39,7 +39,7 @@
         duration: 200
       }}
       in:customSlide={{ duration: 200 }}
-      class="border-b-orange/25 -z-10 min-h-0 w-full overflow-visible border-b bg-[#0D1421]"
+      class="border-b-orange/25 -z-10 min-h-0 w-full overflow-auto border-b bg-[#0D1421]"
     >
       <div
         class="px-6 pt-2 pb-6"

--- a/apps/docs/src/components/Search/Markprompt.tsx
+++ b/apps/docs/src/components/Search/Markprompt.tsx
@@ -31,9 +31,9 @@ function Search({ visible }: { visible: boolean }) {
   const config = { attributes: true, childList: true, subtree: true }
 
   useEffect(() => {
-		if (!container.current) return
+    if (!container.current) return
     const observer = new MutationObserver(callback)
-		observer.observe(container.current, config)
+    observer.observe(container.current, config)
 
     return () => observer.disconnect()
   }, [])

--- a/apps/docs/src/layouts/AppLayout.astro
+++ b/apps/docs/src/layouts/AppLayout.astro
@@ -23,7 +23,7 @@ const title = Astro.props.title
       content="width=device-width"
     />
     <title>{title ?? 'Threlte'}</title>
-    <ViewTransitions />
+    <ViewTransitions fallback="none" />
     <link
       rel="preconnect"
       href="https://fonts.googleapis.com"


### PR DESCRIPTION
**Buggy behavior in the mobile menu (FF) https://github.com/threlte/threlte/issues/545**
I changed default behaviour of ViewTransitions to fallback to "none" when they are not supported. There are two other options but I'm more confident in only having any ViewTransitions at all if they are fully supported (chrome) or none at all.

I tested for a little bit and it seemed to have worked on my Firefox. Can you let me know if the issue is also gone for you @ixxie ?

**Fix mobile layout to display Search on top. https://github.com/threlte/threlte/issues/554**
Search and menu were both using `z-50` as we initially assumed that menu will be always on top.