### PR TITLE
Fix MeshLineMaterial shader to calculate normals and offsets correctly

### DIFF
--- a/.changeset/tidy-spiders-leave.md
+++ b/.changeset/tidy-spiders-leave.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fix MeshLineMaterial shader to calculate normals and offsets correctly

--- a/packages/extras/src/lib/components/MeshLine/MeshLineMaterial.svelte
+++ b/packages/extras/src/lib/components/MeshLine/MeshLineMaterial.svelte
@@ -44,7 +44,7 @@
   })
 
   $: {
-    material.uniforms.resolution.value = new Vector2($size.height, $size.width)
+    material.uniforms.resolution.value = new Vector2($size.width, $size.height)
     invalidate('Canvas size changed')
   }
 

--- a/packages/extras/src/lib/components/MeshLine/vertex.ts
+++ b/packages/extras/src/lib/components/MeshLine/vertex.ts
@@ -67,6 +67,7 @@ export const vertexShader = `
 
         if(sizeAttenuation != 0.0) {
             normal /= currentClip.w;
+						normal *= min(resolution.x, resolution.y) / 2.0;
         }
 
         if (scaleDown > 0.0) {

--- a/packages/extras/src/lib/components/MeshLine/vertex.ts
+++ b/packages/extras/src/lib/components/MeshLine/vertex.ts
@@ -75,7 +75,7 @@ export const vertexShader = `
             normal *= smoothstep(0.0, scaleDown, dist);
         }
 
-        vec2 offsetInScreen = actualWidth * normal * side;
+        vec2 offsetInScreen = actualWidth * normal * side * 0.5;
 
         vec2 withOffsetScreen = currentScreen + offsetInScreen;
         vec3 withOffsetNormed = vec3((2.0 * withOffsetScreen/resolution - 1.0), currentNormed.z);

--- a/packages/extras/src/lib/components/MeshLine/vertex.ts
+++ b/packages/extras/src/lib/components/MeshLine/vertex.ts
@@ -67,7 +67,6 @@ export const vertexShader = `
 
         if(sizeAttenuation != 0.0) {
             normal /= currentClip.w;
-            normal *= min(resolution.x, resolution.y)*0.05;
         }
 
         if (scaleDown > 0.0) {

--- a/packages/extras/src/lib/components/MeshLine/vertex.ts
+++ b/packages/extras/src/lib/components/MeshLine/vertex.ts
@@ -67,7 +67,7 @@ export const vertexShader = `
 
         if(sizeAttenuation != 0.0) {
             normal /= currentClip.w;
-						normal *= min(resolution.x, resolution.y) / 2.0;
+            normal *= min(resolution.x, resolution.y);
         }
 
         if (scaleDown > 0.0) {


### PR DESCRIPTION
Currently the line thickness varries because the normals are not calculated correctly in screen space.

For example here you can see that the line thickness reduces if the line curves away from the camera:
![grafik](https://github.com/threlte/threlte/assets/26493/3ffa7f6c-d340-40f5-9a33-f890c5ebb094)

This occurs even if `scaleDown` is not set. This PR fixes this by adjusting the the vertex shader.

The result looks like this:
![grafik](https://github.com/threlte/threlte/assets/26493/62ff61b9-fbc3-4185-a570-1a71d3d5d51a)

`scaleDown` can still be set (orange line):
![grafik](https://github.com/threlte/threlte/assets/26493/e7604d9d-1072-44c7-abff-524f2e1e5b36)

Custom `shape`, `dashArray` and `attenuation` options are still working:
![grafik](https://github.com/threlte/threlte/assets/26493/89d44d41-c2c2-4b9a-bfca-80887a68bb93)
