### PR TITLE
Fix for cursor lines example

### DIFF
--- a/apps/docs/src/examples/meshline/cursor-lines/CursorLine.svelte
+++ b/apps/docs/src/examples/meshline/cursor-lines/CursorLine.svelte
@@ -38,7 +38,7 @@
     let previousPoint = points[0]
     points.forEach((point, i) => {
       if (previousPoint && i > 0) {
-        point.lerp(previousPoint, delta * 75)
+        point.lerp(previousPoint, Math.pow(0.000001, delta))
         previousPoint = point
       }
     })


### PR DESCRIPTION
The Cursor Lines example is currently causing chaos!
https://threlte.xyz/docs/examples/meshline/cursor-lines

https://github.com/threlte/threlte/assets/14927523/8501e041-8508-4be5-909e-9c632073f3ca


I think this is down to the change to use delta in the lerp function. After reading [this article](https://www.construct.net/en/blogs/ashleys-blog-2/using-lerp-delta-time-924 ) I think the correct method would be using Math.pow rather than multiplication. (Most of the maths in that article is beyond me so happy to be corrected!!)

Using Math.pow(0.000001, delta)) results in a similar lerp speed to the original on my devices at 60fps. @jerzakm are you able to test this at 165fps and check it looks ok? Thanks! 