### PR TITLE
Add a title to every docs page

### DIFF
--- a/apps/docs/src/layouts/AppLayout.astro
+++ b/apps/docs/src/layouts/AppLayout.astro
@@ -8,7 +8,7 @@ import '$styles/dracula.css'
 import { ViewTransitions } from 'astro:transitions'
 
 export interface Props {
-  title?: string | undefined
+  title: string
 }
 
 const title = Astro.props.title
@@ -22,7 +22,7 @@ const title = Astro.props.title
       name="viewport"
       content="width=device-width"
     />
-    <title>{title ?? 'Threlte'}</title>
+    <title>{title}</title>
     <ViewTransitions
       fallback="none"
       transition:animate="initial"

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -18,7 +18,7 @@ import Footer from '../components/Footer/Footer.astro'
 import Markprompt from '$components/Search/Markprompt'
 
 export interface Props {
-  title?: string
+  title: string
   entry: CollectionEntry<'learn'> | CollectionEntry<'reference'>
 }
 

--- a/apps/docs/src/layouts/MainLayout.astro
+++ b/apps/docs/src/layouts/MainLayout.astro
@@ -7,7 +7,7 @@ import MobileMainNav from '$components/Menu/MobileMainNav.svelte'
 import Footer from '$components/Footer/Footer.astro'
 
 export interface Props {
-  title?: string
+  title: string
 }
 
 const title = Astro.props.title

--- a/apps/docs/src/pages/docs/examples/[...slug]/index.astro
+++ b/apps/docs/src/pages/docs/examples/[...slug]/index.astro
@@ -23,7 +23,7 @@ const { category, title } = entry.data
 const { Content } = await entry.render()
 ---
 
-<DocsLayout entry={entry}>
+<DocsLayout entry={entry} title={`${title} | Threlte Example`}>
 	<h6 class="text-faded text-sm font-bold">
 		{category}
 	</h6>

--- a/apps/docs/src/pages/docs/learn/[...slug]/index.astro
+++ b/apps/docs/src/pages/docs/learn/[...slug]/index.astro
@@ -23,7 +23,7 @@ const { category, title } = entry.data
 const { Content } = await entry.render()
 ---
 
-<DocsLayout entry={entry}>
+<DocsLayout entry={entry} title={`${title} | Learn Threlte`}>
   <h6 class="text-faded text-sm font-bold">
     {category}
   </h6>

--- a/apps/docs/src/pages/docs/reference/[...slug]/index.astro
+++ b/apps/docs/src/pages/docs/reference/[...slug]/index.astro
@@ -24,7 +24,7 @@ const { name, category, componentSignature } = entry.data
 const { Content } = await entry.render()
 ---
 
-<DocsLayout entry={entry}>
+<DocsLayout entry={entry} title={`${name} | ${category}`}>
   <h6 class="text-faded text-sm font-bold">
     {category}
   </h6>

--- a/apps/docs/src/pages/showcase/index.astro
+++ b/apps/docs/src/pages/showcase/index.astro
@@ -28,7 +28,7 @@ for (const l of large) {
 filteredCollection.push(...regular)
 ---
 
-<MainLayout>
+<MainLayout title="Threlte Showcase">
   <div class="flex flex-col gap-10 py-24">
     <div class="flex flex-col items-center gap-6">
       <h1 class="text-glow-white text-center text-6xl font-bold">


### PR DESCRIPTION
Currently every page has a `<title>` of "Threlte", which makes referencing multiple pages at once difficult.

I've made it mandatory to specify a title for each page, and provided a title for each.
