### PR TITLE
Replace all instances of SvelteComponentTyped

### DIFF
--- a/apps/docs/src/content/learn/advanced/custom-abstractions.mdx
+++ b/apps/docs/src/content/learn/advanced/custom-abstractions.mdx
@@ -164,7 +164,7 @@ We will create a `Tile.d.ts` file next to the `Tile.svelte` file and add the fol
 
 ```ts title="Tile.d.ts"
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
 export type TileProps = Props<Group> & {
@@ -179,7 +179,7 @@ export type TileSlots = Slots<Mesh> & {
   // Define extra slots here.
 }
 
-export default class Tile extends SvelteComponentTyped<TileProps, TileEvents, TileSlots> {}
+export default class Tile extends SvelteComponent<TileProps, TileEvents, TileSlots> {}
 ```
 
 Now we can use the `<Tile>` component in our scene and get autocompletion and type checking:

--- a/apps/docs/src/examples/extras/positional-audio/Button.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Button.svelte.d.ts
@@ -2,8 +2,4 @@ import type { Events, Props, Slots } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Button extends SvelteComponent<
-  Props<Group>,
-  Events<Group>,
-  Slots<Group>
-> {}
+export default class Button extends SvelteComponent<Props<Group>, Events<Group>, Slots<Group>> {}

--- a/apps/docs/src/examples/extras/positional-audio/Button.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Button.svelte.d.ts
@@ -1,8 +1,8 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Button extends SvelteComponentTyped<
+export default class Button extends SvelteComponent<
   Props<Group>,
   Events<Group>,
   Slots<Group>

--- a/apps/docs/src/examples/extras/positional-audio/Disc.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Disc.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Disc extends SvelteComponentTyped<Props<Group>, Events<Group>, Slots<Group>> {}
+export default class Disc extends SvelteComponent<Props<Group>, Events<Group>, Slots<Group>> {}

--- a/apps/docs/src/examples/extras/positional-audio/Speaker.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Speaker.svelte.d.ts
@@ -1,8 +1,8 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Speaker extends SvelteComponentTyped<
+export default class Speaker extends SvelteComponent<
   Props<Group>,
   Events<Group>,
   Slots<Group>

--- a/apps/docs/src/examples/extras/positional-audio/Speaker.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Speaker.svelte.d.ts
@@ -2,8 +2,4 @@ import type { Events, Props, Slots } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Speaker extends SvelteComponent<
-  Props<Group>,
-  Events<Group>,
-  Slots<Group>
-> {}
+export default class Speaker extends SvelteComponent<Props<Group>, Events<Group>, Slots<Group>> {}

--- a/apps/docs/src/examples/extras/positional-audio/Turntable.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Turntable.svelte.d.ts
@@ -2,8 +2,4 @@ import type { Events, Props, Slots } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Turntable extends SvelteComponent<
-  Props<Group>,
-  Events<Group>,
-  Slots<Group>
-> {}
+export default class Turntable extends SvelteComponent<Props<Group>, Events<Group>, Slots<Group>> {}

--- a/apps/docs/src/examples/extras/positional-audio/Turntable.svelte.d.ts
+++ b/apps/docs/src/examples/extras/positional-audio/Turntable.svelte.d.ts
@@ -1,8 +1,8 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
-export default class Turntable extends SvelteComponentTyped<
+export default class Turntable extends SvelteComponent<
   Props<Group>,
   Events<Group>,
   Slots<Group>

