### PR TITLE
Mark three-mesh-bvh as an optional dependency in package.json

### DIFF
--- a/.changeset/modern-tips-give.md
+++ b/.changeset/modern-tips-give.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Mark three-mesh-bvh as an optional dependency in package.json"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 README.md
 .svelte-kit
+.changeset
+CHANGELOG.md

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -48,6 +48,11 @@
     "three": ">=0.133",
     "three-mesh-bvh": "^0.7.1"
   },
+  "peerDependenciesMeta": {
+    "three-mesh-bvh": {
+      "optional": true
+    }
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
This will improve developer experience when not using three-mesh-bvh, and prevent some builds from breaking.