### PR TITLE
useLoader: Accept constructor arguments

### DIFF
--- a/.changeset/afraid-schools-give.md
+++ b/.changeset/afraid-schools-give.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+fixed useTexture signature

--- a/.changeset/seven-spoons-add.md
+++ b/.changeset/seven-spoons-add.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+Added args to useLoader options

--- a/apps/docs/src/content/reference/core/use-loader.mdx
+++ b/apps/docs/src/content/reference/core/use-loader.mdx
@@ -5,7 +5,25 @@ sourcePath: 'packages/core/src/lib/hooks/useLoader.ts'
 order: 5.4
 ---
 
-A hook to load data with an arbitrary `THREE` loader class. The result of `load` is cached and subsequent calls will return the same result.
+A hook to load data with an arbitrary `THREE` loader class. The result of `load`
+is cached and subsequent calls with the same arguments will yield the same
+return value (i.e. the same reference) across the entire Threlte app. The hook
+can use async loaders (using `loader.loadAsync`) as well as sync/callback-based
+loaders (using `loader.load`) and will default to the async version if
+available.
+
+```typescript
+const loader = useLoader(AudioLoader)
+const soundA = loader.load('audio/ambient_ocean.ogg')
+// -> `soundA` is an AsyncWritable<AudioBuffer> that
+// resolves/is populated once the asset is loaded.
+
+// somewhere else …
+const soundB = loader.load('audio/ambient_ocean.ogg')
+// -> `soundB` is also an AsyncWritable<AudioBuffer>
+// that resolves/is populated with the same reference
+// as `soundA` once the asset is loaded.
+```
 
 ### Instantiating A Loader
 
@@ -36,6 +54,25 @@ A loader can be **extended**, to add custom features:
 </script>
 ```
 
+If the constructor of a particular loader accepts arguments, they must be passed
+as an array to the option `args` of the second argument to `useLoader`:
+
+```svelte
+<script>
+  import { useLoader, useThrelte } from '@threlte/core'
+  import { SplatLoader } from '@pmndrs/vanilla'
+
+  const { renderer } = useThrelte()
+
+  const loader = useLoader(SplatLoader, {
+    args: [renderer]
+  })
+  // This resembles the following:
+  // const loader = new SplatLoader(renderer)
+</script>
+```
+
+
 ### Loading An Asset
 
 ```svelte
