### PR TITLE
Create filter for running dev so 'create-threlte' package doesn't run

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build",
     "build:docs": "turbo run build --filter='@threlte/docs'",
     "preview": "turbo run preview",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev --parallel --filter=!create-threlte",
     "lint": "turbo run lint",
     "install:all": "pnpm install --filter='!@threlte/gltf'",
     "install:packages": "pnpm install --filter='!./apps/*'",


### PR DESCRIPTION
I've seen this pop up a couple of times for folks i.e. from root running `pnpm i` then `pnpm run dev` only for it to pop up with errors from create-threlte.

[relevant turbo docs](https://turbo.build/repo/docs/core-concepts/monorepos/filtering#excluding-workspaces)