### PR TITLE
Orbit controls - now calls `update` on initialization to set a correct camera position.

### DIFF
--- a/.changeset/friendly-years-melt.md
+++ b/.changeset/friendly-years-melt.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+Orbit controls - now calls `update` on initialization to set a correct camera position.

--- a/packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte
+++ b/packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte
@@ -50,6 +50,7 @@
   on:change={invalidate}
   on:create={({ ref, cleanup }) => {
     orbitControls.set(ref)
+    ref.update()
     cleanup(() => {
       orbitControls.set(undefined)
     })


### PR DESCRIPTION
Sometimes camera didn't get moved to the position calculated by orbit controls because we didn't call `update` on create