### PR TITLE
Pass font props to troika-three-text

### DIFF
--- a/.changeset/three-dragons-fail.md
+++ b/.changeset/three-dragons-fail.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+Fixed a bug where the component `<Text>` would not render custom fonts, character sets or SDF glyph sizes

--- a/packages/extras/src/lib/components/Text/Text.svelte
+++ b/packages/extras/src/lib/components/Text/Text.svelte
@@ -38,6 +38,9 @@
   is={ref}
   let:ref
   {...$$restProps}
+  {font}
+  {characters}
+  {sdfGlyphSize}
   bind:this={$component}
 >
   <slot {ref} />


### PR DESCRIPTION
Fixed a bug where the component `<Text>` would not render custom fonts, character sets or SDF glyph sizes