### PR TITLE
<PerfMonitor/> - rendering stats

### DIFF
--- a/.changeset/dirty-impalas-approve.md
+++ b/.changeset/dirty-impalas-approve.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": minor
+---
+
+<PerfMonitor/> component - easy access to rendering stats like draw calls, triangles, fps etc.

--- a/apps/docs/src/content/reference/extras/perf-monitor.mdx
+++ b/apps/docs/src/content/reference/extras/perf-monitor.mdx
@@ -9,83 +9,90 @@
     {
       'props':
         [
-					 {
-            name: 'logsPerSecond',
-            type: 'number',
-            default: '10',
-            required: false,
-            'description': 'Refresh rate of the logs.'
-          	},
-						{
-            name: 'showGraph',
-            type: 'boolean',
-            default: 'true',
-            required: false,
-            'description': 'Toggles cpu/gpu/fps graphs rendering.'
-          	},
-						{
-            name: 'memory',
-            type: 'boolean',
-            default: 'true',
-            required: false,
-            'description': 'Toggles memory info visiblity (geometries, textures, shaders)'
-          	},
-						{
-            name: 'enabled',
-            type: 'boolean',
-            default: 'true',
-            required: false,
-            'description': 'Toggles stats collection.'
-          	},
-						{
-            name: 'visible',
-            type: 'boolean',
-            default: 'true',
-            required: false,
-            'description': 'Toggles visibility of the monitor html element. Disabling this does not stop collection of the stats.'
-          	},
-						{
-            name: 'actionToCallUI',
-            type: 'string',
-            default: ' ',
-            required: false,
-            'description': 'By default is disabled [''], but if set and type this text in the tab window three-perf dev gui will be shown.'
-          	},
-						{
-            name: 'guiVisible',
-            type: 'boolean',
-            default: 'false',
-            required: false,
-            'description': 'Three-perf dev gui visiblity.'
-          	},
-						{
-            name: 'backgroundOpacity',
-            type: 'number',
-            default: '0.7',
-            required: false,
-            'description': 'Stats block background opacity level.'
-          	},
-						{
-            name: 'scale',
-            type: 'number',
-            default: '1',
-            required: false,
-            'description': 'Scale of the stats block html element.'
-          	},
-						{
-            name: 'anchorX',
-            type: "'left' | 'right'",
-            default: '[]',
-            required: false,
-            'description': 'Stats html element horizontal anchor.'
-          	},
-						{
-            name: 'anchorY',
-            type: "'top' | 'bottom'",
-            default: '[]',
-            required: false,
-            'description': 'Stats html element vertical anchor.'
-          	},
+					{
+						name: 'domElement',
+						type: 'HTMLElement',
+						default: 'document.body',
+						required: false,
+						'description': 'Dom element to which stats block will be attached to.'
+					},
+					{
+						name: 'logsPerSecond',
+						type: 'number',
+						default: '10',
+						required: false,
+						'description': 'Refresh rate of the logs.'
+					},
+					{
+						name: 'showGraph',
+						type: 'boolean',
+						default: 'true',
+						required: false,
+						'description': 'Toggles cpu/gpu/fps graphs rendering.'
+					},
+					{
+						name: 'memory',
+						type: 'boolean',
+						default: 'true',
+						required: false,
+						'description': 'Toggles memory info visiblity (geometries, textures, shaders)'
+					},
+					{
+						name: 'enabled',
+						type: 'boolean',
+						default: 'true',
+						required: false,
+						'description': 'Toggles stats collection.'
+					},
+					{
+						name: 'visible',
+						type: 'boolean',
+						default: 'true',
+						required: false,
+						'description': 'Toggles visibility of the monitor html element. Setting `false` does not stop collection of the stats.'
+					},
+					{
+						name: 'actionToCallUI',
+						type: 'string',
+						default: ' ',
+						required: false,
+						'description': 'If set and given characters are typed in the the tab window, the three-perf dev gui will be shown. Disabled by default (empty string).'
+					},
+					{
+						name: 'guiVisible',
+						type: 'boolean',
+						default: 'false',
+						required: false,
+						'description': 'Toggles Three-perf dev gui visiblity.'
+						},
+					{
+						name: 'backgroundOpacity',
+						type: 'number',
+						default: '0.7',
+						required: false,
+						'description': 'Stats block background opacity level.'
+					},
+					{
+						name: 'scale',
+						type: 'number',
+						default: '1',
+						required: false,
+						'description': 'Scale of the stats block html element.'
+					},
+					{
+						name: 'anchorX',
+						type: "'left' | 'right'",
+						default: "'left'",
+						required: false,
+						'description': 'Stats html element horizontal anchor.'
+					},
+					{
+						name: 'anchorY',
+						type: "'top' | 'bottom'",
+						default: "'top'",
+						required: false,
+						'description': 'Stats html element vertical anchor.'
+					},
         ]
     }
 }

