### PR TITLE
ContactShadows: use WebGLRenderTarget#colorSpace when available

### DIFF
--- a/.changeset/serious-ducks-rescue.md
+++ b/.changeset/serious-ducks-rescue.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+ContactShadows: use WebGLRenderTarget#colorSpace when available

--- a/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
+++ b/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
@@ -52,7 +52,12 @@
   const renderTarget = useMemo(() => {
     const rt = new WebGLRenderTarget(resolution, resolution)
     rt.texture.generateMipmaps = false
-    rt.texture.encoding = renderer.outputEncoding
+    if ('colorSpace' in rt.texture) {
+      rt.texture.colorSpace = renderer.outputColorSpace
+    } else {
+      // deprecated in three.js r152
+      rt.texture.encoding = renderer.outputEncoding
+    }
     return rt
   })
   $: renderTarget.memoize(resolution)


### PR DESCRIPTION
VSCode will warn that the second branch is "unreachable", but I kept that in. Wasn't sure how long you'd like to keep support for three.js <= r151.

![Screenshot 2023-09-19 at 9 54 00 PM](https://github.com/threlte/threlte/assets/1848368/d15eb25b-9980-4338-9e57-27179f687197)