--- a/apps/docs/src/examples/extras/suspense/Spaceship.svelte.d.ts
+++ b/apps/docs/src/examples/extras/suspense/Spaceship.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Props } from '@threlte/core'
-import type { SvelteComponentTyped } from 'svelte'
+import type { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
 export type SpaceshipProps = Props<Group> & {
@@ -17,4 +17,4 @@ export type SpaceshipProps = Props<Group> & {
     | 'Zenith'
 }
 
-export default class Spaceship extends SvelteComponentTyped<SpaceshipProps, {}, {}> {}
+export default class Spaceship extends SvelteComponent<SpaceshipProps, {}, {}> {}

--- a/packages/extras/src/lib/audio/Audio/Audio.svelte.d.ts
+++ b/packages/extras/src/lib/audio/Audio/Audio.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Props, Events, Slots } from '@threlte/core'
-import type { SvelteComponentTyped } from 'svelte'
+import type { SvelteComponent } from 'svelte'
 import type { Audio as ThreeAudio } from 'three'
 import type {
   AudioProps as CommonAudioProps,
@@ -15,4 +15,4 @@ export type AudioEvents = Events<ThreeAudio<GainNode>> & CommonAudioEvents
 
 export type AudioSlots = Slots<ThreeAudio<GainNode>>
 
-export default class Audio extends SvelteComponentTyped<AudioProps, AudioEvents, AudioSlots> {}
+export default class Audio extends SvelteComponent<AudioProps, AudioEvents, AudioSlots> {}

--- a/packages/extras/src/lib/audio/AudioListener/AudioListener.svelte.d.ts
+++ b/packages/extras/src/lib/audio/AudioListener/AudioListener.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import type { SvelteComponentTyped } from 'svelte'
+import type { SvelteComponent } from 'svelte'
 import type { AudioListener as ThreeAudioListener } from 'three'
 
 export type AudioListenerProps = Props<ThreeAudioListener> & {
@@ -11,7 +11,7 @@ export type AudioListenerEvents = Events<ThreeAudioListener>
 
 export type AudioListenerSlots = Slots<ThreeAudioListener>
 
-export default class AudioListener extends SvelteComponentTyped<
+export default class AudioListener extends SvelteComponent<
   AudioListenerProps,
   AudioListenerEvents,
   AudioListenerSlots

--- a/packages/extras/src/lib/audio/PositionalAudio/PositionalAudio.svelte.d.ts
+++ b/packages/extras/src/lib/audio/PositionalAudio/PositionalAudio.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import type { SvelteComponentTyped } from 'svelte'
+import type { SvelteComponent } from 'svelte'
 import type { PositionalAudio as ThreePositionalAudio } from 'three'
 import type { AudioProps, AudioEvents } from '../utils/useAudio'
 
@@ -21,7 +21,7 @@ export type PositionalAudioEvents = Events<ThreePositionalAudio> & AudioEvents
 
 export type PositionalAudioSlots = Slots<ThreePositionalAudio>
 
-export default class PositionalAudio extends SvelteComponentTyped<
+export default class PositionalAudio extends SvelteComponent<
   PositionalAudioProps,
   PositionalAudioEvents,
   PositionalAudioSlots

--- a/packages/extras/src/lib/components/Billboard/Billboard.svelte.d.ts
+++ b/packages/extras/src/lib/components/Billboard/Billboard.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
 export type BillboardProps = Props<Group> & {
@@ -12,7 +12,7 @@ export type BillboardProps = Props<Group> & {
 export type BillboardEvents = Events<Group>
 export type BillboardSlots = Slots<Group>
 
-export default class Billboard extends SvelteComponentTyped<
+export default class Billboard extends SvelteComponent<
   BillboardProps,
   BillboardEvents,
   BillboardSlots

--- a/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte.d.ts
+++ b/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
 export type ContactShadowsProps = Props<Group> & {
@@ -20,7 +20,7 @@ export type ContactShadowsEvents = Events<Group>
 
 export type ContactShadowsSlots = Slots<Group>
 
-export default class ContactShadows extends SvelteComponentTyped<
+export default class ContactShadows extends SvelteComponent<
   ContactShadowsProps,
   ContactShadowsEvents,
   ContactShadowsSlots

--- a/packages/extras/src/lib/components/Edges/Edges.svelte.d.ts
+++ b/packages/extras/src/lib/components/Edges/Edges.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { ColorRepresentation, LineSegments } from 'three'
 
 export type EdgesProps = Props<LineSegments> & {
@@ -11,4 +11,4 @@ export type EdgesEvents = Events<LineSegments>
 
 export type EdgesSlots = Slots<LineSegments>
 
-export default class Edges extends SvelteComponentTyped<EdgesProps, EdgesEvents, EdgesSlots> {}
+export default class Edges extends SvelteComponent<EdgesProps, EdgesEvents, EdgesSlots> {}

--- a/packages/extras/src/lib/components/Environment/Environment.svelte.d.ts
+++ b/packages/extras/src/lib/components/Environment/Environment.svelte.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Props } from '@threlte/core'
 import type { TextureEncoding } from 'three'
 import type { GroundProjectedEnv } from 'three/examples/jsm/objects/GroundProjectedEnv'
@@ -30,4 +30,4 @@ export type EnvironmentProps = {
   encoding?: TextureEncoding
 }
 
-export default class Environment extends SvelteComponentTyped<EnvironmentProps> {}
+export default class Environment extends SvelteComponent<EnvironmentProps> {}

--- a/packages/extras/src/lib/components/Float/Float.svelte.d.ts
+++ b/packages/extras/src/lib/components/Float/Float.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
 export type FloatProps = Props<Group> & {
@@ -14,4 +14,4 @@ export type FloatProps = Props<Group> & {
 export type FloatEvents = Events<Group>
 export type FloatSlots = Slots<Group>
 
-export default class Float extends SvelteComponentTyped<FloatProps, FloatEvents, FloatSlots> {}
+export default class Float extends SvelteComponent<FloatProps, FloatEvents, FloatSlots> {}

--- a/packages/extras/src/lib/components/GLTF/GLTF.svelte.d.ts
+++ b/packages/extras/src/lib/components/GLTF/GLTF.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
 export type GltfProps = Props<Group> & {
@@ -12,4 +12,4 @@ export type GltfProps = Props<Group> & {
 export type GltfEvents = Events<Group>
 export type GltfSlots = Slots<Group>
 
-export default class Gltf extends SvelteComponentTyped<GltfProps, GltfEvents, GltfSlots> {}
+export default class Gltf extends SvelteComponent<GltfProps, GltfEvents, GltfSlots> {}

--- a/packages/extras/src/lib/components/HTML/HTML.svelte.d.ts
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Camera, Group, Object3D } from 'three'
 
 export type HTMLProps = Props<Group> & {
@@ -40,4 +40,4 @@ export type HTMLSlots = {
   default: {}
 }
 
-export default class HTML extends SvelteComponentTyped<HTMLProps, HTMLEvents, HTMLSlots> {}
+export default class HTML extends SvelteComponent<HTMLProps, HTMLEvents, HTMLSlots> {}

--- a/packages/extras/src/lib/components/Instancing/Instance.svelte.d.ts
+++ b/packages/extras/src/lib/components/Instancing/Instance.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { PositionMesh } from './PositionMesh'
 import type { Color } from 'three'
 
@@ -11,7 +11,7 @@ export type InstanceProps = Props<PositionMesh> & {
 export type InstanceEvents = Events<PositionMesh>
 export type InstanceSlots = Slots<PositionMesh>
 
-export default class Instance extends SvelteComponentTyped<
+export default class Instance extends SvelteComponent<
   InstanceProps,
   InstanceEvents,
   InstanceSlots

--- a/packages/extras/src/lib/components/Instancing/InstancedMeshes/InstancedMeshes.svelte.d.ts
+++ b/packages/extras/src/lib/components/Instancing/InstancedMeshes/InstancedMeshes.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { InstancedMesh, Mesh } from 'three'
 import type Instance from '../Instance.svelte'
 
@@ -15,7 +15,7 @@ export type InstancedMeshesSlots<T extends Meshes> = {
   }
 }
 
-export default class InstancedMeshes<T extends Meshes> extends SvelteComponentTyped<
+export default class InstancedMeshes<T extends Meshes> extends SvelteComponent<
   InstancedMeshesProps<T>,
   InstancedMeshesEvents,
   InstancedMeshesSlots<T>

--- a/packages/extras/src/lib/components/Text/Text.svelte.d.ts
+++ b/packages/extras/src/lib/components/Text/Text.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Color, ColorRepresentation, Material, Mesh } from 'three'
 
 export interface TextMesh extends Mesh {
@@ -249,4 +249,4 @@ export type TextEvents = Events<TextMesh>
 
 export type TextSlots = Slots<TextMesh>
 
-export default class Text extends SvelteComponentTyped<TextProps, TextEvents, TextSlots> {}
+export default class Text extends SvelteComponent<TextProps, TextEvents, TextSlots> {}

--- a/packages/rapier/src/lib/components/Attractor/Attractor.svelte.d.ts
+++ b/packages/rapier/src/lib/components/Attractor/Attractor.svelte.d.ts
@@ -1,5 +1,5 @@
 import { Props, type Events, type Slots } from '@threlte/core'
-import { SvelteComponentTyped } from 'svelte'
+import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 import type { GravityType } from '../../types/types'
 
@@ -35,7 +35,7 @@ type AttractorEvents = Events<Group>
 
 type AttractorSlots = Slots<Group>
 
-export default class Attractor extends SvelteComponentTyped<
+export default class Attractor extends SvelteComponent<
   AttractorProps,
   AttractorEvents,
   AttractorSlots


### PR DESCRIPTION
This is just a small maintenance PR to prepare for Svelte 5. Here I've replaced all instances of the deprecated `SvelteComponentTyped` type with `SvelteComponent`. I didn't include a changeset since this was just internal type maintenance.