### PR TITLE
Fix about unused export property 'endFrame'

### DIFF
--- a/packages/extras/src/lib/components/AnimatedSpriteMaterial/AnimatedSpriteMaterial.svelte
+++ b/packages/extras/src/lib/components/AnimatedSpriteMaterial/AnimatedSpriteMaterial.svelte
@@ -48,7 +48,7 @@
   export let transparent: $$Props['transparent'] = true
   export let flipX: $$Props['flipX'] = false
   export let startFrame: $$Props['startFrame'] = 0
-  export let endFrame: $$Props['endFrame'] | undefined = undefined
+  export const endFrame: $$Props['endFrame'] | undefined = undefined
   export let rows: $$Props['rows'] = 1
   export let columns: $$Props['columns'] | undefined = undefined
   export let totalFrames: $$Props['totalFrames'] = 0


### PR DESCRIPTION
Hi all,

I'm really not sure if this is helpful at all, so please close this if it wastes time and is a false positive warning message I got within my repository using `@threlte+extras@8.0.0`.

```
transforming (233) node_modules/.pnpm/@skeletonlabs+skeleton@2.5.0_svelte@4.2.7/node_modules/@skeletonlabs/skeleton/dist/actions/Filters/svg-filters/BlueNight.svelte12:13:27 AM [vite-plugin-svelte] <redacted>/hellob.art/node_modules/.pnpm/@threlte+extras@8.0.0_svelte@4.2.7_three@0.159.0/node_modules/@threlte/extras/dist/components/AnimatedSpriteMaterial/AnimatedSpriteMaterial.svelte:17:11 AnimatedSpriteMaterial has unused export property 'endFrame'. If it is for external reference only, please consider using `export const endFrame`
15: export let flipX = false;
16: export let startFrame = 0;
17: export let endFrame = undefined;
               ^
18: export let rows = 1;
19: export let columns = undefined;
```