### PR TITLE
`shouldRender()` fix

### DIFF
--- a/.changeset/long-bags-burn.md
+++ b/.changeset/long-bags-burn.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Fixes a bug where calling `useThrelte().shouldRender()` resets the invalidation flags and makes it impossible to invoke more than once per frame.

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -170,7 +170,10 @@
 
     contexts.getCtx().renderer.setAnimationLoop((time) => {
       contexts.getInternalCtx().dispose()
+
       scheduler.run(time)
+
+      contexts.getInternalCtx().resetFrameInvalidation()
     })
 
     initialized.set(true)


### PR DESCRIPTION
Fixes a bug where calling `useThrelte().shouldRender()` resets the invalidation flags and makes it impossible to invoke more than once per frame.