@@ -54,8 +91,10 @@ A loader can be **extended**, to add custom features:
 </script>
 ```
 
-The return type of `load` is a custom Threlte store called `AsyncWritable` and can be used as a regular Svelte store.
-Its initial value is `undefined` and will be updated once the asset is loaded.
+The return type of `load` is a [custom Threlte store called
+`AsyncWritable`](/docs/reference/core/utilities#asyncwritable) and can be used
+as a regular Svelte store. Its initial value is `undefined` and will be updated
+once the asset is loaded.
 
 The store also exposes the underlying promise methods `then` and `catch` and can therefore be directly awaited:
 

--- a/packages/core/src/lib/hooks/useLoader.ts
+++ b/packages/core/src/lib/hooks/useLoader.ts
@@ -96,17 +96,6 @@ export type UseLoaderOptions<Proto extends LoaderProtoWithoutArgs> =
     ? UseLoaderOptionsWithoutArgs<Proto>
     : UseLoaderOptionsWithArgs<Proto>
 
-/**
- * This works only with ES6 classes.
- */
-function isClass(t: any): t is { new (): any } {
-  try {
-    return Boolean(class extends t {})
-  } catch {
-    return false
-  }
-}
-
 export function useLoader<Proto extends LoaderProtoWithoutArgs>(
   Proto: Proto,
   options?: UseLoaderOptions<Proto>

--- a/packages/core/src/lib/hooks/useLoader.ts
+++ b/packages/core/src/lib/hooks/useLoader.ts
@@ -8,15 +8,18 @@ type AsyncLoader = {
 type SyncLoader = {
   load: (
     url: string,
-    success: (data: any) => void,
+    onLoad: (data: any) => void,
     onProgress?: (event: ProgressEvent) => void,
-    onError?: (event: ErrorEvent) => void
-  ) => void
+    onError?: (event: unknown) => void
+  ) => unknown
 }
 
 export type Loader = AsyncLoader | SyncLoader
 
-type LoaderProto = { new (): Loader }
+// Some loaders may not have any constructor arguments …
+type LoaderProtoWithoutArgs = { new (): Loader }
+// … but some other loaders do.
+type LoaderProtoWithArgs = { new (...args: any[]): Loader }
 
 export type UseLoaderLoadInput = string | string[] | Record<string, string>
 
@@ -62,38 +65,84 @@ type ThrelteUseLoader<TLoader extends Loader> = {
   clear: <Input extends string | string[] | Record<string, string>>(input: Input) => void
 }
 
-export type UseLoaderOptions<TLoader extends Loader> = {
+type UseLoaderOptionsWithoutArgs<Proto extends LoaderProtoWithoutArgs> = {
   /**
    * A loader can be extended to add custom
    * functionality, e.g. add DRACO support.
    */
-  extend?: (loader: TLoader) => void
+  extend?: (loader: InstanceType<Proto>) => void
+  /**
+   * Arguments to pass to the loader.
+   */
+  args?: ConstructorParameters<Proto>
 }
 
-export const useLoader = <
-  Proto extends LoaderProto,
-  UseLoaderResult = ThrelteUseLoader<InstanceType<Proto>>
->(
+type UseLoaderOptionsWithArgs<Proto extends LoaderProtoWithArgs> = {
+  /**
+   * A loader can be extended to add custom
+   * functionality, e.g. add DRACO support.
+   */
+  extend?: (loader: InstanceType<Proto>) => void
+  /**
+   * Arguments to pass to the loader.
+   */
+  args: ConstructorParameters<Proto>
+}
+
+export type UseLoaderOptions<Proto extends LoaderProtoWithoutArgs> =
+  ConstructorParameters<Proto> extends []
+    ? UseLoaderOptionsWithoutArgs<Proto>
+    : undefined extends ConstructorParameters<Proto>[0]
+    ? UseLoaderOptionsWithoutArgs<Proto>
+    : UseLoaderOptionsWithArgs<Proto>
+
+/**
+ * This works only with ES6 classes.
+ */
+function isClass(t: any): t is { new (): any } {
+  try {
+    return Boolean(class extends t {})
+  } catch {
+    return false
+  }
+}
+
+export function useLoader<Proto extends LoaderProtoWithoutArgs>(
   Proto: Proto,
-  options: UseLoaderOptions<InstanceType<Proto>> = {}
-): UseLoaderResult => {
+  options?: UseLoaderOptions<Proto>
+): ThrelteUseLoader<InstanceType<Proto>>
+export function useLoader<Proto extends LoaderProtoWithArgs>(
+  Proto: Proto,
+  options: UseLoaderOptions<Proto>
+): ThrelteUseLoader<InstanceType<Proto>>
+export function useLoader<Proto extends LoaderProtoWithoutArgs>(
+  Proto: Proto,
+  options?: UseLoaderOptions<Proto>
+): ThrelteUseLoader<InstanceType<Proto>> {
   const { remember, clear: clearCacheItem } = useCache()
 
-  // instantiate the loader
-  const loader = new Proto()
+  let loader: InstanceType<Proto> | undefined
 
-  // extend the loader if necessary
-  options.extend?.(loader as InstanceType<Proto>)
+  const initializeLoader = (): InstanceType<Proto> => {
+    // Type-wrestling galore
+    const lazyLoader = new Proto(...(((options as any)?.args as []) ?? [])) as InstanceType<Proto>
+    // extend the loader if necessary
+    options?.extend?.(lazyLoader)
+    return lazyLoader
+  }
 
   const load: ThrelteUseLoader<InstanceType<Proto>>['load'] = (input, options) => {
     // Allow Async and Sync loaders
     const loadResource = async (url: string) => {
+      if (!loader) {
+        loader = initializeLoader()
+      }
       if ('loadAsync' in loader) {
         const result = await loader.loadAsync(url, options?.onProgress)
         return options?.transform?.(result) ?? result
       } else {
         return new Promise((resolve, reject) => {
-          loader.load(
+          ;(loader as SyncLoader).load(
             url,
             (data) => resolve(options?.transform?.(data) ?? data),
             (event) => options?.onProgress?.(event),
@@ -113,7 +162,6 @@ export const useLoader = <
       const store = asyncWritable(Promise.all(promises))
       return store as any // TODO: Dirty escape hatch
     } else if (typeof input === 'string') {
-      // debugger
       const promise = remember(() => loadResource(input), [Proto, input])
 
       // return an AsyncWritable that resolves to the promise
@@ -152,5 +200,83 @@ export const useLoader = <
     load,
     clear,
     loader
-  } as UseLoaderResult
+  } as ThrelteUseLoader<InstanceType<Proto>>
 }
+
+// Type tests
+
+// class WithConstructorParameters {
+//   constructor(hello: 'abc' | 'def') {
+//     console.log(hello)
+//   }
+
+//   loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<any> {
+//     return new Promise((r) => r('hello'))
+//   }
+// }
+
+// class WithOptionalConstructorParameters {
+//   constructor(hello?: string) {
+//     console.log(hello)
+//   }
+
+//   loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<any> {
+//     return new Promise((r) => r('hello'))
+//   }
+// }
+
+// class WithoutConstructorParameters {
+//   constructor() {
+//     console.log('without')
+//   }
+
+//   loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<any> {
+//     return new Promise((r) => r('hello'))
+//   }
+// }
+
+// const shouldFail = () => {
+//   useLoader(WithConstructorParameters)
+//   useLoader(WithoutConstructorParameters, {
+//     args: ['hello']
+//   })
+// }
+
+// const shouldSucceed = () => {
+//   useLoader(WithConstructorParameters, {
+//     args: ['abc']
+//   })
+//   useLoader(WithConstructorParameters, {
+//     args: ['abc'],
+//     extend(loader) {
+//       // …
+//     }
+//   })
+//   useLoader(WithOptionalConstructorParameters)
+//   useLoader(WithOptionalConstructorParameters, {
+//     extend(loader) {
+//       // …
+//     }
+//   })
+//   useLoader(WithOptionalConstructorParameters, {
+//     args: [],
+//     extend(loader) {
+//       // …
+//     }
+//   })
+//   useLoader(WithOptionalConstructorParameters, {
+//     args: ['hello'],
+//     extend(loader) {
+//       // …
+//     }
+//   })
+//   useLoader(WithOptionalConstructorParameters, {
+//     args: ['hello']
+//   })
+//   useLoader(WithoutConstructorParameters)
+//   useLoader(WithoutConstructorParameters, {
+//     extend(loader) {
+//       // …
+//     }
+//   })
+// }

--- a/packages/extras/src/lib/hooks/useTexture.ts
+++ b/packages/extras/src/lib/hooks/useTexture.ts
@@ -9,7 +9,7 @@ import { TextureLoader } from 'three'
 
 export const useTexture = <Input extends UseLoaderLoadInput>(
   input: Input,
-  options?: UseLoaderOptions<TextureLoader> &
+  options?: UseLoaderOptions<typeof TextureLoader> &
     Parameters<ReturnType<typeof useLoader<typeof TextureLoader>>['load']>[1]
 ): UseLoaderLoadResult<TextureLoader, Input> => {
   const loader = useLoader(TextureLoader, options)


### PR DESCRIPTION
- Enables the use of loaders that accept arguments

```ts
class SomeLoader {
  constructor(foo: string) {}
  loadAsync: (/* ... */) {}
}

const loader = useLoader(SomeLoader, {
  args: ['bar']
})
```

- Lazily creates loader before cache retrieval, so best case scenario doesn't create a loader at all