### PR TITLE
chore: update extras components to useTask

### DIFF
--- a/.changeset/soft-phones-prove.md
+++ b/.changeset/soft-phones-prove.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': major
+---
+
+@threlte/core ^7 is now required as useTask is used by default

--- a/packages/extras/src/lib/components/Align/Align.svelte
+++ b/packages/extras/src/lib/components/Align/Align.svelte
@@ -93,7 +93,7 @@
       invalidate()
       stop()
     },
-    { autoStart: false }
+    { autoStart: false, autoInvalidate: false }
   )
 
   /** Force a recalculation of the bounding box. */

--- a/packages/extras/src/lib/components/Align/Align.svelte
+++ b/packages/extras/src/lib/components/Align/Align.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { T, createRawEventDispatcher, forwardEventHandlers, useFrame } from '@threlte/core'
+  import {
+    T,
+    createRawEventDispatcher,
+    forwardEventHandlers,
+    useTask,
+    useThrelte
+  } from '@threlte/core'
   import { onMount } from 'svelte'
   import { Box3, Group, Sphere, Vector3 } from 'three'
   import type { AlignEvents, AlignProps, AlignSlots } from './Align.svelte'
@@ -21,6 +27,7 @@
   export let auto: $$Props['auto'] = false
 
   const dispatch = createRawEventDispatcher<$$Events>()
+  const { invalidate } = useThrelte()
 
   const containerGroup = new Group()
   const innerGroup = new Group()
@@ -80,16 +87,13 @@
    * We're only aligning at most *once* per frame, so even if a lot of child
    * components request aligning, it's only done *once*.
    */
