### PR TITLE
Update Volume Description in <Audio/> Component to Specify Range

### DIFF
--- a/apps/docs/src/content/reference/extras/audio.mdx
+++ b/apps/docs/src/content/reference/extras/audio.mdx
@@ -23,7 +23,12 @@
           },
           { name: 'autoplay', type: 'boolean', required: false },
           { name: 'loop', type: 'boolean', required: false },
-          { name: 'volume', type: 'number', required: false },
+				 	{
+						name: 'volume',
+						type: 'number',
+						required: false,
+						description: 'The value should range between 0 to 1. Be cautious, values outside this range might cause unintended loudness.'
+					},
           { name: 'playbackRate', type: 'number', required: false },
           { name: 'detune', type: 'number', required: false }
         ],


### PR DESCRIPTION
This pull request resolves issue #553 by updating the description field for the `volume` attribute in the `<Audio/>` component. 

The new description clearly mentions that the volume range should be between 0 and 1. This clarification aims to prevent any confusion for users setting the volume and to avoid issues with unintended loudness.

Closes #553
