### PR TITLE
Changed `controller` to `targetRay` on `useController`

### DIFF
--- a/.changeset/three-peaches-perform.md
+++ b/.changeset/three-peaches-perform.md
@@ -1,0 +1,5 @@
+---
+'@threlte/xr': patch
+---
+
+Changed `controller` to `targetRay` (adhering to type and slot name rather than function call)

--- a/packages/xr/src/lib/components/ShortRay.svelte
+++ b/packages/xr/src/lib/components/ShortRay.svelte
@@ -1,8 +1,8 @@
-<script lang='ts'>
+<script lang="ts">
   import { T } from '@threlte/core'
 
   const vertexShader = `
-  uniform mat4 modelViewMatrix;                                                                                                                                                                                                  
+  uniform mat4 modelViewMatrix;
   uniform mat4 projectionMatrix;
   attribute vec2 uv;
   attribute vec3 position;
@@ -27,5 +27,9 @@
   {@const heightSegments = 1}
   {@const openEnded = false}
   <T.CylinderGeometry args={[radius, radius, height, radialSegments, heightSegments, openEnded]} />
-  <T.RawShaderMaterial transparent {vertexShader} {fragmentShader} />
+  <T.RawShaderMaterial
+    transparent
+    {vertexShader}
+    {fragmentShader}
+  />
 </T.Mesh>

--- a/packages/xr/src/lib/components/TeleportControls.svelte
+++ b/packages/xr/src/lib/components/TeleportControls.svelte
@@ -138,7 +138,7 @@
     const selecting = (teleportGamepad.current?.axes[3] ?? 0) < -0.9
 
     if (selecting && activeController === undefined) {
-      handleSelectStart(teleportController.current!.controller)
+      handleSelectStart(teleportController.current!.targetRay)
     } else if (!selecting && activeController !== undefined) {
       handleSelectEnd()
     }

--- a/packages/xr/src/lib/components/XR.svelte
+++ b/packages/xr/src/lib/components/XR.svelte
@@ -21,11 +21,11 @@ This should be placed within a Threlte `<Canvas />`.
   import { onDestroy } from 'svelte'
   import type { XRSessionEvent } from '../types'
   import {
-    session,
-    referenceSpaceType,
-    isPresenting,
-    isHandTracking,
     initialized,
+    isHandTracking,
+    isPresenting,
+    referenceSpaceType,
+    session,
     xr as xrStore
   } from '../internal/stores'
 

--- a/packages/xr/src/lib/components/XR.svelte
+++ b/packages/xr/src/lib/components/XR.svelte
@@ -1,7 +1,6 @@
 <!--
 
-@component
-`<XR />` is a WebXR manager that configures your scene for XR rendering and interaction.
+@component `<XR />` is a WebXR manager that configures your scene for XR rendering and interaction.
 
 This should be placed within a Threlte `<Canvas />`.
 
@@ -18,12 +17,18 @@ This should be placed within a Threlte `<Canvas />`.
 ```
 
 -->
-
-<script lang='ts'>
+<script lang="ts">
   import { onDestroy } from 'svelte'
   import { useThrelte, createRawEventDispatcher } from '@threlte/core'
   import type { XRSessionEvent } from '../types'
-  import { session, referenceSpaceType, isPresenting, isHandTracking, initialized, xr as xrStore } from '../internal/stores'
+  import {
+    session,
+    referenceSpaceType,
+    isPresenting,
+    isHandTracking,
+    initialized,
+    xr as xrStore
+  } from '../internal/stores'
 
   /**
    * Enables foveated rendering. Default is `1`, the three.js default.
@@ -110,7 +115,7 @@ This should be placed within a Threlte `<Canvas />`.
     currentSession.addEventListener('frameratechange', handleFramerateChange)
 
     xr.setFoveation(foveation)
-    
+
     updateTargetFrameRate(frameRate)
   }
 

--- a/packages/xr/src/lib/hooks/useEvent.ts
+++ b/packages/xr/src/lib/hooks/useEvent.ts
@@ -1,11 +1,10 @@
 import { onDestroy } from 'svelte'
-import { isHandTracking } from '../internal/stores'
-import { on, off } from '../internal/events'
+import { off, on } from '../internal/events'
 import type {
-  XRControllerEventType,
-  XRHandEventType,
   XRControllerEvent,
-  XRHandEvent
+  XRControllerEventType,
+  XRHandEvent,
+  XRHandEventType
 } from '../types'
 
 /**

--- a/packages/xr/src/lib/types.ts
+++ b/packages/xr/src/lib/types.ts
@@ -31,7 +31,7 @@ export type XRControllerEvent<Type = XRControllerEventType> = THREE.Event & {
 }
 
 export type XRController = {
-  controller: THREE.XRTargetRaySpace
+  targetRay: THREE.XRTargetRaySpace
   grip: THREE.XRGripSpace
   model?: XRControllerModel
   inputSource: XRInputSource


### PR DESCRIPTION
- Adhering to type and slot name rather than function call
- Also cleaned up some components

Closes #604 

I wasn't able to find any use of `useController().controller` and I hope I didn't miss one …