### PR TITLE
[docs] Fix missing variable declarations in `useGltfAnimations` example

### DIFF
--- a/apps/docs/src/content/reference/extras/use-gltf-animations.mdx
+++ b/apps/docs/src/content/reference/extras/use-gltf-animations.mdx
@@ -53,7 +53,7 @@ Sometimes you might want to use the hook [`useGltf`](/docs/reference/extras/use-
   const gltf = useGltf('/path/to/model.glb')
 
   // Provide that store to the hook useGltfAnimations
-  useGltfAnimations<'All Animations'>(gltf)
+  const { gltf, actions, mixer } = useGltfAnimations<'All Animations'>(gltf)
 
   // play the animation as soon as it's loaded
   $: $actions['All Animations']?.play()

--- a/apps/docs/src/content/reference/extras/use-gltf-animations.mdx
+++ b/apps/docs/src/content/reference/extras/use-gltf-animations.mdx
@@ -53,7 +53,7 @@ Sometimes you might want to use the hook [`useGltf`](/docs/reference/extras/use-
   const gltf = useGltf('/path/to/model.glb')
 
   // Provide that store to the hook useGltfAnimations
-  const { gltf, actions, mixer } = useGltfAnimations<'All Animations'>(gltf)
+  const { actions, mixer } = useGltfAnimations<'All Animations'>(gltf)
 
   // play the animation as soon as it's loaded
   $: $actions['All Animations']?.play()


### PR DESCRIPTION
Woohoo, docs!

Previously, there were missing destructuring declarations from `useGltfAnimations(gltf)` that were referenced in later in the example. This PR simply adds that.