### PR TITLE
docs: fix typo in core/t.mdx

### DIFF
--- a/apps/docs/src/content/reference/core/t.mdx
+++ b/apps/docs/src/content/reference/core/t.mdx
@@ -297,7 +297,7 @@ The following attaches a material to the material property of a mesh and a geome
   <T
     is={OrthographicCamera}
     args={[-1, 1, 1, -1, 0.1, 100]}
-    attach="shadow.camera"
+    attach="shadow-camera"
   />
 </T>
 ```


### PR DESCRIPTION
Attach should be "shadow-camera" (not "shadow.camera") in order to work properly.