### PR TITLE
On-demand rendering for the `<TrackballControls>`

### DIFF
--- a/.changeset/tiny-rules-double.md
+++ b/.changeset/tiny-rules-double.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+On-demand rendering for the `<TrackballControls>` as well as JSDoc test for tsdocs.dev

--- a/apps/docs/src/content/reference/extras/trackball-controls.mdx
+++ b/apps/docs/src/content/reference/extras/trackball-controls.mdx
@@ -21,7 +21,9 @@
 The component `<TrackballControls>` must be a direct child of a camera component and will mount itself to that camera.
 By default, damping is enabled. You can disable this by setting `staticMoving` to true.
 
-When using `<TrackballControls>`, the frame loop will run continously. Note that unlike `<OrbitControls>`, `<TrackballControls>` does not support `autoRotate`.
+<Tip type="info">
+	Unlike `<OrbitControls>`, `<TrackballControls>` does not support `autoRotate`.
+</Tip>
 
 <Example
   path="extras/trackball-controls"
@@ -47,5 +49,4 @@ This example shows off just a few of the configurable properties of `<TrackballC
 ```
 
 `<TrackballControls>` is a light wrapper that will use its parent as the target camera and the DOM element
-the renderer is rendering to as the DOM element to listen to. It will also by demand invalidate the frame loop
-and will run the frame loop continuously.
+the renderer is rendering to as the DOM element to listen to. It will also by demand invalidate the frame loop.

--- a/packages/extras/src/lib/components/controls/TrackballControls/TrackballControls.svelte
+++ b/packages/extras/src/lib/components/controls/TrackballControls/TrackballControls.svelte
@@ -31,7 +31,9 @@
 
   export const ref = new ThreeTrackballControls($parent, renderer.domElement)
 
-  useTask(ref.update)
+  useTask(ref.update, {
+    autoInvalidate: false
+  })
 
   const component = forwardEventHandlers()
 

--- a/packages/extras/src/lib/components/controls/TrackballControls/TrackballControls.svelte.d.ts
+++ b/packages/extras/src/lib/components/controls/TrackballControls/TrackballControls.svelte.d.ts
@@ -6,6 +6,38 @@ export type TrackballControlsProps = Props<ThreeTrackballControls>
 export type TrackballControlsEvents = Events<ThreeTrackballControls>
 export type TrackballControlsSlots = Slots<ThreeTrackballControls>
 
+/**
+ * `<TrackballControls>` allow the camera to orbit freely around a target
+ * without causing gimbal lock. This type of camera controller is commonly used
+ * when the concepts of up and down are less important than the ability to
+ * carefully inspect a model from every angle.
+ *
+ * For an alternative camera controller, see
+ * [`<OrbitControls>`](https://threlte.xyz/docs/reference/extras/orbit-controls).
+ *
+ * The component `<TrackballControls>` must be a direct child of a camera
+ * component and will mount itself to that camera. By default, damping is
+ * enabled. You can disable this by setting `staticMoving` to true.
+ *
+ * ## Usage
+ *
+ * ```svelte
+ * <script>
+ *   import { TrackballControls } from '@threlte/extras'
+ *   import { T } from '@threlte/core'
+ * </script>
+ *
+ * <T.PerspectiveCamera
+ *   makeDefault
+ *   fov={50}
+ * >
+ *   <TrackballControls />
+ * </T.PerspectiveCamera>
+ * ```
+ *
+ * `<TrackballControls>` is a light wrapper that will use its parent as the target camera and the DOM element
+ * the renderer is rendering to as the DOM element to listen to. It will also by demand invalidate the frame loop.
+ */
 export default class TrackballControls extends SvelteComponent<
   TrackballControlsProps,
   TrackballControlsEvents,


### PR DESCRIPTION
On-demand rendering for the `<TrackballControls>` as well as JSDoc test for tsdocs.dev.