### PR TITLE
`<Sky>` fix

### DIFF
--- a/.changeset/cyan-elephants-jog.md
+++ b/.changeset/cyan-elephants-jog.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fixed a bug where `<Sky>`'s renderTarget wasn't able to be disposed because the canvas context did not exist anymore.

--- a/packages/extras/src/lib/components/Sky/Sky.svelte
+++ b/packages/extras/src/lib/components/Sky/Sky.svelte
@@ -104,8 +104,12 @@
 
   onDestroy(() => {
     sky.material.dispose()
-    renderTarget?.dispose()
     scene.environment = originalEnvironment
+    try {
+      renderTarget?.dispose()
+    } catch (error) {
+      console.warn('Could not dispose renderTarget:', error)
+    }
   })
 </script>
 


### PR DESCRIPTION
Fixed a bug where `<Sky>`'s renderTarget wasn't able to be disposed because the canvas context did not exist anymore.