### PR TITLE
Fix broken URLs returned from `getGithubEditUrl`

### DIFF
--- a/apps/docs/src/lib/getGithubEditUrl.ts
+++ b/apps/docs/src/lib/getGithubEditUrl.ts
@@ -3,8 +3,7 @@ import type { AstroGlobal } from 'astro'
 /** Gets the URL to edit the page on GitHub */
 export const getGithubEditUrl = (Astro: Readonly<AstroGlobal>) => {
   const currentPage = Astro.url.pathname
-  return `https://github.com/threlte/threlte/blob/main/apps/docs/src/content/${currentPage.replace(
-    '/docs/',
-    ''
-  )}.mdx`
+  return `https://github.com/threlte/threlte/blob/main/apps/docs/src/content/${currentPage
+    .replace('/docs/', '')
+    .replace(/\/$/, '')}.mdx`
 }


### PR DESCRIPTION
Fixes #749