-  const { start: scheduleAligning, stop } = useFrame(
-    ({ invalidate }) => {
+  const { start: scheduleAligning, stop } = useTask(
+    () => {
       calculate()
       invalidate()
       stop()
     },
-    {
-      autostart: false,
-      invalidate: false
-    }
+    { autoStart: false }
   )
 
   /** Force a recalculation of the bounding box. */

--- a/packages/extras/src/lib/components/AnimatedSpriteMaterial/AnimatedSpriteMaterial.svelte
+++ b/packages/extras/src/lib/components/AnimatedSpriteMaterial/AnimatedSpriteMaterial.svelte
@@ -16,7 +16,7 @@
     asyncWritable,
     type AsyncWritable,
     createRawEventDispatcher,
-    useFrame,
+    useTask,
     watch,
     useLoader,
     useParent
@@ -197,12 +197,13 @@
     stop()
   }
 
-  const { start, stop } = useFrame(
+  const { start, stop } = useTask(
     () => {
+      if (!json) return
       const now = performance.now()
       const diff = now - timerOffset
       const name = frameNames[currentFrame]
-      const { frame, duration } = json!.frames[name]
+      const { frame, duration } = json.frames[name]
       const interval = duration ?? fpsInterval
 
       if (diff <= interval) return
@@ -231,7 +232,7 @@
         }
       }
     },
-    { autostart: false }
+    { autoStart: false }
   )
 
   watch([textureStore, jsonStore], ([nextTexture, nextJson]) => {

--- a/packages/extras/src/lib/components/CSM/CSM.svelte
+++ b/packages/extras/src/lib/components/CSM/CSM.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { currentWritable, useFrame, useThrelte, watch } from '@threlte/core'
+  import { currentWritable, useTask, useThrelte, watch } from '@threlte/core'
   import { onDestroy } from 'svelte'
   import { writable } from 'svelte/store'
   import type { Camera, ColorRepresentation, Vector3Tuple } from 'three'
@@ -38,7 +38,7 @@
 
   const csm = currentWritable<CSM | undefined>(undefined)
 
-  useFrame(() => $csm?.update(), { invalidate: false })
+  useTask(() => $csm?.update(), { autoInvalidate: false })
 
   const { onNewMaterial, allMaterials } = useMaterials()
 

--- a/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
+++ b/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { forwardEventHandlers, T, useFrame, useThrelte } from '@threlte/core'
+  import { forwardEventHandlers, T, useTask, useThrelte } from '@threlte/core'
   import { onDestroy } from 'svelte'
   import {
     Color,
@@ -193,7 +193,7 @@
   }
 
   let count = 0
-  useFrame(() => {
+  useTask(() => {
     if (frames === Infinity || count < frames) {
       renderShadows()
       count += 1
@@ -213,7 +213,11 @@
   const components = forwardEventHandlers()
 </script>
 
-<T.Group {...$$restProps} let:ref bind:this={$components}>
+<T.Group
+  {...$$restProps}
+  let:ref
+  bind:this={$components}
+>
   <T.Group rotation.x={Math.PI / 2}>
     <T.Mesh
       scale.y={-1}
@@ -222,7 +226,10 @@
       geometry={$planeGeometry}
     />
 
-    <T is={shadowCamera} manual />
+    <T
+      is={shadowCamera}
+      manual
+    />
 
     <slot {ref} />
   </T.Group>

--- a/packages/extras/src/lib/components/Float/Float.svelte
+++ b/packages/extras/src/lib/components/Float/Float.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { MathUtils, type EulerOrder } from 'three'
-  import { useFrame, T } from '@threlte/core'
+  import { useTask, T } from '@threlte/core'
   import type { FloatEvents, FloatProps, FloatSlots } from './Float.svelte'
 
   type $$Props = Required<FloatProps>
@@ -31,7 +31,7 @@
     ? rotation
     : [rotation, rotation, rotation]
 
-  useFrame((_, delta) => {
+  useTask((delta) => {
     t += delta
 
     // Floating

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -3,7 +3,7 @@
     createRawEventDispatcher,
     forwardEventHandlers,
     T,
-    useFrame,
+    useTask,
     useThrelte
   } from '@threlte/core'
   import { derived, writable, type Writable } from 'svelte/store'
@@ -201,7 +201,7 @@
 
   let showEl = getAncestorVisibility()
 
-  useFrame(async () => {
+  useTask(async () => {
     showEl = getAncestorVisibility()
 
     const camera = getCamera()

--- a/packages/extras/src/lib/components/Instancing/Api.svelte
+++ b/packages/extras/src/lib/components/Instancing/Api.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { T, useFrame } from '@threlte/core'
+  import { T, useTask } from '@threlte/core'
   import type { InstancedMesh } from 'three'
   import { DynamicDrawUsage, Matrix4, Quaternion, Vector3 } from 'three'
   import { createApi } from './api'
@@ -26,7 +26,7 @@
   const scale = new Vector3()
 
   let initialUpdateDone = false
-  useFrame(() => {
+  useTask(() => {
     instancedMesh.updateMatrix()
     if (update || !initialUpdateDone) {
       instancedMesh.updateMatrixWorld()

--- a/packages/extras/src/lib/components/Sky/Sky.svelte
+++ b/packages/extras/src/lib/components/Sky/Sky.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { T, useFrame, useThrelte } from '@threlte/core'
+  import { T, useTask, useThrelte } from '@threlte/core'
   import { onDestroy } from 'svelte'
   import {
     CubeCamera,
@@ -64,7 +64,7 @@
     invalidate()
   }
 
-  const { start: scheduleUpdate, stop } = useFrame(
+  const { start: scheduleUpdate, stop } = useTask(
     () => {
       sky.scale.setScalar(scale)
 
@@ -88,8 +88,8 @@
       stop()
     },
     {
-      autostart: false,
-      invalidate: false
+      autoStart: false,
+      autoInvalidate: false
     }
   )
 

--- a/packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte
+++ b/packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { forwardEventHandlers, T, useFrame, useParent, useThrelte } from '@threlte/core'
+  import { forwardEventHandlers, T, useTask, useParent, useThrelte } from '@threlte/core'
   import type { Camera } from 'three'
   import { OrbitControls as ThreeOrbitControls } from 'three/examples/jsm/controls/OrbitControls'
   import { useControlsContext } from '../useControlsContext'
@@ -27,8 +27,8 @@
 
   export const ref = new ThreeOrbitControls($parent, renderer.domElement)
 
-  const { start, stop } = useFrame(() => ref.update(), {
-    autostart: false
+  const { start, stop } = useTask(() => ref.update(), {
+    autoStart: false
   })
 
   $: {

--- a/packages/extras/src/lib/hooks/useGamepad.ts
+++ b/packages/extras/src/lib/hooks/useGamepad.ts
@@ -1,5 +1,5 @@
 import { onDestroy } from 'svelte'
-import { currentWritable, useFrame, useThrelte } from '@threlte/core'
+import { currentWritable, useTask, useThrelte } from '@threlte/core'
 
 type UseGamepadOptions = {
   /** The threshold value of any axis before change events are fired. Default is 0.05. */
@@ -361,9 +361,9 @@ export function useGamepad(options: UseGamepadOptions = {}) {
       })
     }
 
-    // useFrame automatically stops whenever the host component unmounts, so we
+    // useTask automatically stops whenever the host component unmounts, so we
     // don't need to clean up here.
-    const { start, stop } = useFrame(processSnapshot, { autostart: false, invalidate: false })
+    const { start, stop } = useTask(processSnapshot, { autoStart: false, autoInvalidate: false })
 
     const handleConnected = (event: THREE.Event) => {
       if (event.data.handedness !== options.hand) return
@@ -462,9 +462,9 @@ export function useGamepad(options: UseGamepadOptions = {}) {
       )
     }
 
-    // useFrame automatically stops whenever the host component unmounts, so we
+    // useTask automatically stops whenever the host component unmounts, so we
     // don't need to clean up here.
-    const { start, stop } = useFrame(processSnapshot, { autostart: false, invalidate: false })
+    const { start, stop } = useTask(processSnapshot, { autoStart: false, autoInvalidate: false })
 
     const handleGamepadDisconnected = (event: GamepadEvent): void => {
       const { id } = event.gamepad

--- a/packages/extras/src/lib/hooks/useGltfAnimations.ts
+++ b/packages/extras/src/lib/hooks/useGltfAnimations.ts
@@ -1,4 +1,4 @@
-import { currentWritable, useFrame, watch, type CurrentWritable } from '@threlte/core'
+import { currentWritable, useTask, watch, type CurrentWritable } from '@threlte/core'
 import { tick } from 'svelte'
 import { derived, writable, type Writable } from 'svelte/store'
 import { AnimationMixer, type AnimationAction, type Object3D } from 'three'
@@ -89,11 +89,11 @@ export function useGltfAnimations<
     }
   })
 
-  const { start, stop } = useFrame(
-    (_, delta) => {
+  const { start, stop } = useTask(
+    (delta) => {
       mixer.update(delta)
     },
-    { autostart: false }
+    { autoStart: false }
   )
 
   watch(actions, (actions) => {


### PR DESCRIPTION
First the good news. These components have been tested in the docs and work the same as before.

~~the interesting news. Some components errored out looking for the `after` prop but wasn't supplied any additional options. [HTML for ex](https://github.com/threlte/threlte/blob/e260da1ea4510d6ac553c64eed036e4f976e1c78/packages/extras/src/lib/components/HTML/HTML.svelte#L283C5-L283C5).~~

still to go:

- [x] AnimatedSpriteMaterial
- [x] Contact shadows
- [x] Float
- [x] HTML
- [x] instance
- [x] gamepad