### PR TITLE
docs example fix: Interactive shader flickering text

### DIFF
--- a/apps/docs/src/examples/shaders/interactiveShader/App.svelte
+++ b/apps/docs/src/examples/shaders/interactiveShader/App.svelte
@@ -3,6 +3,8 @@
   import Scene from './Scene.svelte'
 </script>
 
+<span class="absolute top-0 left-0 z-20 whitespace-nowrap pl-4">Click on the terrain mesh</span>
+
 <Canvas>
   <Scene />
 </Canvas>

--- a/apps/docs/src/examples/shaders/interactiveShader/Scene.svelte
+++ b/apps/docs/src/examples/shaders/interactiveShader/Scene.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { T } from '@threlte/core'
-  import { OrbitControls, HTML } from '@threlte/extras'
+  import { OrbitControls } from '@threlte/extras'
   import { createNoise2D } from 'simplex-noise'
   import { PlaneGeometry, Vector3 } from 'three'
   import { DEG2RAD } from 'three/src/math/MathUtils'
@@ -36,9 +36,6 @@
   position={[-70, 50, 10]}
   fov={15}
 >
-  <HTML>
-    <span class="whitespace-nowrap pl-4">Click on the terrain mesh</span>
-  </HTML>
   <OrbitControls
     autoRotate
     target.y={1.5}


### PR DESCRIPTION
Helper text was flickering because I used <HTML/> as a child of the camera instead of just a regular div outside of the Canvas.