### PR TITLE
Suspense and useLoader features

### DIFF
--- a/.changeset/early-clouds-search.md
+++ b/.changeset/early-clouds-search.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': minor
+---
+
+Added `suspended` store to return type of `useSuspense`

--- a/.changeset/shaggy-gifts-march.md
+++ b/.changeset/shaggy-gifts-march.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': minor
+---
+
+Added `loader.load` support to `useLoader`

--- a/apps/docs/src/content/reference/extras/suspense.mdx
+++ b/apps/docs/src/content/reference/extras/suspense.mdx
@@ -44,8 +44,8 @@ inside (nested) child components. The implementation roughly follows a subset of
 established by the [React Suspense
 API](https://react.dev/reference/react/Suspense) and has certain limitations.
 
-The basic idea is to allow a parent component to make decisions based on the loading
-state of child components. The parent component can then decide to show a loading
+The idea is to allow a parent component to make decisions based on the _loading
+state_ of child components. The parent component can then decide to show a loading
 indicator or a fallback component while the child component is loading.
 
 <Example path="extras/suspense" />

--- a/apps/docs/src/content/reference/extras/use-suspense.mdx
+++ b/apps/docs/src/content/reference/extras/use-suspense.mdx
@@ -8,4 +8,33 @@
 }
 ---
 
-The hook `useSuspense` is used to mark a resource as being used in a Suspense boundary. Follow the implementation details for the [`<Suspense>` component](/docs/reference/extras/suspense).
+The hook `useSuspense` is used to mark a resource as being used in a
+`<Suspense>` boundary or to get the `suspended`-state of the closest
+`<Suspense>` boundary. For a complete implementation example, have a look at the
+[`<Suspense>` component](/docs/reference/extras/suspense).
+
+## Usage
+
+### Mark as Async Resource
+
+The hook returns a function that allows you to mark a resource as being used in
+a `<Suspense>` boundary. To suspend the closest `<Suspense>` boundary, call the
+function returned by `useSuspense()` and pass a promise as the first argument.
+Because [`useLoader().load()`](/docs/reference/core/use-loader) returns an
+[`AsyncWritable`](/docs/reference/core/utilities#asyncwritable), the result of
+`useLoader().load()` can be passed directly to the function returned by
+`useSuspense()`.
+
+```ts
+const suspend = useSuspense()
+suspend(useTexture('/texture.png'))
+```
+
+### Get Suspended State
+
+The hook can be used to get the `suspended`-state of the closest `<Suspense>` boundary.
+
+```ts
+const { suspended } = useSuspense()
+$: console.log($suspended)
+```

--- a/packages/core/src/lib/hooks/useLoader.ts
+++ b/packages/core/src/lib/hooks/useLoader.ts
@@ -2,15 +2,30 @@ import type { Loader as ThreeLoader } from 'three'
 import { asyncWritable, type AsyncWritable } from '../lib/asyncWritable'
 import { useCache } from '../lib/cache'
 
-export interface Loader extends ThreeLoader {
-  loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<any>
+export interface AsyncLoader extends ThreeLoader {
+  loadAsync: (url: string, onProgress?: (event: ProgressEvent) => void) => Promise<any>
 }
+
+export interface SyncLoader extends ThreeLoader {
+  load: (
+    url: string,
+    success: (data: any) => void,
+    onProgress?: (event: ProgressEvent) => void,
+    onError?: (event: ErrorEvent) => void
+  ) => void
+}
+
+export type Loader = AsyncLoader | SyncLoader
 
 type LoaderProto = { new (): Loader }
 
 export type UseLoaderLoadInput = string | string[] | Record<string, string>
 
-type LoaderResultType<TLoader extends Loader> = Awaited<ReturnType<TLoader['loadAsync']>>
+type LoaderResultType<TLoader extends Loader> = TLoader extends AsyncLoader
+  ? Awaited<ReturnType<TLoader['loadAsync']>>
+  : TLoader extends SyncLoader
+  ? Awaited<ReturnType<TLoader['load']>>
+  : never
 
 export type UseLoaderLoadResult<
   TLoader extends Loader,
@@ -70,13 +85,27 @@ export const useLoader = <
   options.extend?.(loader as InstanceType<Proto>)
 
   const load: ThrelteUseLoader<InstanceType<Proto>>['load'] = (input, options) => {
+    // Allow Async and Sync loaders
+    const loadResource = async (url: string) => {
+      if ('loadAsync' in loader) {
+        const result = await loader.loadAsync(url, options?.onProgress)
+        return options?.transform?.(result) ?? result
+      } else {
+        return new Promise((resolve, reject) => {
+          loader.load(
+            url,
+            (data) => resolve(options?.transform?.(data) ?? data),
+            (event) => options?.onProgress?.(event),
+            reject
+          )
+        })
+      }
+    }
+
     if (Array.isArray(input)) {
       // map over the input array and return an array of promises
       const promises = input.map((url) => {
-        return remember(async () => {
-          const result = await loader.loadAsync(url, options?.onProgress)
-          return options?.transform?.(result) ?? result
-        }, [Proto, url])
+        return remember(() => loadResource(url), [Proto, url])
       })
 
       // return an AsyncWritable that resolves to the array of promises
@@ -84,10 +113,7 @@ export const useLoader = <
       return store as any // TODO: Dirty escape hatch
     } else if (typeof input === 'string') {
       // debugger
-      const promise = remember(async () => {
-        const result = await loader.loadAsync(input, options?.onProgress)
-        return options?.transform?.(result) ?? result
-      }, [Proto, input])
+      const promise = remember(() => loadResource(input), [Proto, input])
 
       // return an AsyncWritable that resolves to the promise
       const store = asyncWritable(promise)
@@ -95,10 +121,7 @@ export const useLoader = <
     } else {
       // map over the input object and return an array of promises
       const promises = Object.values(input).map((url) => {
-        return remember(async () => {
-          const result = await loader.loadAsync(url, options?.onProgress)
-          return options?.transform?.(result) ?? result
-        }, [Proto, url])
+        return remember(() => loadResource(url), [Proto, url])
       })
       // return an AsyncWritable that resolves to the object of promises
       const store = asyncWritable(

--- a/packages/extras/src/lib/suspense/useSuspense.ts
+++ b/packages/extras/src/lib/suspense/useSuspense.ts
@@ -1,6 +1,7 @@
 import { getContext } from 'svelte'
-import { suspenseContextIdentifier, type SuspenseContext } from './context'
 import { get_current_component, onDestroy } from 'svelte/internal'
+import { derived, readable } from 'svelte/store'
+import { suspenseContextIdentifier, type SuspenseContext } from './context'
 
 /**
  * This hook is used to suspend the component until the promise is resolved.
@@ -16,9 +17,13 @@ export const useSuspense = () => {
     return promise
   }
 
+  const state = {
+    suspended: derived(ctx?.suspended ?? readable(false), (suspended) => suspended)
+  }
+
   onDestroy(() => {
     ctx?.onComponentDestroy(component)
   })
 
-  return suspend
+  return Object.assign(suspend, state)
 }


### PR DESCRIPTION
This PR will enable Loaders that only implement the `load` function to be used with `useLoader`. Also it enables listening to the `suspended` state inside a `<Suspense>` boundary with a store.