### PR TITLE
[xr] - useHitTest: Allow hit testing from controller or hand inputs

### DIFF
--- a/.changeset/quick-deers-hope.md
+++ b/.changeset/quick-deers-hope.md
@@ -1,0 +1,7 @@
+---
+'@threlte/core': patch
+'@threlte/xr': patch
+---
+
+* Allow hit testing from controllers / hands
+* Do not attempt to resize renderer when in an immersive xr session

--- a/.changeset/quick-deers-hope.md
+++ b/.changeset/quick-deers-hope.md
@@ -3,5 +3,5 @@
 '@threlte/xr': patch
 ---
 
-* Allow hit testing from controllers / hands
-* Do not attempt to resize renderer when in an immersive xr session
+* (xr) - useHitTest: Allow hit testing from controllers / hands
+* (core) - Do not attempt to resize renderer when in an immersive xr session

--- a/apps/docs/src/content/reference/xr/use-hit-test.mdx
+++ b/apps/docs/src/content/reference/xr/use-hit-test.mdx
@@ -33,7 +33,7 @@ Hit testing lets you position virtual items in a real-world view.
 </T.Mesh>
 ```
 
-This hook can optionally specify one of three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` and `rightInput`.
+This hook can optionally specify one of three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` or `rightInput`.
 
 ```ts
 useHitTest((hitMatrix, hit) => {

--- a/apps/docs/src/content/reference/xr/use-hit-test.mdx
+++ b/apps/docs/src/content/reference/xr/use-hit-test.mdx
@@ -7,14 +7,44 @@ type: 'hook'
 
 Provides a [hit test result](https://developer.mozilla.org/en-US/docs/Web/API/XRHitTestResult) on each frame during an `immersive-ar` session.
 
+Hit testing lets you position virtual items in a real-world view.
+
 ```svelte
 <script>
-  useHitTest((hitMatrix: THREE.Matrix4, hit: XRHitTestResult) => {
+  import { useHitTest } from '@threlte/xr'
 
+  let ref
+
+  useHitTest((hitMatrix, hit) => {
+    if (hit) {
+      ref.visible = true
+      ref.matrix.copy(hitMatrix)
+    } else {
+      ref.visible = false
+    }
   })
 </script>
+
+<T.Mesh bind:ref>
+  <T.SphereGeometry args={[0.1]}>
+  <T.MeshBasicMaterial />
+</T.Mesh>
 ```
 
-Hit testing can be useful for placing virtual objects relative to real world objects.
+This hook can specify three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` and `rightInput`.
+
+```ts
+useHitTest((hitMatrix, hit) => {
+  // Perform a hit test from the left controller or hand.
+}, { source: 'leftInput' })
+```
+
+In the following example, hit testing is set up from both controllers and hands.
 
 <Example path="xr/use-hit-test" />
+
+### Signature
+
+```ts
+useHitTest((hitMatrix: THREE.Matrix4, hit: XRHitTestResult | undefined) => {})
+```

--- a/apps/docs/src/content/reference/xr/use-hit-test.mdx
+++ b/apps/docs/src/content/reference/xr/use-hit-test.mdx
@@ -16,6 +16,8 @@ Hit testing lets you position virtual items in a real-world view.
   let ref
 
   useHitTest((hitMatrix, hit) => {
+    if (!ref) return
+  
     if (hit) {
       ref.visible = true
       ref.matrix.copy(hitMatrix)

--- a/apps/docs/src/content/reference/xr/use-hit-test.mdx
+++ b/apps/docs/src/content/reference/xr/use-hit-test.mdx
@@ -33,7 +33,7 @@ Hit testing lets you position virtual items in a real-world view.
 </T.Mesh>
 ```
 
-This hook can optionally specify on of three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` and `rightInput`.
+This hook can optionally specify one of three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` and `rightInput`.
 
 ```ts
 useHitTest((hitMatrix, hit) => {

--- a/apps/docs/src/content/reference/xr/use-hit-test.mdx
+++ b/apps/docs/src/content/reference/xr/use-hit-test.mdx
@@ -33,7 +33,7 @@ Hit testing lets you position virtual items in a real-world view.
 </T.Mesh>
 ```
 
-This hook can specify three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` and `rightInput`.
+This hook can optionally specify on of three origins from which to cast the hit test ray: `viewer` (the default), `leftInput` and `rightInput`.
 
 ```ts
 useHitTest((hitMatrix, hit) => {

--- a/apps/docs/src/examples/xr/use-hit-test/Scene.svelte
+++ b/apps/docs/src/examples/xr/use-hit-test/Scene.svelte
@@ -6,17 +6,17 @@
   const geometry = new THREE.CylinderGeometry(0.1, 0.1, 0.2, 32).translate(0, 0.1, 0);
   
   let meshes: THREE.Mesh[] = []
-  let reticles = { left: undefined! as THREE.Mesh, right: undefined! as THREE.Mesh }
+  let cursors = { left: undefined! as THREE.Mesh, right: undefined! as THREE.Mesh }
 
   const hands = ['left', 'right'] as const
   type Hands = (typeof hands)[number]
   
   const handleSelect = (hand: Hands) => () => {
-    if (!reticles[hand].visible) return
+    if (!cursors[hand].visible) return
 
     const material = new THREE.MeshPhongMaterial({ color: 0xffffff * Math.random() })
     const mesh = new THREE.Mesh(geometry, material)
-    reticles[hand].matrix.decompose(mesh.position, mesh.quaternion, mesh.scale)
+    cursors[hand].matrix.decompose(mesh.position, mesh.quaternion, mesh.scale)
     mesh.scale.y = Math.random() * 2 + 1
     meshes.push(mesh)
     meshes = meshes
@@ -24,10 +24,10 @@
 
   const handleHitTest = (hand: Hands) => (hitMatrix: THREE.Matrix4, hit: XRHitTestResult) => {
     if (hit) {
-      reticles[hand].visible = true
-      reticles[hand].matrix.copy(hitMatrix)
+      cursors[hand].visible = true
+      cursors[hand].matrix.copy(hitMatrix)
     } else {
-      reticles[hand].visible = false
+      cursors[hand].visible = false
     }
   }
 
@@ -41,7 +41,7 @@
     <Hand {hand} on:pinchend={handleSelect(hand)} />
 
     <T.Mesh
-      bind:ref={reticles[hand]}
+      bind:ref={cursors[hand]}
       matrixAutoUpdate={false}
       visible={false}
     >

--- a/apps/docs/src/examples/xr/use-hit-test/Scene.svelte
+++ b/apps/docs/src/examples/xr/use-hit-test/Scene.svelte
@@ -22,7 +22,9 @@
     meshes = meshes
   }
 
-  const handleHitTest = (hand: Hands) => (hitMatrix: THREE.Matrix4, hit: XRHitTestResult) => {
+  const handleHitTest = (hand: Hands) => (hitMatrix: THREE.Matrix4, hit: XRHitTestResult | undefined) => {
+    if (!cursors[hand]) return
+  
     if (hit) {
       cursors[hand].visible = true
       cursors[hand].matrix.copy(hitMatrix)

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -93,7 +93,7 @@ export const useRenderer = (ctx: ThrelteContext) => {
   })
 
   watch([renderer, ctx.size], ([renderer, size]) => {
-    if (renderer?.xr.isPresenting) return
+    if (renderer?.xr?.isPresenting) return
     renderer?.setSize(size.width, size.height)
   })
 

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -93,6 +93,7 @@ export const useRenderer = (ctx: ThrelteContext) => {
   })
 
   watch([renderer, ctx.size], ([renderer, size]) => {
+    if (renderer?.xr.isPresenting) return
     renderer?.setSize(size.width, size.height)
   })
 

--- a/packages/xr/src/lib/hooks/useHitTest.ts
+++ b/packages/xr/src/lib/hooks/useHitTest.ts
@@ -1,50 +1,71 @@
 import * as THREE from 'three'
-import { onDestroy } from 'svelte'
-import { session } from '../internal/stores'
+import { useThrelte, useFrame, watch, currentWritable } from '@threlte/core'
 import type { HitTestCallback } from '../types'
-import { useThrelte, useFrame } from '@threlte/core'
+import { useXR } from './useXR'
+import { useController } from './useController'
+
+export type UseHitTestOptions = {
+  /**
+   * The ray source when performing hit testing.
+   * 
+   * @default 'viewer'
+   */
+  source?: 'viewer' | 'leftInput' | 'rightInput'
+}
 
 /**
- * Use this hook to perform a hit test for an AR environment.
+ * Use this hook to perform a hit test per frame in an AR environment.
+ * 
+ * ```ts
+ * useHitTest((hitMatrix, hit) => {
+ * 
+ * }, {
+ *  source: 'viewer' | 'leftInput' | 'rightInput'
+ * })
+ * ```
  */
-export const useHitTest = (hitTestCallback: HitTestCallback): void => {
+export const useHitTest = (hitTestCallback: HitTestCallback, options: UseHitTestOptions = {}): void => {
+  const source = options.source ?? 'viewer'
   const { xr } = useThrelte().renderer
+  const xrState = useXR()
   const hitMatrix = new THREE.Matrix4()
 
-  let started = false
-  let hitTestSource: XRHitTestSource | undefined
+  let hitTestSource = currentWritable<XRHitTestSource | undefined>(undefined)
 
-  onDestroy(
-    session.subscribe(async (value) => {
-      if (value === undefined) {
-        hitTestSource = undefined
-        if (started) {
-          stop()
-          started = false
-        }
-        return
-      }
-
-      const space = await value.requestReferenceSpace('viewer')
-      hitTestSource = await value.requestHitTestSource?.({ space })
-      if (!started) {
-        start()
-        started = true
-      }
+  if (source === 'viewer') {
+    watch(xrState.session, async (session) => {
+      if (session === undefined) return
+      const space = await session.requestReferenceSpace('viewer') 
+      hitTestSource.set(await session.requestHitTestSource?.({ space }))
     })
-  )
+  } else {
+    const controller = useController(source === 'leftInput' ? 'left' : 'right')
+    const hand = useController(source === 'leftInput' ? 'left' : 'right')
+
+    watch([xrState.session, controller], async ([session, input]) => {
+      if (input === undefined || session === undefined) return
+      const space = input.inputSource.targetRaySpace
+      hitTestSource.set(await session.requestHitTestSource?.({ space }))
+    })
+  
+    watch([xrState.session, hand], async ([session, input]) => {
+      if (input === undefined || session === undefined) return
+      const space = input.inputSource.targetRaySpace
+      hitTestSource.set(await session.requestHitTestSource?.({ space }))
+    })
+  }
 
   const { start, stop } = useFrame(
     () => {
-      if (hitTestSource === undefined) return
-
-      const [hit] = xr.getFrame().getHitTestResults(hitTestSource)
-
-      if (hit === undefined) return
-
       const referenceSpace = xr.getReferenceSpace()
 
       if (referenceSpace === null) return
+
+      if (hitTestSource.current === undefined) return
+
+      const [hit] = xr.getFrame().getHitTestResults(hitTestSource.current)
+
+      if (hit === undefined) return
 
       const pose = hit.getPose(referenceSpace)
 
@@ -55,4 +76,12 @@ export const useHitTest = (hitTestCallback: HitTestCallback): void => {
     },
     { autostart: false }
   )
+
+  watch(hitTestSource, (testSource) => {
+    if (testSource === undefined) {
+      stop()
+    } else {
+      start()
+    }
+  })
 }

--- a/packages/xr/src/lib/types.ts
+++ b/packages/xr/src/lib/types.ts
@@ -55,5 +55,3 @@ export type XRHandEvent<Type = XRHandEventType> = Type extends 'connected' | 'di
       target: null;
     }
   : never;
-
-export type HitTestCallback = (hitMatrix: THREE.Matrix4, hit: XRHitTestResult) => void


### PR DESCRIPTION
The `useHitTest` hook currently only supports providing hit tests from the headset, which isn't as nearly as valuable as providing hit tests from either the headset or the user's inputs, so this PR changes that!

I've updated the docs to explain this in more detail:

https://threlte-git-fork-michealparks-hit-test-improvements-threlte.vercel.app/docs/reference/xr/use-hit-test