### PR TITLE
Force svelte/motion to use session.requestAnimationFrame when presenting

### DIFF
--- a/.changeset/clean-students-shout.md
+++ b/.changeset/clean-students-shout.md
@@ -1,0 +1,5 @@
+---
+'@threlte/xr': patch
+---
+
+Force svelte/motion to use session.requestAnimationFrame when presenting

--- a/packages/xr/src/lib/components/XR.svelte
+++ b/packages/xr/src/lib/components/XR.svelte
@@ -29,6 +29,7 @@ This should be placed within a Threlte `<Canvas />`.
     session,
     xr as xrStore
   } from '../internal/stores'
+  import { updateRaf } from '../internal/updateRaf'
   import { useUpdateHeadset } from '../internal/headset'
 
   /**
@@ -65,6 +66,9 @@ This should be placed within a Threlte `<Canvas />`.
   }
 
   const dispatch = createRawEventDispatcher<$$Events>()
+
+  updateRaf()
+
   const { renderer, frameloop } = useThrelte()
   const { xr } = renderer
 

--- a/packages/xr/src/lib/internal/updateRaf.ts
+++ b/packages/xr/src/lib/internal/updateRaf.ts
@@ -1,0 +1,24 @@
+import { set_raf } from 'svelte/internal'
+import { onDestroy } from 'svelte'
+import { watch } from '@threlte/core'
+import { session } from './stores'
+
+export const updateRaf = () => {
+  if (typeof window === 'undefined') return
+
+  const currentRaf = { fn: window.requestAnimationFrame }
+  set_raf((fn: FrameRequestCallback) => currentRaf.fn(fn))
+
+  watch(session, (session) => {
+    if (session) {
+      currentRaf.fn = session.requestAnimationFrame
+    } else {
+      currentRaf.fn = window.requestAnimationFrame
+    }
+    console.log(currentRaf.fn)
+  })
+
+	// set_now(() => Date.now())
+
+	onDestroy(() => (currentRaf.fn = window.requestAnimationFrame))
+}

--- a/packages/xr/src/lib/internal/updateRaf.ts
+++ b/packages/xr/src/lib/internal/updateRaf.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error svelte/internal is untyped.
 import { set_raf } from 'svelte/internal'
 import { onDestroy } from 'svelte'
 import { watch } from '@threlte/core'
@@ -6,19 +7,19 @@ import { session } from './stores'
 export const updateRaf = () => {
   if (typeof window === 'undefined') return
 
-  const currentRaf = { fn: window.requestAnimationFrame }
+  const browserRaf = (fn: FrameRequestCallback) => requestAnimationFrame(fn)
+  const currentRaf = { fn: browserRaf }
   set_raf((fn: FrameRequestCallback) => currentRaf.fn(fn))
 
   watch(session, (session) => {
     if (session) {
-      currentRaf.fn = session.requestAnimationFrame
+      currentRaf.fn = (fn: XRFrameRequestCallback) => (
+        session.requestAnimationFrame(fn)
+      )
     } else {
-      currentRaf.fn = window.requestAnimationFrame
+      currentRaf.fn = browserRaf
     }
-    console.log(currentRaf.fn)
   })
 
-	// set_now(() => Date.now())
-
-	onDestroy(() => (currentRaf.fn = window.requestAnimationFrame))
+	onDestroy(() => (currentRaf.fn = browserRaf))
 }


### PR DESCRIPTION
This PR uses the `set_raf` svelte internal to force motion to use session.requestAnimationFrame. Thank you @grischaerbe for helping investigate this!

I tested that this works with the new pointer controls example on that branch.