### PR TITLE
Disable mouse acceleration

### DIFF
--- a/apps/docs/src/examples/camera/pointer-lock-controls/PointerLockControls.svelte
+++ b/apps/docs/src/examples/camera/pointer-lock-controls/PointerLockControls.svelte
@@ -37,7 +37,9 @@
     dispatch('change')
   }
 
-  export const lock = () => domElement.requestPointerLock()
+  export const lock = () => domElement.requestPointerLock({
+    unadjustedMovement: true,
+  })
   export const unlock = () => document.exitPointerLock()
 
   domElement.addEventListener('mousemove', onMouseMove)


### PR DESCRIPTION
I'm on my laptop and mouse acceleration causes the camera to flick. To get a more accurate position and make the experience more pleasant on laptops, I tweaked the example.