### PR TITLE
Fix color prop type for materials used with T component

### DIFF
--- a/.changeset/sour-planets-search.md
+++ b/.changeset/sour-planets-search.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Add color overload for materials for r153 type change

--- a/packages/core/src/lib/components/T/types.ts
+++ b/packages/core/src/lib/components/T/types.ts
@@ -87,6 +87,16 @@ export type CameraProps<Type extends any> = MaybeInstance<Type> extends { isCame
   : Record<string, unknown>
 
 /**
+ * ### Material Props
+ */
+export type MaterialProps<Type extends any> = MaybeInstance<Type> extends { isMaterial: true }
+    // This overload is necessary since types changed in r153.
+  ? {
+      color?: THREE.ColorRepresentation
+    }
+  : Record<string, unknown>
+
+/**
  * ### Instance Props
  *
  * Enables the use of props that are infered from the provided type.
@@ -129,7 +139,8 @@ export type Props<Type extends any> = AnyProps &
   BaseProps<Type> &
   ClassProps<Type> &
   CameraProps<Type> &
-  InstanceProps<Type>
+  InstanceProps<Type> |
+  MaterialProps<Type>
 
 // –––––––––––––––––––––––– SLOTS ––––––––––––––––––––––––
 


### PR DESCRIPTION
This PR fixes an issue where Typescript would complain about valid color values passed as a prop to materials declared with the `<T>` component.

<img width="969" alt="Screenshot 2023-09-25 at 4 21 48 PM" src="https://github.com/threlte/threlte/assets/3834780/8da9d2e2-8487-414f-838c-35600d64f8b8">

