### PR TITLE
Fixes error when loading docs with an Example for the first time.

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -23,6 +23,9 @@ if (process.env.NODE_ENV === 'production') {
 
 // https://astro.build/config
 export default defineConfig({
+  build: {
+    inlineStylesheets: 'never'
+  },
   integrations: [
     AutoImport({
       imports: [


### PR DESCRIPTION
It seems because of our spaghetti we still can't inline stylesheets. This happens only in prod because Astro3 has the new default to inlineStylesheets so I had to turn it off in astro config.