### PR TITLE
Gizmo visuals

### DIFF
--- a/.changeset/green-pianos-learn.md
+++ b/.changeset/green-pianos-learn.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+Improved Gizmo visuals

--- a/apps/docs/src/examples/extras/gizmo/App.svelte
+++ b/apps/docs/src/examples/extras/gizmo/App.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { Canvas, T, type CurrentWritable, currentWritable } from '@threlte/core'
-  import { Gizmo, OrbitControls } from '@threlte/extras'
   import { useTweakpane } from '$lib/useTweakpane'
+  import { Canvas, T, currentWritable, type CurrentWritable } from '@threlte/core'
+  import { Gizmo, OrbitControls } from '@threlte/extras'
+  import type { Writable } from 'svelte/store'
+  import { OrbitControls as ThreeOrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
   import Scene from './Scene.svelte'
-  import { OrbitControls as ThreeOrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
   const { action, addInput } = useTweakpane({
     title: 'Gizmo',
@@ -18,19 +19,27 @@
     }
   })
 
-  const vert = addInput({
+  const verticalPlacement = addInput({
     label: 'Vertical placement (top or bottom)',
-    value: 'bottom'
-  })
-  let verticalPlacement: 'top' | 'bottom'
-  $: verticalPlacement = $vert === 'top' ? 'top' : 'bottom'
+    value: 'bottom',
+    params: {
+      options: {
+        top: 'top',
+        bottom: 'bottom'
+      }
+    }
+  }) as Writable<'top' | 'bottom'>
 
-  const horiz = addInput({
+  const horizontalPlacement = addInput({
     label: 'Horizontal placement (left or right)',
-    value: 'right'
-  })
-  let horizontalPlacement: 'left' | 'right'
-  $: horizontalPlacement = $horiz === 'left' ? 'left' : 'right'
+    params: {
+      options: {
+        left: 'left',
+        right: 'right'
+      }
+    },
+    value: 'left'
+  }) as Writable<'left' | 'right'>
 
   const xColor = addInput({
     label: 'X color',
@@ -98,8 +107,8 @@
     <Gizmo
       center={$center}
       turnRate={$turnRate}
-      {verticalPlacement}
-      {horizontalPlacement}
+      verticalPlacement={$verticalPlacement}
+      horizontalPlacement={$horizontalPlacement}
       xColor={$xColor}
       yColor={$yColor}
       zColor={$zColor}

--- a/apps/docs/src/examples/extras/gizmo/Scene.svelte
+++ b/apps/docs/src/examples/extras/gizmo/Scene.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { T } from '@threlte/core'
+  import { Grid } from '@threlte/extras'
 
   export let center: [number, number, number]
 
@@ -35,7 +36,15 @@
   ])
 </script>
 
-<T.AxesHelper args={[5]} />
+<T.AxesHelper
+  args={[5]}
+  renderOrder={1}
+/>
+
+<Grid
+  sectionSize={0}
+  cellColor="#eee"
+/>
 
 <T.Mesh position={center}>
   <T.BoxGeometry>

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
@@ -210,7 +210,7 @@
     context.beginPath()
     context.arc(32, 32, 16, 0, 2 * Math.PI)
     context.closePath()
-    context.fillStyle = new Color(color).getStyle()
+    context.fillStyle = new Color(color).convertSRGBToLinear().getStyle()
     context.fill()
 
     if (text) {
@@ -228,6 +228,7 @@
   <T.Scene bind:ref={root}>
     <!-- xAxis -->
     <T.Sprite
+      renderOrder={1}
       bind:ref={posX}
       position.x={1}
       userData.targetPosition={[1, 0, 0]}
@@ -253,6 +254,7 @@
     </T.Mesh>
 
     <T.Sprite
+      renderOrder={1}
       bind:ref={negX}
       position.x={-1}
       scale={0.8}
@@ -267,6 +269,7 @@
 
     <!-- yAxis -->
     <T.Sprite
+      renderOrder={1}
       bind:ref={posY}
       position.y={1}
       userData.targetPosition={[0, 1, 0]}
@@ -295,6 +298,7 @@
     </T.Mesh>
 
     <T.Sprite
+      renderOrder={1}
       bind:ref={negY}
       position.y={-1}
       scale={0.8}
@@ -309,6 +313,7 @@
 
     <!-- zAxis -->
     <T.Sprite
+      renderOrder={1}
       bind:ref={posZ}
       position.z={1}
       userData.targetPosition={[0, 0, 1]}
@@ -337,6 +342,7 @@
     </T.Mesh>
 
     <T.Sprite
+      renderOrder={1}
       bind:ref={negZ}
       position.z={-1}
       scale={0.8}


### PR DESCRIPTION
@ethanlook, I hope you're fine with me doing some adjustments to the visuals. I corrected the colors of the canvas textures as well as adding a `renderOrder` to the sprites so that the overlap of the sprites with the "axis stems" do not create a transparency artifact.
I also added a mechanic that if you click on a target rotation that is already reached, the camera rotates towards the opposite side, so if you click on Y+ once, it's going to rotate to Y+. Then, if you click on Y+, it's going to rotate towards Y-. It's a common Gizmo mechanic and makes it intuitive to go to the opposite side of an axis.
