### PR TITLE
Allow reactive `<Portal>` ids

### DIFF
--- a/.changeset/loud-panthers-cough.md
+++ b/.changeset/loud-panthers-cough.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+Allow reactive <Portal> ids

--- a/packages/extras/src/lib/components/portals/Portal/Portal.svelte
+++ b/packages/extras/src/lib/components/portals/Portal/Portal.svelte
@@ -1,26 +1,48 @@
 <script lang="ts">
-  import { HierarchicalObject } from '@threlte/core'
+  import { HierarchicalObject, watch } from '@threlte/core'
   import type { Object3D } from 'three'
   import { usePortalContext } from '../usePortalContext'
+  import { writable } from 'svelte/store'
 
   export let id = 'default'
   export let object: Object3D | undefined = undefined
 
   const { getPortal } = usePortalContext()
 
-  const portal = getPortal(id)
+  const children = writable<Object3D[]>([])
+  const target = writable<Object3D | undefined>()
 
-  $: portalTarget = object ?? $portal
+  $: portal = getPortal(id)
+  $: target.set(object ?? $portal)
+
+  watch([children, target], ([children, target]) => {
+    if (target === undefined) return
+
+    for (const child of children) {
+      if (target.children.includes(child)) continue
+      target.add(child)
+    }
+    
+    return () => {
+      for (const child of children) {
+        if (target.children.includes(child)) {
+          target.remove(child)
+        }
+      }
+    }
+  })
 </script>
 
-{#if portalTarget}
+{#if $target}
   <HierarchicalObject
-    onChildMount={(child) => {
-      portalTarget?.add(child)
-    }}
-    onChildDestroy={(child) => {
-      portalTarget?.remove(child)
-    }}
+    onChildMount={(child) => children.update((array) => {
+      array.push(child)
+      return array
+    })}
+    onChildDestroy={(child) => children.update((array) => {
+      array.splice(array.indexOf(child), 1)
+      return array
+    })}
   >
     <slot />
   </HierarchicalObject>


### PR DESCRIPTION
I currently have the following use case for `<Portal>`:

```svelte
<Portal {id}>
  <T.Mesh>...</T.Mesh>
</Portal>
```

Where `id` is reactive. The current portal doesn't support reactive ids, so this PR adds it!