### PR TITLE
[xr] - Add useHeadset hook

### DIFF
--- a/.changeset/lucky-ears-applaud.md
+++ b/.changeset/lucky-ears-applaud.md
@@ -1,0 +1,5 @@
+---
+'@threlte/xr': patch
+---
+
+Add useHeadset hook

--- a/apps/docs/src/content/reference/xr/headset.mdx
+++ b/apps/docs/src/content/reference/xr/headset.mdx
@@ -22,7 +22,9 @@
 </Headset>
 ```
 
-Like a Portal, it can exist anywhere in your Threlte application.
+If you need to only read from the current headset pose, the [useHeadset](/docs/reference/xr/use-headset) hook is available.
+
+Like a [Portal](/docs/reference/extras/portal), you can place it anywhere in your Threlte application.
 
 `<Headset>` will sync position and rotation with the current camera when not in an immersive XR session.
 

--- a/apps/docs/src/content/reference/xr/use-headset.mdx
+++ b/apps/docs/src/content/reference/xr/use-headset.mdx
@@ -1,0 +1,31 @@
+---
+order: 17
+category: '@threlte/xr'
+name: 'useHeadset'
+type: 'hook'
+---
+
+Provides a reference to the user's headset pose.
+
+```svelte
+<script>
+  import { useFrame } from '@threlte/core'
+  import { useHeadset } from '@threlte/xr'
+
+  const headset = useHeadset()
+
+  useFrame(() => {
+    // Read the current headset position and rotation.
+    console.log(headset.position, headset.quaternion)
+  })
+</script>
+```
+
+If you would like to attach objects to the headset, the [`<Headset>`](/docs/reference/xr/headset) component is available.
+
+### Signature
+
+```ts
+// THREE.Group - A group representing the headset pose.
+const headset = useHeadset() 
+```

--- a/packages/xr/src/lib/components/Headset.svelte
+++ b/packages/xr/src/lib/components/Headset.svelte
@@ -1,53 +1,17 @@
+
 <script lang="ts">
-	import { T, HierarchicalObject, useFrame, useThrelte } from '@threlte/core'
-	import { Group } from 'three'
-  import { useXR } from '../hooks'
+  import { T, HierarchicalObject, useThrelte } from '@threlte/core'
+  import { useHeadset } from '../hooks/useHeadset'
 
-  const { isPresenting } = useXR()
-	const { renderer, scene, camera } = useThrelte()
-  const { xr } = renderer
-
-	const group = new Group()
-
-  const immersiveFrame = useFrame(() => {
-    const space = xr.getReferenceSpace()
-
-    if (space === null) return
-
-    const pose = xr.getFrame().getViewerPose(space)
-
-    if (pose === undefined) return
-
-    const { position, orientation } = pose.transform
-
-    group.position.set(position.x, position.y, position.z)
-    group.quaternion.set(orientation.x, orientation.y, orientation.z, orientation.w)
-  }, { autostart: false })
-
-  $: if ($isPresenting) {
-    immersiveFrame.start()
-  } else {
-    immersiveFrame.stop()
-  }
-
-  const nonImmersiveFrame = useFrame(() => {
-    group.position.copy(camera.current.position)
-    group.quaternion.copy(camera.current.quaternion)
-  }, { autostart: false })
-
-  $: if ($isPresenting === false) {
-    nonImmersiveFrame.start()
-  } else {
-    nonImmersiveFrame.stop()
-  }
-
+  const { scene } = useThrelte()
+  const headset = useHeadset()
 </script>
 
 <HierarchicalObject
   onChildMount={(child) => { scene.add(child) }}
   onChildDestroy={(child) => { scene.remove(child) }}
 >
-	<T is={group}>
+	<T is={headset}>
 		<slot />
 	</T>
 </HierarchicalObject>

--- a/packages/xr/src/lib/hooks/useHeadset.ts
+++ b/packages/xr/src/lib/hooks/useHeadset.ts
@@ -1,0 +1,52 @@
+import { useFrame, useThrelte } from '@threlte/core'
+import { Group } from 'three'
+import { isPresenting } from '../internal/stores'
+
+const group = new Group()
+
+let initialized = false
+
+const initialize = () => {
+  const { renderer, camera } = useThrelte()
+  const { xr } = renderer
+
+  const immersiveFrame = useFrame(() => {
+    const space = xr.getReferenceSpace()
+
+    if (space === null) return
+
+    const pose = xr.getFrame().getViewerPose(space)
+
+    if (pose === undefined) return
+
+    const { position, orientation } = pose.transform
+
+    group.position.set(position.x, position.y, position.z)
+    group.quaternion.set(orientation.x, orientation.y, orientation.z, orientation.w)
+  }, { autostart: false })
+
+  const nonImmersiveFrame = useFrame(() => {
+    group.position.copy(camera.current.position)
+    group.quaternion.copy(camera.current.quaternion)
+  }, { autostart: false })
+
+  isPresenting.subscribe((value) => {
+    if (value) {
+      immersiveFrame.start()
+      nonImmersiveFrame.stop()
+    } else {
+      immersiveFrame.stop()
+      nonImmersiveFrame.start()
+    }
+  })
+}
+
+export const useHeadset = (): Readonly<THREE.Group> => {
+  // We don't want to perform headset syncing more than once per frame
+  if (!initialized) {
+    initialize()
+    initialized = true
+  }
+
+  return group
+}


### PR DESCRIPTION
This PR adds a `useHeadset` hook that exposes the pose of the user headset. It also ensure that syncing the viewer pose the the headset object only occurs once per frame no matter how many `<Headset>` components or `useHeadset` hooks exist.