### PR TITLE
Fix color management of Theatre.js color picker

### DIFF
--- a/.changeset/pink-seals-serve.md
+++ b/.changeset/pink-seals-serve.md
@@ -1,0 +1,5 @@
+---
+"@threlte/theatre": patch
+---
+
+Fix color management of Theatre.js color picker

--- a/packages/theatre/src/lib/sheetObject/transfomers/defaults/color.ts
+++ b/packages/theatre/src/lib/sheetObject/transfomers/defaults/color.ts
@@ -1,13 +1,15 @@
 import { types } from '../../../theatre'
 import { createTransformer } from '../createTransformer'
+import { Color, SRGBColorSpace } from 'three'
+
+const _color = new Color()
 
 export const color = createTransformer({
   transform(value) {
-    return types.rgba({ r: value.r, g: value.g, b: value.b, a: 1 })
+    value.getRGB(_color, SRGBColorSpace)
+    return types.rgba({ r: _color.r, g: _color.g, b: _color.b, a: 1 })
   },
   apply(target, path, value) {
-    target[path].r = value.r
-    target[path].g = value.g
-    target[path].b = value.b
+    target[path].setRGB(value.r, value.g, value.b, SRGBColorSpace)
   }
 })


### PR DESCRIPTION
Unless otherwise specified, a color picker usually has sRGB input and output. When assigning the color to a THREE.Color instance, this should be specified so that three.js can make any necessary conversions to the working color space.

To test this change, create a canvas with `toneMapping={LinearToneMapping}`, and a MeshBasicMaterial. Assign a color to the material that isn't fully saturated, like `#FF69B4`. Then use a color meter (like [macOS Color Meter](https://docs.google.com/document/d/12W-n3nTl6C8-SyeP_trvKBXQirMLmvsGGl3yUlQsHaQ/edit#heading=h.vks9e22yqulu)) to check that the value shown on the material matches exactly. If the color meter can display colors in other color spaces, ensure that it's set to sRGB.

If non-linear tone mapping is enabled, some differences in display are expected.

![Screenshot 2023-09-19 at 11 03 20 AM](https://github.com/threlte/threlte/assets/1848368/f2d36e73-13fe-4e75-8a7b-b0845c3e9443)
