### PR TITLE
Use `watch()` in useEvents

### DIFF
--- a/packages/core/src/app.d.ts
+++ b/packages/core/src/app.d.ts
@@ -9,7 +9,3 @@ declare namespace App {
   // interface Session {}
   // interface Stuff {}
 }
-
-declare module '*.svelte' {
-  export { SvelteComponentDev as default } from 'svelte/internal'
-}


### PR DESCRIPTION
While investigating how to upgrade `@threlte/core`'s event dispatching to svelte 5 I ran into a store subscription that could be simplified with `watch()`.

This PR simplifies the subscriptions made in the `useEvents` hook!