--- a/apps/docs/src/content/reference/extras/perf-monitor.mdx
+++ b/apps/docs/src/content/reference/extras/perf-monitor.mdx
@@ -91,15 +91,15 @@
 }
 ---
 
-Utility component for monitoring basic rendering statistics. Based on [three-perf](https://github.com/TheoTheDev/three-perf).
+Utility component for monitoring basic rendering statistics using [three-perf](https://github.com/TheoTheDev/three-perf).
 
 <Example path="extras/perf-monitor" />
 
 ## Usage
 
 Simply drop in the `<PerfMonitor>` component as a child of Threlte `<Canvas>`.
-The component starts measuring before `mainStage` and ends at `renderStage`.
-Learn more about the stages [here](/docs/learn/basics/scheduling-tasks)
+The component starts measuring before `mainStage` and ends after `renderStage`.
+Learn more about tasks in threlte [here](/docs/learn/basics/scheduling-tasks)
 
 
 ```svelte

--- a/apps/docs/src/content/reference/extras/perf-monitor.mdx
+++ b/apps/docs/src/content/reference/extras/perf-monitor.mdx
@@ -103,8 +103,8 @@ Learn more about the stages [here](/docs/learn/basics/scheduling-tasks)
 
 
 ```svelte
-	<Canvas>
-    <PerfMonitor anchorX={'right'} logsPerSecond={30}/>
-    <Scene />
-  </Canvas>
+<Canvas>
+	<PerfMonitor anchorX={'right'} logsPerSecond={30}/>
+	<Scene />
+</Canvas>
 ```

--- a/apps/docs/src/content/reference/extras/perf-monitor.mdx
+++ b/apps/docs/src/content/reference/extras/perf-monitor.mdx
@@ -1,0 +1,110 @@
+---
+{
+  order: 10.5,
+  category: '@threlte/extras',
+  name: '<PerfMonitor>',
+  sourcePath: 'packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte',
+  type: 'component',
+  'componentSignature':
+    {
+      'props':
+        [
+					 {
+            name: 'logsPerSecond',
+            type: 'number',
+            default: '10',
+            required: false,
+            'description': 'Refresh rate of the logs.'
+          	},
+						{
+            name: 'showGraph',
+            type: 'boolean',
+            default: 'true',
+            required: false,
+            'description': 'Toggles cpu/gpu/fps graphs rendering.'
+          	},
+						{
+            name: 'memory',
+            type: 'boolean',
+            default: 'true',
+            required: false,
+            'description': 'Toggles memory info visiblity (geometries, textures, shaders)'
+          	},
+						{
+            name: 'enabled',
+            type: 'boolean',
+            default: 'true',
+            required: false,
+            'description': 'Toggles stats collection.'
+          	},
+						{
+            name: 'visible',
+            type: 'boolean',
+            default: 'true',
+            required: false,
+            'description': 'Toggles visibility of the monitor html element. Disabling this does not stop collection of the stats.'
+          	},
+						{
+            name: 'actionToCallUI',
+            type: 'string',
+            default: ' ',
+            required: false,
+            'description': 'By default is disabled [''], but if set and type this text in the tab window three-perf dev gui will be shown.'
+          	},
+						{
+            name: 'guiVisible',
+            type: 'boolean',
+            default: 'false',
+            required: false,
+            'description': 'Three-perf dev gui visiblity.'
+          	},
+						{
+            name: 'backgroundOpacity',
+            type: 'number',
+            default: '0.7',
+            required: false,
+            'description': 'Stats block background opacity level.'
+          	},
+						{
+            name: 'scale',
+            type: 'number',
+            default: '1',
+            required: false,
+            'description': 'Scale of the stats block html element.'
+          	},
+						{
+            name: 'anchorX',
+            type: "'left' | 'right'",
+            default: '[]',
+            required: false,
+            'description': 'Stats html element horizontal anchor.'
+          	},
+						{
+            name: 'anchorY',
+            type: "'top' | 'bottom'",
+            default: '[]',
+            required: false,
+            'description': 'Stats html element vertical anchor.'
+          	},
+        ]
+    }
+}
+---
+
+Utility component for monitoring basic rendering statistics. Based on [three-perf](https://github.com/TheoTheDev/three-perf).
+
+<Example path="extras/perf-monitor" />
+
+## Usage
+
+Simply drop in the `<PerfMonitor>` component as a child of Threlte `<Canvas>`.
+The component starts measuring before `mainStage` and ends at `renderStage`.
+Learn more about the stages [here](/docs/learn/basics/scheduling-tasks)
+
+
+```svelte
+	<Canvas>
+    <PerfMonitor anchorX={'right'} logsPerSecond={30}/>
+    <Scene />
+  </Canvas>
+```

--- a/apps/docs/src/examples/extras/perf-monitor/App.svelte
+++ b/apps/docs/src/examples/extras/perf-monitor/App.svelte
@@ -6,7 +6,6 @@
 
 <div>
   <Canvas>
-    <!-- todo why is TS erroring here? Using Required wrong? -->
     <PerfMonitor />
     <Scene />
   </Canvas>

--- a/apps/docs/src/examples/extras/perf-monitor/App.svelte
+++ b/apps/docs/src/examples/extras/perf-monitor/App.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Canvas } from '@threlte/core'
+  import Scene from './Scene.svelte'
+  import { PerfMonitor } from '@threlte/extras'
+</script>
+
+<div>
+  <Canvas>
+    <!-- todo why is TS erroring here? Using Required wrong? -->
+    <PerfMonitor />
+    <Scene />
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/perf-monitor/Scene.svelte
+++ b/apps/docs/src/examples/extras/perf-monitor/Scene.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+  import { OrbitControls } from '@threlte/extras'
+  import { DoubleSide } from 'three'
+  import { DEG2RAD } from 'three/src/math/MathUtils.js'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[45, 40, -45]}
+  fov={90}
+>
+  <OrbitControls
+    autoRotate
+    autoRotateSpeed={0.1}
+    target.y={-10}
+  />
+</T.PerspectiveCamera>
+
+<T.AmbientLight intensity={1} />
+
+<T.DirectionalLight position={[10, 5, 0]} />
+
+<T.Mesh
+  rotation.x={DEG2RAD * -90}
+  castShadow
+  receiveShadow
+>
+  <T.PlaneGeometry args={[1000, 1000]} />
+  <T.MeshStandardMaterial color={'#fa992a'} />
+</T.Mesh>
+
+<T.Mesh>
+  <T.SphereGeometry args={[400]} />
+  <T.MeshBasicMaterial
+    color="#0057fa"
+    side={DoubleSide}
+  />
+</T.Mesh>
+
+{#each { length: 120 } as _, x}
+  {@const distance = Math.abs(Math.sin(x)) * 50 + 10}
+  {@const height = Math.abs((30 - distance) / 2)}
+  {@const posX = distance * Math.cos(DEG2RAD * ((360 / 120) * x))}
+  {@const posY = distance * Math.sin(DEG2RAD * ((360 / 120) * x))}
+  <T.Mesh
+    castShadow
+    receiveShadow
+    position.x={posX}
+    position.y={height / 2}
+    position.z={posY}
+  >
+    <T.CapsuleGeometry args={[3, height, 12, 32]} />
+    <T.MeshStandardMaterial color={'#45c1ff'} />
+  </T.Mesh>
+{/each}

--- a/apps/docs/src/examples/extras/perf-monitor/Scene.svelte
+++ b/apps/docs/src/examples/extras/perf-monitor/Scene.svelte
@@ -2,7 +2,7 @@
   import { T } from '@threlte/core'
   import { OrbitControls } from '@threlte/extras'
   import { DoubleSide } from 'three'
-  import { DEG2RAD } from 'three/src/math/MathUtils.js'
+  import { DEG2RAD } from 'three/src/math/MathUtils'
 </script>
 
 <T.PerspectiveCamera

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "troika-three-text": "^0.49.0",
-    "three-mesh-bvh": "^0.7.1"
-    "three-perf": "^1.0.10",
+    "three-mesh-bvh": "^0.7.1",
+    "three-perf": "^1.0.10"
   }
 }

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -76,5 +76,6 @@
   "dependencies": {
     "troika-three-text": "^0.49.0",
     "three-mesh-bvh": "^0.7.1"
+    "three-perf": "^1.0.10",
   }
 }

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.d.ts
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.d.ts
@@ -1,0 +1,17 @@
+import { SvelteComponent } from 'svelte'
+
+export type PerfMonitorProps = {
+  logsPerSecond?: number // Refresh rate of the logs [default 10]
+  showGraph?: boolean // toggles cpu/gpu/fps graphs rendering
+  memory?: boolean // toggles memory info visiblity [like geos / textures / shaders etc count]
+  enabled?: boolean // toggles stats harvesting
+  visible?: boolean // stats are harvested, but stats panel is hidden
+  actionToCallUI?: string // by default is disabled [''], but if set and type this text in the tab window three-perf dev gui will be shown
+  guiVisible?: boolean // default three-perf dev gui visiblity [falde by default]
+  backgroundOpacity?: number // stats block background opacity level [0.7 by default]
+  scale?: 1 // stats block scale [default 1]
+  anchorX?: 'left' | 'right' // default is left [stats container horrisontal anchor]
+  anchorY?: 'top' | 'bottom' // default is top [stats container vertical anchor]
+}
+
+export default class PerfMonitor extends SvelteComponent<PerfMonitorProps> {}

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.d.ts
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.d.ts
@@ -1,16 +1,65 @@
 import { SvelteComponent } from 'svelte'
 
 export type PerfMonitorProps = {
-  logsPerSecond?: number // Refresh rate of the logs [default 10]
-  showGraph?: boolean // toggles cpu/gpu/fps graphs rendering
+  /**
+   * Dom element to which stats block will be attached to.
+   * @default `document.body`
+   */
+  domElement?: HTMLElement
+  /**
+   * Refresh rate of the logs
+   * @default 10
+   */
+  logsPerSecond?: number
+  /**
+   * Toggles cpu/gpu/fps graphs rendering
+   * @default true
+   */
+  showGraph?: boolean
+  /**
+   * Toggles memory info visiblity (geometries, textures, shaders)
+   * @default true
+   */
   memory?: boolean // toggles memory info visiblity [like geos / textures / shaders etc count]
+  /**
+   * Toggles stats collection.
+   * @default true
+   */
   enabled?: boolean // toggles stats harvesting
+  /**
+   * Toggles visibility of the monitor html element. Setting `false` does not stop collection of the stats.
+   * @default true
+   */
   visible?: boolean // stats are harvested, but stats panel is hidden
+  /**
+   * If set and given characters are typed in the the tab window, the three-perf dev gui will be shown. Disabled by default (empty string).
+   * @default ""
+   */
   actionToCallUI?: string // by default is disabled [''], but if set and type this text in the tab window three-perf dev gui will be shown
+  /**
+   * Toggles Three-perf dev gui visiblity.
+   * @default false
+   */
   guiVisible?: boolean // default three-perf dev gui visiblity [falde by default]
+  /**
+   * Stats block background opacity level.
+   * @default 0.7
+   */
   backgroundOpacity?: number // stats block background opacity level [0.7 by default]
+  /**
+   * Scale of the stats block html element.
+   * @default 1
+   */
   scale?: 1 // stats block scale [default 1]
+  /**
+   * Stats html element horizontal anchor.
+   * @default "left"
+   */
   anchorX?: 'left' | 'right' // default is left [stats container horrisontal anchor]
+  /**
+   * Stats html element vertical anchor.
+   * @default "top"
+   */
   anchorY?: 'top' | 'bottom' // default is top [stats container vertical anchor]
 }
 

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
@@ -25,7 +25,8 @@
   let perf: ThreePerf
 
   // Has to be fully re-initialized if dom element changes
-  const domElementStore = writable(domElement)
+  const domElementStore = writable<typeof domElement>(domElement)
+  $: domElementStore.set(domElement)
   watch([domElementStore], ([domElement]) => {
     perf = new ThreePerf({
       anchorX,

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
@@ -6,19 +6,20 @@
   import { writable } from 'svelte/store'
 
   type $$Props = PerfMonitorProps
+  type $$PropsWithDefaults = Required<$$Props>
 
-  export let domElement: $$Props['domElement'] = undefined
-  export let logsPerSecond: $$Props['logsPerSecond'] = 10
-  export let showGraph: $$Props['showGraph'] = true
-  export let memory: $$Props['memory'] = true
-  export let enabled: $$Props['enabled'] = true
-  export let visible: $$Props['visible'] = true
-  export let actionToCallUI: $$Props['actionToCallUI'] = ''
-  export let guiVisible: $$Props['guiVisible'] = false
-  export let backgroundOpacity: $$Props['backgroundOpacity'] = 0.7
-  export let scale: $$Props['scale'] = 1
-  export let anchorX: $$Props['anchorX'] = 'left'
-  export let anchorY: $$Props['anchorY'] = 'top'
+  export let domElement: $$PropsWithDefaults['domElement'] = document.body
+  export let logsPerSecond: $$PropsWithDefaults['logsPerSecond'] = 10
+  export let showGraph: $$PropsWithDefaults['showGraph'] = true
+  export let memory: $$PropsWithDefaults['memory'] = true
+  export let enabled: $$PropsWithDefaults['enabled'] = true
+  export let visible: $$PropsWithDefaults['visible'] = true
+  export let actionToCallUI: $$PropsWithDefaults['actionToCallUI'] = ''
+  export let guiVisible: $$PropsWithDefaults['guiVisible'] = false
+  export let backgroundOpacity: $$PropsWithDefaults['backgroundOpacity'] = 0.7
+  export let scale: $$PropsWithDefaults['scale'] = 1
+  export let anchorX: $$PropsWithDefaults['anchorX'] = 'left'
+  export let anchorY: $$PropsWithDefaults['anchorY'] = 'top'
 
   const { renderer, renderStage, mainStage } = useThrelte()
 
@@ -28,34 +29,24 @@
   const domElementStore = writable<typeof domElement>(domElement)
   $: domElementStore.set(domElement)
   watch([domElementStore], ([domElement]) => {
+    if (perf) perf.dispose()
     perf = new ThreePerf({
-      anchorX,
-      anchorY,
       domElement: domElement || document.body,
-      renderer: renderer,
-      logsPerSecond,
-      showGraph,
-      memory,
-      enabled,
-      visible,
-      actionToCallUI,
-      guiVisible,
-      backgroundOpacity,
-      scale
+      renderer: renderer
     })
   })
 
-  $: perf && (perf.logsPerSecond = logsPerSecond || 10)
-  $: perf && (perf.showGraph = showGraph ? true : false)
-  $: perf && (perf.memory = memory ? true : false)
-  $: perf && (perf.enabled = enabled ? true : false)
-  $: perf && (perf.visible = visible ? true : false)
-  $: perf && (perf.actionToCallUI = actionToCallUI || '')
-  $: perf && (perf.guiVisible = guiVisible ? true : false)
-  $: perf && (perf.backgroundOpacity = backgroundOpacity || 0.7)
-  $: perf && (perf.scale = scale !== undefined ? scale : 1)
-  $: perf && (perf.anchorX = anchorX || 'left')
-  $: perf && (perf.anchorY = anchorY || 'top')
+  $: perf.logsPerSecond = logsPerSecond
+  $: perf.showGraph = showGraph
+  $: perf.memory = memory
+  $: perf.enabled = enabled
+  $: perf.visible = visible
+  $: perf.actionToCallUI = actionToCallUI
+  $: perf.guiVisible = guiVisible
+  $: perf.backgroundOpacity = backgroundOpacity
+  $: perf.scale = scale
+  $: perf.anchorX = anchorX
+  $: perf.anchorY = anchorY
 
   useTask(
     () => {

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { useStage, useTask, useThrelte } from '@threlte/core'
+  import { ThreePerf } from 'three-perf'
+  import type { PerfMonitorProps } from './PerfMonitor'
+
+  type $$Props = Required<PerfMonitorProps>
+
+  export let logsPerSecond: $$Props['logsPerSecond'] = 10
+  export let showGraph: $$Props['showGraph'] = true
+  export let memory: $$Props['memory'] = true
+  export let enabled: $$Props['enabled'] = true
+  export let visible: $$Props['visible'] = true
+  export let actionToCallUI: $$Props['actionToCallUI'] = ''
+  export let guiVisible: $$Props['guiVisible'] = false
+  export let backgroundOpacity: $$Props['backgroundOpacity'] = 0.7
+  export let scale: $$Props['scale'] = 1
+  export let anchorX: $$Props['anchorX'] = 'left'
+  export let anchorY: $$Props['anchorY'] = 'top'
+
+  const { renderer, renderStage, mainStage } = useThrelte()
+
+  const perf = new ThreePerf({
+    anchorX,
+    anchorY,
+    domElement: document.body,
+    renderer: renderer,
+    logsPerSecond,
+    showGraph,
+    memory,
+    enabled,
+    visible,
+    actionToCallUI,
+    guiVisible,
+    backgroundOpacity,
+    scale
+  })
+
+  $: perf.logsPerSecond = logsPerSecond
+  $: perf.showGraph = showGraph
+  $: perf.memory = memory
+  $: perf.enabled = enabled
+  $: perf.visible = visible
+  $: perf.actionToCallUI = actionToCallUI
+  $: perf.guiVisible = guiVisible
+  $: perf.backgroundOpacity = backgroundOpacity
+  $: perf.scale = scale
+  $: perf.anchorX = anchorX
+  $: perf.anchorY = anchorY
+
+  useTask(
+    () => {
+      perf.begin()
+    },
+    {
+      stage: useStage('monitor-begin', {
+        before: mainStage
+      })
+    }
+  )
+
+  useTask(
+    () => {
+      perf.end()
+    },
+    {
+      stage: useStage('monitor-end', {
+        after: renderStage
+      })
+    }
+  )
+</script>

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-  import { useStage, useTask, useThrelte } from '@threlte/core'
+  import { useStage, useTask, useThrelte, watch } from '@threlte/core'
   import { ThreePerf } from 'three-perf'
   import type { PerfMonitorProps } from './PerfMonitor'
+  import { onDestroy } from 'svelte'
+  import { writable } from 'svelte/store'
 
-  type $$Props = Required<PerfMonitorProps>
+  type $$Props = PerfMonitorProps
 
+  export let domElement: $$Props['domElement'] = undefined
   export let logsPerSecond: $$Props['logsPerSecond'] = 10
   export let showGraph: $$Props['showGraph'] = true
   export let memory: $$Props['memory'] = true
@@ -19,33 +22,39 @@
 
   const { renderer, renderStage, mainStage } = useThrelte()
 
-  const perf = new ThreePerf({
-    anchorX,
-    anchorY,
-    domElement: document.body,
-    renderer: renderer,
-    logsPerSecond,
-    showGraph,
-    memory,
-    enabled,
-    visible,
-    actionToCallUI,
-    guiVisible,
-    backgroundOpacity,
-    scale
+  let perf: ThreePerf
+
+  // Has to be fully re-initialized if dom element changes
+  const domElementStore = writable(domElement)
+  watch([domElementStore], ([domElement]) => {
+    perf = new ThreePerf({
+      anchorX,
+      anchorY,
+      domElement: domElement || document.body,
+      renderer: renderer,
+      logsPerSecond,
+      showGraph,
+      memory,
+      enabled,
+      visible,
+      actionToCallUI,
+      guiVisible,
+      backgroundOpacity,
+      scale
+    })
   })
 
-  $: perf.logsPerSecond = logsPerSecond
-  $: perf.showGraph = showGraph
-  $: perf.memory = memory
-  $: perf.enabled = enabled
-  $: perf.visible = visible
-  $: perf.actionToCallUI = actionToCallUI
-  $: perf.guiVisible = guiVisible
-  $: perf.backgroundOpacity = backgroundOpacity
-  $: perf.scale = scale
-  $: perf.anchorX = anchorX
-  $: perf.anchorY = anchorY
+  $: perf && (perf.logsPerSecond = logsPerSecond || 10)
+  $: perf && (perf.showGraph = showGraph ? true : false)
+  $: perf && (perf.memory = memory ? true : false)
+  $: perf && (perf.enabled = enabled ? true : false)
+  $: perf && (perf.visible = visible ? true : false)
+  $: perf && (perf.actionToCallUI = actionToCallUI || '')
+  $: perf && (perf.guiVisible = guiVisible ? true : false)
+  $: perf && (perf.backgroundOpacity = backgroundOpacity || 0.7)
+  $: perf && (perf.scale = scale !== undefined ? scale : 1)
+  $: perf && (perf.anchorX = anchorX || 'left')
+  $: perf && (perf.anchorY = anchorY || 'top')
 
   useTask(
     () => {
@@ -68,4 +77,8 @@
       })
     }
   )
+
+  onDestroy(() => {
+    if (perf) perf.dispose()
+  })
 </script>

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -34,6 +34,7 @@ export { default as Billboard } from './components/Billboard/Billboard.svelte'
 export { default as FakeGlowMaterial } from './components/FakeGlowMaterial/FakeGlowMaterial.svelte'
 export { default as Stars } from './components/Stars/Stars.svelte'
 export { default as MeshRefractionMaterial } from './components/MeshRefractionMaterial/MeshRefractionMaterial.svelte'
+export { default as PerfMonitor } from './components/PerfMonitor/PerfMonitor.svelte'
 
 // suspense
 export { default as Suspense } from './suspense/Suspense.svelte'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11711,7 +11711,6 @@ packages:
       troika-three-utils: 0.47.2(three@0.158.0)
       troika-worker-utils: 0.47.2
       webgl-sdf-generator: 1.1.1
-    dev: true
 
   /troika-three-text@0.49.0(three@0.160.1):
     resolution: {integrity: sha512-sn9BNC6eIX8OO3iAkPwjecJ7Pn21Ve8P1UNFMNeQzXx759rrqS4i4pSZs7FLMYdWyCKVXBFGimBySFwRKLjq/Q==}
@@ -11731,7 +11730,6 @@ packages:
       three: '>=0.125.0'
     dependencies:
       three: 0.158.0
-    dev: true
 
   /troika-three-utils@0.49.0(three@0.160.1):
     resolution: {integrity: sha512-umitFL4cT+Fm/uONmaQEq4oZlyRHWwVClaS6ZrdcueRvwc2w+cpNQ47LlJKJswpqtMFWbEhOLy0TekmcPZOdYA==}
@@ -11743,7 +11741,6 @@ packages:
 
   /troika-worker-utils@0.47.2:
     resolution: {integrity: sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==}
-    dev: true
 
   /troika-worker-utils@0.49.0:
     resolution: {integrity: sha512-1xZHoJrG0HFfCvT/iyN41DvI/nRykiBtHqFkGaGgJwq5iXfIZFBiPPEHFpPpgyKM3Oo5ITHXP5wM2TNQszYdVg==}
@@ -11934,6 +11931,10 @@ packages:
   /tweakpane@3.1.0:
     resolution: {integrity: sha512-PGAp/LPQdHwzL7/iAW4lV1p9iPQTti7YMjMWO48CoYjvZRS59RmgQnhEGzKzqST1JnmOYmQUjTe8bdhlZRJs5A==}
     dev: true
+
+  /tweakpane@3.1.10:
+    resolution: {integrity: sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ==}
+    dev: false
 
   /tweakpane@4.0.1:
     resolution: {integrity: sha512-1JmmGbF4h2zuFbpN1XfIWcV0kLbBUgSXpR1QtW19vJFx44asnCrufRSvd69OItOFMEWgbVtoiWM2uDPUEUKcMQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       three-mesh-bvh:
         specifier: ^0.7.1
         version: 0.7.1(three@0.160.1)
+      three-perf:
+        specifier: ^1.0.10
+        version: 1.0.10(three@0.160.1)
       troika-three-text:
         specifier: ^0.49.0
         version: 0.49.0(three@0.160.1)
@@ -11579,6 +11582,16 @@ packages:
       three: 0.160.1
     dev: false
 
+  /three-perf@1.0.10(three@0.160.1):
+    resolution: {integrity: sha512-lCur/i8U6m0ysWYhQ1yFGWOZB0QA2oVsDsfynYd65HhXxLxJfiAt8OsXmpv9PnTLacfaZclBcZHUOB9QKk3eaw==}
+    peerDependencies:
+      three: '>=0.151'
+    dependencies:
+      three: 0.160.1
+      troika-three-text: 0.47.2(three@0.160.1)
+      tweakpane: 3.1.10
+    dev: false
+
   /three-stdlib@2.21.8(three@0.122.0):
     resolution: {integrity: sha512-kqisiKvO4mSy59v5vWqBQSH8famLxp7Z51LxpMJI9GwDxqODaW02rhIwmjYDEzZWNFpjZpoDHVGbdpeHf8h3SA==}
     peerDependencies:
@@ -11711,6 +11724,19 @@ packages:
       troika-three-utils: 0.47.2(three@0.158.0)
       troika-worker-utils: 0.47.2
       webgl-sdf-generator: 1.1.1
+    dev: true
+
+  /troika-three-text@0.47.2(three@0.160.1):
+    resolution: {integrity: sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==}
+    peerDependencies:
+      three: '>=0.125.0'
+    dependencies:
+      bidi-js: 1.0.2
+      three: 0.160.1
+      troika-three-utils: 0.47.2(three@0.160.1)
+      troika-worker-utils: 0.47.2
+      webgl-sdf-generator: 1.1.1
+    dev: false
 
   /troika-three-text@0.49.0(three@0.160.1):
     resolution: {integrity: sha512-sn9BNC6eIX8OO3iAkPwjecJ7Pn21Ve8P1UNFMNeQzXx759rrqS4i4pSZs7FLMYdWyCKVXBFGimBySFwRKLjq/Q==}
@@ -11730,6 +11756,15 @@ packages:
       three: '>=0.125.0'
     dependencies:
       three: 0.158.0
+    dev: true
+
+  /troika-three-utils@0.47.2(three@0.160.1):
+    resolution: {integrity: sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==}
+    peerDependencies:
+      three: '>=0.125.0'
+    dependencies:
+      three: 0.160.1
+    dev: false
 
   /troika-three-utils@0.49.0(three@0.160.1):
     resolution: {integrity: sha512-umitFL4cT+Fm/uONmaQEq4oZlyRHWwVClaS6ZrdcueRvwc2w+cpNQ47LlJKJswpqtMFWbEhOLy0TekmcPZOdYA==}


### PR DESCRIPTION
At some point I found myself copy pasting the same three-perf component between my multiple projects and I figured we could use one. 

Based on https://github.com/TheoTheDev/three-perf .