### PR TITLE
Remove children binding from HierarchicalObject component

### DIFF
--- a/.changeset/good-items-add.md
+++ b/.changeset/good-items-add.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": minor
+---
+
+Remove children binding from HierarchicalObject component

--- a/apps/docs/src/content/reference/core/hierarchical-object.mdx
+++ b/apps/docs/src/content/reference/core/hierarchical-object.mdx
@@ -52,17 +52,6 @@ In this example the component is responsible for
 - adding children to the scene graph (i.e. as children to the mesh)
 - removing children from the scene graph
 
-```svelte
-@@ -86,23 +117,41 @@ The component `<HierarchicalObject>` also provides a useful binding to collect a
-
-<HierarchicalObject
-  object={mesh}
-  bind:children
->
-  <slot />
-</HierarchicalObject>
-```
-
 ### Mounting a component to a different parent
 
 Sometimes you need to add a component as a child to another object than its parent. Let's say we want to transform a `THREE.Mesh` object with `TransformControls`. In this case, Three.js wants you to mount the `TransformControls` as a child to the `scene` and `attach` it to the `THREE.Mesh`. We can use the `<HierarchicalObject>` component to add an object to an arbitrary parent object:

--- a/packages/core/src/lib/internal/HierarchicalObject.svelte
+++ b/packages/core/src/lib/internal/HierarchicalObject.svelte
@@ -32,25 +32,14 @@
 <script lang="ts">
   export let object: HierarchicalObjectProperties['object'] = undefined
 
-  export let children: Object3D[] = []
-
   export let onChildMount: HierarchicalObjectProperties['onChildMount'] = undefined
   const onChildMountProxy: HierarchicalObjectProperties['onChildMount'] = (child) => {
-    // keep track of children
-    children.push(child)
-    children = children
-
     // maybe call provided method
     onChildMount?.(child)
   }
 
   export let onChildDestroy: HierarchicalObjectProperties['onChildDestroy'] = undefined
   const onChildDestroyProxy: HierarchicalObjectProperties['onChildDestroy'] = (child) => {
-    // keep track of children
-    const index = children.findIndex((c) => c.uuid === child.uuid)
-    if (index !== -1) children.splice(index, 1)
-    children = children
-
     // maybe call provided method
     onChildDestroy?.(child)
   }


### PR DESCRIPTION
In Svelte 5 `children` is a reserved property for snippets. When testing Svelte 5 integration with Threlte one thing that breaks is the HierarchicalObject component because of the `children` binding.

I propose that we remove it to prepare for Svelte 5, since HierarchicalObject isn't used in the community often, and it seems like there's little documentation behind this binding.

I may be missing context about this binding, so I'd love to hear if there's a problem with this!