### PR TITLE
Remove three/addons import for compatibility with older Three versions

### DIFF
--- a/.changeset/yellow-bears-kiss.md
+++ b/.changeset/yellow-bears-kiss.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Remove three/addons import for compatibility with older Three versions

--- a/packages/extras/src/lib/components/Environment/GroundProjectedSkybox.svelte
+++ b/packages/extras/src/lib/components/Environment/GroundProjectedSkybox.svelte
@@ -5,9 +5,10 @@
 
   export let envMap: Texture
 
-  const url = revision > 160
-    ? 'three/examples/jsm/objects/GroundedSkybox'
-    : 'three/examples/jsm/objects/GroundProjectedSkybox'
+  const url =
+    revision > 160
+      ? 'three/examples/jsm/objects/GroundedSkybox'
+      : 'three/examples/jsm/objects/GroundProjectedSkybox'
 
   const module = import(/* @vite-ignore */ url)
 </script>

--- a/packages/extras/src/lib/components/Environment/GroundProjectedSkybox.svelte
+++ b/packages/extras/src/lib/components/Environment/GroundProjectedSkybox.svelte
@@ -2,15 +2,22 @@
   import { T } from '@threlte/core'
   import type { Texture } from 'three'
   import { revision } from '../../lib/revision'
-  import * as Addons from 'three/examples/jsm/Addons'
 
   export let envMap: Texture
+
+  const url = revision > 160
+    ? 'three/examples/jsm/objects/GroundedSkybox'
+    : 'three/examples/jsm/objects/GroundProjectedSkybox'
+
+  const module = import(/* @vite-ignore */ url)
 </script>
 
 {#if envMap}
-  <T
-    is={revision > 160 ? Addons.GroundedSkybox : Addons.GroundProjectedSkybox}
-    args={[envMap]}
-    {...$$restProps}
-  />
+  {#await module then result}
+    <T
+      is={revision > 160 ? result.GroundedSkybox : result.GroundProjectedSkybox}
+      args={[envMap]}
+      {...$$restProps}
+    />
+  {/await}
 {/if}


### PR DESCRIPTION
When attempting to fix the recent `GroundProjectedSkybox` to `GroundedSkybox` I found a solution involving `three/examples/jsm/Addons`. What I didn't realize was that this was very recently added, and therefore this solution breaks compatibility with a lot of Three.js versions. This PR introduces another solution with individual imports that improves compatibility. 