### PR TITLE
Cursor Lines width fix

### DIFF
--- a/.changeset/three-walls-chew.md
+++ b/.changeset/three-walls-chew.md
@@ -1,0 +1,5 @@
+---
+'@threlte/docs': patch
+---
+
+Adjusted widths of lines in Cursor Lines example

--- a/apps/docs/src/content/examples/meshline/cursor-lines.mdx
+++ b/apps/docs/src/content/examples/meshline/cursor-lines.mdx
@@ -80,6 +80,7 @@ To give each line a different color and with we export these propertys to be set
     {width}
     {color}
     scaleDown={0.1}
+    attenuate={false}
   />
 </T.Mesh>
 ```
@@ -146,7 +147,7 @@ We use the index to give each line slightly different position, stiffness, dampe
 
 ```svelte
 <script lang="ts">
-	let colors = ['#fc6435', '#ff541f', '#f53c02', '#261f79', '#1e165c']
+  let colors = ['#fc6435', '#ff541f', '#f53c02', '#261f79', '#1e165c']
 </script>
 
 {#each colors as color, i}
@@ -156,7 +157,7 @@ We use the index to give each line slightly different position, stiffness, dampe
     position.y={5 - i}
     stiffness={0.02 * i + 0.02}
     damping={0.25 - 0.04 * i}
-    width={0.3 + i / 5}
+    width={15 + i * 10}
   />
 {/each}
 ```

--- a/apps/docs/src/examples/extras/meshline-material/alpha-map/Scene.svelte
+++ b/apps/docs/src/examples/extras/meshline-material/alpha-map/Scene.svelte
@@ -7,7 +7,7 @@
     OrbitControls,
     useTexture
   } from '@threlte/extras'
-  import { Vector3, CubicBezierCurve3, Color } from 'three'
+  import { Vector3, CubicBezierCurve3, Color, DoubleSide } from 'three'
 
   const texture = useTexture('/brush-texture.png')
 
@@ -42,7 +42,7 @@
     scale={2}
   >
     <T.PlaneGeometry />
-    <T.MeshBasicMaterial {map} />
+    <T.MeshBasicMaterial {map} side={DoubleSide}/>
   </T.Mesh>
 {/await}
 

--- a/apps/docs/src/examples/meshline/cursor-lines/CursorLine.svelte
+++ b/apps/docs/src/examples/meshline/cursor-lines/CursorLine.svelte
@@ -55,5 +55,6 @@
     {width}
     {color}
     scaleDown={0.1}
+    attenuate={false}
   />
 </T.Mesh>

--- a/apps/docs/src/examples/meshline/cursor-lines/Scene.svelte
+++ b/apps/docs/src/examples/meshline/cursor-lines/Scene.svelte
@@ -17,7 +17,7 @@
     position.y={5 - i}
     stiffness={0.02 * i + 0.02}
     damping={0.25 - 0.04 * i}
-    width={0.3 + i / 5}
+    width={15 + i * 10}
   />
 {/each}
 


### PR DESCRIPTION
Changes the widths of the lines in the Cursor Lines example and sets 'attenuate' correctly.

Also tiny change to the AlphaMap example on the <MeshLineMaterial> page to make the brush texture visible from both sides.