### PR TITLE
`@threlte/gltf`: Remove pascal casing, model pipeline perf fix

### DIFF
--- a/.changeset/smart-buttons-invite.md
+++ b/.changeset/smart-buttons-invite.md
@@ -1,0 +1,5 @@
+---
+'create-threlte': minor
+---
+
+Model Pipeline: Do not process a file if it's already present.

--- a/.changeset/yellow-spiders-whisper.md
+++ b/.changeset/yellow-spiders-whisper.md
@@ -1,0 +1,5 @@
+---
+'@threlte/gltf': major
+---
+
+Removed pascal-casing of output file in favor of more reliable output file naming for automation purposes. The output file will now be 1:1 filename.glb -> filename.svelte.

--- a/packages/create-threlte/src/templates/model-pipeline+typescript/scripts/model-pipeline.js
+++ b/packages/create-threlte/src/templates/model-pipeline+typescript/scripts/model-pipeline.js
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import { readdirSync, copyFileSync, unlinkSync, mkdirSync, existsSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { exit } from 'node:process'
 
 /**
  * This script is used to transform gltf and glb files into Threlte components.
@@ -55,7 +56,29 @@ const gltfFiles = readdirSync(configuration.sourceDir).filter((file) => {
   )
 })
 
-gltfFiles.forEach((file) => {
+if (gltfFiles.length === 0) {
+  console.log('No gltf or glb files found.')
+  exit()
+}
+
+const filteredGltfFiles = gltfFiles.filter((file) => {
+  if (!configuration.overwrite) {
+    const componentFilename = file.split('.').slice(0, -1).join('.') + '.svelte'
+    const componentPath = join(configuration.targetDir, componentFilename)
+    if (existsSync(componentPath)) {
+      console.error(`File ${componentPath} already exists, skipping.`)
+      return false
+    }
+  }
+  return true
+})
+
+if (filteredGltfFiles.length === 0) {
+  console.log('No gltf or glb files to process.')
+  exit()
+}
+
+filteredGltfFiles.forEach((file) => {
   // run the gltf transform command on every file
   const path = join(configuration.sourceDir, file)
 
@@ -102,18 +125,21 @@ svelteFiles.forEach((file) => {
   // now move every file to /src/components/models
   const path = join(configuration.sourceDir, file)
   const newPath = join(configuration.targetDir, file)
-  try {
+  copyFile: try {
+    // Sanity check, we checked earlier if the file exists. Still, the CLI takes
+    // a while, so who knows what happens in the meantime.
     if (!configuration.overwrite) {
       // check if file already exists
       if (existsSync(newPath)) {
         console.error(`File ${newPath} already exists, skipping.`)
-        return
+        break copyFile
       }
     }
     copyFileSync(path, newPath)
   } catch (error) {
     console.error(`Error copying file: ${error}`)
   }
+
   // remove the file from /static/models
   try {
     unlinkSync(path)

--- a/packages/gltf/cli.js
+++ b/packages/gltf/cli.js
@@ -65,26 +65,6 @@ const cli = meow(
 
 const { packageJson } = readPackageUpSync({ cwd: __dirname, normalize: false })
 
-function toPascalCase(str) {
-  return (
-    str
-      .replace(/(\w)(\w*)/g, function (g0, g1, g2) {
-        // capitalize first letter of g1, leave the reset as-is and return the result
-        return g1.toUpperCase() + g2
-      })
-      // replace every non-word character with an empty string and capitalize the first following letter
-      .replace(/\W+(.)/g, function (g0, g1) {
-        return g1.toUpperCase()
-      })
-      // replace every non-word character with an empty string
-      .replace(/\s+/g, '')
-      // make first letter uppercase
-      .replace(/^\w/, function (g0) {
-        return g0.toUpperCase()
-      })
-  )
-}
-
 if (cli.input.length === 0) {
   console.log(cli.help)
 } else {
@@ -96,13 +76,12 @@ Command: npx @threlte/gltf@${packageJson.version} ${process.argv.slice(2).join('
   const file = cli.input[0]
   let nameExt = file.match(/[-_\w]+[.][\w]+$/i)[0]
   let name = nameExt.split('.').slice(0, -1).join('.')
-  const baseName = toPascalCase(name.charAt(0).toUpperCase() + name.slice(1))
-  const output = baseName + '.svelte'
+  const output = name + '.svelte'
   const showLog = (log) => {
     console.info('log:', log)
   }
   try {
-    const response = await gltf(file, output, {
+    await gltf(file, output, {
       ...config,
       showLog,
       timeout: 0,


### PR DESCRIPTION
- Removed the Pascal-casing from the `@threlte/gltf` CLI. It prevents proper automation.
- The model pipeline now skips files that are already present *before* transforming them, making it way faster.