### PR TITLE
THREE.WebGLRenderer: A WebGL context could not be created - powerPreference: "high-performance"

### DIFF
--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -54,7 +54,7 @@ export const useRenderer = (ctx: ThrelteContext) => {
     rendererParameters: WebGLRendererParameters | undefined
   ): void => {
     ctx.renderer = new WebGLRenderer({
-      powerPreference: 'high-performance',
+      powerPreference: 'default',
       canvas,
       antialias: true,
       alpha: true,


### PR DESCRIPTION
Hi

With my GPU, the `powerPreference: "high-performance"` which is the default on threlte wasn't working

I know it's my GPU because when I deactivate `Hardware Acceleration` on the browser the webpage is loading correctly

So just to say, if you have this issue, maybe just add

```js
<Canvas rendererParameters={{ powerPreference: "default" }}>
 //....
</Canvas>
```


**Why does  `powerPreference: "high-performance"` is the default in threlte ?**


On the discord: https://discord.com/channels/985983540804091964/1173742823141548072/1173742823141548072