### PR TITLE
fix: Gizmo click detection works properly when <Canvas> does not cover viewport

### DIFF
--- a/.changeset/funny-apricots-roll.md
+++ b/.changeset/funny-apricots-roll.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': patch
+---
+
+fix Gizmo click events when the Canvas is not taking up the full viewport

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
@@ -88,22 +88,26 @@
   // target is added as a sibling of the renderer's
   // dom element.
   const clickTarget = document.createElement('div')
+  // We need to know the bounding rect of the renderer's dom element
+  const renderTarget = renderer.domElement
+  const boundingRect = renderTarget.getBoundingClientRect()
+
   clickTarget.style.position = 'absolute'
   $: {
     if (horizontalPlacement === 'right') {
-      clickTarget.style.right = `${paddingX}px`
-      clickTarget.style.left = ''
+      clickTarget.style.right = ''
+      clickTarget.style.left = `${boundingRect.right - size - paddingX}px`
     } else {
       clickTarget.style.right = ''
-      clickTarget.style.left = `${paddingX}px`
+      clickTarget.style.left = `${paddingX + boundingRect.left}px`
     }
 
     if (verticalPlacement === 'bottom') {
-      clickTarget.style.bottom = `${paddingY}px`
-      clickTarget.style.top = ''
+      clickTarget.style.bottom = ''
+      clickTarget.style.top = `${boundingRect.bottom - size - paddingY}px`
     } else {
       clickTarget.style.bottom = ''
-      clickTarget.style.top = `${paddingY}px`
+      clickTarget.style.top = `${paddingY + boundingRect.top}px`
     }
 
     clickTarget.style.height = `${size}px`


### PR DESCRIPTION
This PR addresses https://github.com/threlte/threlte/issues/809.

The `<Gizmo>` component does its own manual click detection because the `<Gizmo>` is not part of the `<Scene>`. To do that it creates its own dedicated div for listening to click events. To position that div correctly, the `<Gizmo>` component needs to understand the bounding rectangle of the DOM element that the renderer is attached to. If that DOM element is offset on the page by some X and Y, we need to respect those offsets when styling the `<Gizmo>`'s click div. Similarly, if the div that the `<Canvas>` is rendering to is shorter and thinner than the page overall, we need to account for that.

Here is one screenshot of the testing I performed to ensure this PR functions as intended even with padding on all four sides of the `<Canvas>`, and when placing the `<Gizmo>` in all four corners:
<img width="911" alt="Screenshot 2023-12-30 at 11 32 16 PM" src="https://github.com/threlte/threlte/assets/1302431/7f5119d9-e23f-4d6e-8e03-68ef5b9a61be">

I did not include the changes I made to perform that testing in this PR because they make the example page ugly, but if you'd like to test it out you can check out https://github.com/threlte/threlte/commit/dc5c3aa3ab64b19312b094149142a0c59a3011a9 which is stored in my companion branch, `fix-gizmo-click-events-testing`