### PR TITLE
Add error messages to context-based hooks

### DIFF
--- a/.changeset/silver-squids-change.md
+++ b/.changeset/silver-squids-change.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Add error messages to context-based hooks

--- a/packages/core/src/lib/hooks/useFrame.ts
+++ b/packages/core/src/lib/hooks/useFrame.ts
@@ -56,9 +56,13 @@ export const useFrame = (
     }
   }
 
-  const invalidate = options?.invalidate ?? true
-
   const renderCtx = getContext<ThrelteInternalContext>('threlte-internal-context')
+
+  if (renderCtx === undefined) {
+    throw new Error('No Threlte context found, are you using this hook inside of <Canvas>?')
+  }
+
+  const invalidate = options?.invalidate ?? true
 
   const handler: ThrelteFrameHandler = {
     fn,

--- a/packages/core/src/lib/hooks/useRender.ts
+++ b/packages/core/src/lib/hooks/useRender.ts
@@ -28,6 +28,10 @@ export const useRender = (
 
   const renderCtx = getContext<ThrelteInternalContext>('threlte-internal-context')
 
+  if (renderCtx === undefined) {
+    throw new Error('No Threlte context found, are you using this hook inside of <Canvas>?')
+  }
+
   const handler: ThrelteRenderHandler = {
     fn,
     order: options?.order


### PR DESCRIPTION
We had a user on discord that was confused by an unclear error that was thrown when `useFrame` was called outside a `<Canvas>`. This got me thinking that it would be nice to add the same message that we have in `useThrelte` to the other context-based hooks!