### PR TITLE
Remove tailwind classes from examples

### DIFF
--- a/.changeset/hip-lemons-invite.md
+++ b/.changeset/hip-lemons-invite.md
@@ -1,0 +1,5 @@
+---
+"@threlte/docs": minor
+---
+
+Remove tailwind classes from examples

--- a/.changeset/hip-lemons-invite.md
+++ b/.changeset/hip-lemons-invite.md
@@ -1,5 +1,0 @@
----
-'@threlte/docs': minor
----
-
-Remove tailwind classes from examples

--- a/.changeset/hip-lemons-invite.md
+++ b/.changeset/hip-lemons-invite.md
@@ -1,5 +1,5 @@
 ---
-"@threlte/docs": minor
+'@threlte/docs': minor
 ---
 
 Remove tailwind classes from examples

--- a/apps/docs/src/examples/extras/billboard/App.svelte
+++ b/apps/docs/src/examples/extras/billboard/App.svelte
@@ -3,8 +3,14 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full ">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/contact-shadows/App.svelte
+++ b/apps/docs/src/examples/extras/contact-shadows/App.svelte
@@ -12,6 +12,6 @@
 <style>
   div {
     height: 100%;
-		background-color: rgb(255 255 255 / 0.9)
+    background-color: rgb(255 255 255 / 0.9);
   }
 </style>

--- a/apps/docs/src/examples/extras/contact-shadows/App.svelte
+++ b/apps/docs/src/examples/extras/contact-shadows/App.svelte
@@ -3,8 +3,15 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full bg-white/90">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+		background-color: rgb(255 255 255 / 0.9)
+  }
+</style>

--- a/apps/docs/src/examples/extras/fake-glow-material/App.svelte
+++ b/apps/docs/src/examples/extras/fake-glow-material/App.svelte
@@ -3,8 +3,14 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full ">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/float/App.svelte
+++ b/apps/docs/src/examples/extras/float/App.svelte
@@ -3,8 +3,14 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full ">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/meshline-geometry/App.svelte
+++ b/apps/docs/src/examples/extras/meshline-geometry/App.svelte
@@ -3,8 +3,14 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/meshline-material/alpha-map/App.svelte
+++ b/apps/docs/src/examples/extras/meshline-material/alpha-map/App.svelte
@@ -3,8 +3,14 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/meshline-material/animated/App.svelte
+++ b/apps/docs/src/examples/extras/meshline-material/animated/App.svelte
@@ -3,8 +3,14 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/portals/basic/App.svelte
+++ b/apps/docs/src/examples/extras/portals/basic/App.svelte
@@ -3,8 +3,15 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full bg-blue-500/20">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+		background-color: rgb(47 125 198 / 0.2);
+  }
+</style>

--- a/apps/docs/src/examples/extras/portals/basic/App.svelte
+++ b/apps/docs/src/examples/extras/portals/basic/App.svelte
@@ -12,6 +12,6 @@
 <style>
   div {
     height: 100%;
-		background-color: rgb(47 125 198 / 0.2);
+    background-color: rgb(47 125 198 / 0.2);
   }
 </style>

--- a/apps/docs/src/examples/extras/portals/helper/App.svelte
+++ b/apps/docs/src/examples/extras/portals/helper/App.svelte
@@ -3,8 +3,15 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full bg-blue-500/20">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+		background-color: rgb(47 125 198 / 0.2);
+  }
+</style>

--- a/apps/docs/src/examples/extras/portals/helper/App.svelte
+++ b/apps/docs/src/examples/extras/portals/helper/App.svelte
@@ -12,6 +12,6 @@
 <style>
   div {
     height: 100%;
-		background-color: rgb(47 125 198 / 0.2);
+    background-color: rgb(47 125 198 / 0.2);
   }
 </style>

--- a/apps/docs/src/examples/extras/suspense/App.svelte
+++ b/apps/docs/src/examples/extras/suspense/App.svelte
@@ -3,8 +3,15 @@
   import Scene from './Scene.svelte'
 </script>
 
-<div class="relative h-full w-full bg-blue-500/20">
+<div>
   <Canvas>
     <Scene />
   </Canvas>
 </div>
+
+<style>
+  div {
+    height: 100%;
+		background-color: rgb(47 125 198 / 0.2);
+  }
+</style>

--- a/apps/docs/src/examples/extras/suspense/App.svelte
+++ b/apps/docs/src/examples/extras/suspense/App.svelte
@@ -12,6 +12,6 @@
 <style>
   div {
     height: 100%;
-		background-color: rgb(47 125 198 / 0.2);
+    background-color: rgb(47 125 198 / 0.2);
   }
 </style>


### PR DESCRIPTION
Removed most tailwind classes from the examples.

Only example I found that I left as-is for now that still has tailwind classes is extras/transitions, as that uses a few more classes for a custom button, which maybe should be switched to tweakpane instead?