### PR TITLE
update astro config

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -24,9 +24,6 @@ if (process.env.NODE_ENV === 'production') {
 // https://astro.build/config
 export default defineConfig({
   prefetch: true,
-  experimental: {
-    clientPrerender: true
-  },
   build: {
     inlineStylesheets: 'never'
   },


### PR DESCRIPTION
With updating dependencies the [experimental flag](https://docs.astro.build/en/reference/configuration-reference/#experimentalclientprerender) is no longer needed. 

Builds will fail because:

```
[config] Astro found issue(s) with your configuration:
  ! experimental  Invalid experimental key: `clientPrerender`. 
Make sure the spelling is correct, and that your Astro version supports this experiment.
See https://docs.astro.build/en/reference/configuration-reference/#experimental-flags for more information..
```

And red squiggles because:

```sh
Object literal may only specify known properties, and 'clientPrerender' does not exist in type '{ optimizeHoistedScript?: boolean; }'.
```