### PR TITLE
Docs: layout/nav/organization

### DIFF
--- a/apps/docs/src/components/Menu/LeftSidebar/LeftSidebar.svelte
+++ b/apps/docs/src/components/Menu/LeftSidebar/LeftSidebar.svelte
@@ -11,7 +11,7 @@
 <nav class={c('relative hidden h-full w-full pl-6 pr-2 md:block')}>
   <ul
     id="sidebar-scrollwindow"
-    class={c('mt-0 block h-full overflow-x-hidden overflow-y-scroll pb-24 lg:pt-6')}
+    class={c('mt-0 block h-full overflow-x-hidden overflow-y-scroll pb-24')}
   >
     {#each menu[activeSidebarTab].categories as category}
       <li class="mb-6 text-sm">

--- a/apps/docs/src/components/Menu/LeftSidebar/getLeftSidebarMenu.ts
+++ b/apps/docs/src/components/Menu/LeftSidebar/getLeftSidebarMenu.ts
@@ -51,7 +51,7 @@ const getReferenceSidebarMenu = async (): Promise<LeftSidebarMenu> => {
 type LearnCategoryKey = CollectionEntry<'learn'>['data']['category']
 
 const learnSidebarMenuCategoryOrder: LearnCategoryKey[] = [
-  'Getting Started',
+  'Start Here',
   'Basics',
   'Advanced',
   'More',

--- a/apps/docs/src/components/Menu/MobileDocsNav.svelte
+++ b/apps/docs/src/components/Menu/MobileDocsNav.svelte
@@ -12,7 +12,7 @@
   export let activeUrlPathName: string
 </script>
 
-<MobileNav search>
+<MobileNav>
   <svelte:fragment slot="topbar-left">
     <a
       class="flex flex-row gap-3"

--- a/apps/docs/src/components/Menu/MobileNav.svelte
+++ b/apps/docs/src/components/Menu/MobileNav.svelte
@@ -6,14 +6,12 @@
   import BurgerIcon from './BurgerIcon.svelte'
   import Search from '$components/Search/Search.svelte'
 
-  export let search = false
-
   let showMenu = false
 
   const { action, mounted } = useElementMounted()
 </script>
 
-<div class="fixed left-0 top-0 z-40 flex max-h-screen w-full flex-col md:hidden">
+<div class="fixed left-0 top-0 z-40 flex max-h-screen w-full flex-col lg:hidden">
   <header
     class={c(
       'flex h-[70px] w-full flex-shrink-0 flex-row items-center justify-between border-b bg-[#0A0F19] px-6 py-2',
@@ -28,6 +26,7 @@
       <div>
         <slot name="topbar-right" />
       </div>
+      <Search />
       <BurgerIcon bind:showMenu />
     </div>
   </header>
@@ -46,11 +45,6 @@
         in:fade={{ delay: 200, duration: 200 }}
         out:fade={{ duration: 200 }}
       >
-        {#if search}
-          <div class="relative w-full pb-8 pt-4">
-            <Search />
-          </div>
-        {/if}
         <slot name="content" />
       </div>
     </div>

--- a/apps/docs/src/components/Menu/RightSidebar/RightSidebar.svelte
+++ b/apps/docs/src/components/Menu/RightSidebar/RightSidebar.svelte
@@ -206,6 +206,10 @@
 </div>
 
 <style lang="postcss">
+  .text-faded {
+    @apply text-white/60;
+  }
+
   .nav-list-item {
     @apply text-faded border-l-2 border-white/20 py-1 pl-4 text-sm hover:border-white/60 hover:text-white;
   }

--- a/apps/docs/src/components/Search/Search.svelte
+++ b/apps/docs/src/components/Search/Search.svelte
@@ -20,7 +20,7 @@
 
 <button
   aria-label="Search"
-  class="text-faded relative flex w-full min-w-[50px] max-w-[14rem] flex-row items-center justify-start gap-2 rounded-md border border-blue-500/10 bg-blue-900 px-3 py-2 hover:text-white hover:brightness-110 md:max-w-none"
+  class="text-faded relative flex flex-row items-center gap-2 px-3 py-2 hover:brightness-110"
   on:click={() => {
     searchActive.set(true)
   }}
@@ -30,11 +30,10 @@
     width="20"
     height="20"
     fill="#000000"
-    class="hidden fill-current lg:block"
+    class="fill-current"
     viewBox="0 0 256 256"
     ><path
       d="M232.49,215.51,185,168a92.12,92.12,0,1,0-17,17l47.53,47.54a12,12,0,0,0,17-17ZM44,112a68,68,0,1,1,68,68A68.07,68.07,0,0,1,44,112Z"
     /></svg
   >
-  <p class="text-sm">Search</p>
 </button>

--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -77,7 +77,7 @@ export const referenceCollection = defineCollection({
     sourcePath: z.string().optional(),
     order: z.number().optional(),
     isDivider: z.boolean().optional(),
-    category: z.enum(referenceCategories),
+    category: z.string(), //z.enum(referenceCategories),
     componentSignature: componentSignature.optional(),
     showInSidebar: z.boolean().optional().default(true)
   })
@@ -86,7 +86,7 @@ export const referenceCollection = defineCollection({
 export const learnCollection = defineCollection({
   schema: z.object({
     schemaType: z.string().default('learn'),
-    category: z.enum(['Getting Started', 'Basics', 'Advanced', 'More', 'Preprocessing']),
+    category: z.enum(['Start Here', 'Basics', 'Advanced', 'More', 'Preprocessing']),
     isDivider: z.boolean().optional(),
     title: z.string(),
     order: z.number().optional(),

--- a/apps/docs/src/content/learn/getting-started/Packages.mdx
+++ b/apps/docs/src/content/learn/getting-started/Packages.mdx
@@ -1,0 +1,41 @@
+---
+category: Start Here
+title: Packages
+order: 0
+---
+
+Threlte is a renderer and component library for using Three.js in a **declarative** and **state-driven** way in Svelte apps.
+
+Threlte is comprised of six distinct packages to allow you to import only what you need:
+
+## Packages
+
+### [@threlte/core](/docs/reference/core/getting-started)
+
+This is the heart of Threlte, providing simple transparent Svelte binding to Three.js
+
+### [@threlte/extras](/docs/reference/extras/getting-started)
+
+A collection of components, plugins and hooks that extend Threlte with additional functionality.
+
+### [@threlte/rapier](/docs/reference/rapier/getting-started)
+
+Provides components to enable performant physics in your Threlte application through the [Rapier engine](https://rapier.rs/)
+
+### [@threlte/theatre](/docs/reference/theatre/getting-started)
+
+provides components to enable animations in your Threlte application through the [Theatre.js animation library](https://www.theatrejs.com/)
+
+### [@threlte/xr](/docs/reference/xr/getting-started)
+
+provides components for VR and AR.
+
+### [@threlte/flex](/docs/reference/flex/getting-started)
+
+provides components to easily use the flex engine [`yoga-layout`](https://yogalayout.com/) with Threlte.
+
+## CLI
+
+### [@threlte/gltf](/docs/reference/gltf/getting-started)
+
+is a command-line tool that turns GLTF assets into declarative and re-usable Threlte components.

--- a/apps/docs/src/content/learn/getting-started/Tutorials.mdx
+++ b/apps/docs/src/content/learn/getting-started/Tutorials.mdx
@@ -1,0 +1,41 @@
+---
+category: Start Here
+title: Tutorials
+order: 10
+---
+
+Threlte is a renderer and component library for using Three.js in a **declarative** and **state-driven** way in Svelte apps.
+
+Threlte is comprised of six distinct packages to allow you to import only what you need:
+
+## Packages
+
+### [@threlte/core](/docs/reference/core/getting-started)
+
+This is the heart of Threlte, providing simple transparent Svelte binding to Three.js
+
+### [@threlte/extras](/docs/reference/extras/getting-started)
+
+A collection of components, plugins and hooks that extend Threlte with additional functionality.
+
+### [@threlte/rapier](/docs/reference/rapier/getting-started)
+
+Provides components to enable performant physics in your Threlte application through the [Rapier engine](https://rapier.rs/)
+
+### [@threlte/theatre](/docs/reference/theatre/getting-started)
+
+provides components to enable animations in your Threlte application through the [Theatre.js animation library](https://www.theatrejs.com/)
+
+### [@threlte/xr](/docs/reference/xr/getting-started)
+
+provides components for VR and AR.
+
+### [@threlte/flex](/docs/reference/flex/getting-started)
+
+provides components to easily use the flex engine [`yoga-layout`](https://yogalayout.com/) with Threlte.
+
+## CLI
+
+### [@threlte/gltf](/docs/reference/gltf/getting-started)
+
+is a command-line tool that turns GLTF assets into declarative and re-usable Threlte components.

--- a/apps/docs/src/content/learn/getting-started/examples.mdx
+++ b/apps/docs/src/content/learn/getting-started/examples.mdx
@@ -1,0 +1,41 @@
+---
+category: Start Here
+title: Examples
+order: 20
+---
+
+Threlte is a renderer and component library for using Three.js in a **declarative** and **state-driven** way in Svelte apps.
+
+Threlte is comprised of six distinct packages to allow you to import only what you need:
+
+## Packages
+
+### [@threlte/core](/docs/reference/core/getting-started)
+
+This is the heart of Threlte, providing simple transparent Svelte binding to Three.js
+
+### [@threlte/extras](/docs/reference/extras/getting-started)
+
+A collection of components, plugins and hooks that extend Threlte with additional functionality.
+
+### [@threlte/rapier](/docs/reference/rapier/getting-started)
+
+Provides components to enable performant physics in your Threlte application through the [Rapier engine](https://rapier.rs/)
+
+### [@threlte/theatre](/docs/reference/theatre/getting-started)
+
+provides components to enable animations in your Threlte application through the [Theatre.js animation library](https://www.theatrejs.com/)
+
+### [@threlte/xr](/docs/reference/xr/getting-started)
+
+provides components for VR and AR.
+
+### [@threlte/flex](/docs/reference/flex/getting-started)
+
+provides components to easily use the flex engine [`yoga-layout`](https://yogalayout.com/) with Threlte.
+
+## CLI
+
+### [@threlte/gltf](/docs/reference/gltf/getting-started)
+
+is a command-line tool that turns GLTF assets into declarative and re-usable Threlte components.

--- a/apps/docs/src/content/learn/getting-started/installation.mdx
+++ b/apps/docs/src/content/learn/getting-started/installation.mdx
@@ -1,6 +1,7 @@
 ---
 category: Start Here
 title: Installation
+order: -998
 ---
 
 To start using Threlte, you can either [scaffold a new project using the CLI](#scaffold-a-new-threlte-project) or install the packages [manually in an existing project](#manually-install-threlte-in-an-existing-project).

--- a/apps/docs/src/content/learn/getting-started/installation.mdx
+++ b/apps/docs/src/content/learn/getting-started/installation.mdx
@@ -1,5 +1,5 @@
 ---
-category: Getting Started
+category: Start Here
 title: Installation
 ---
 

--- a/apps/docs/src/content/learn/getting-started/introduction.mdx
+++ b/apps/docs/src/content/learn/getting-started/introduction.mdx
@@ -1,28 +1,41 @@
 ---
-category: Getting Started
-title: Introduction
+category: Start Here
+title: Overview
 order: -999
 ---
 
-Threlte is a renderer and component library for using Three.js in a **declarative** and **state-driven** way in Svelte apps. It provides strictly typed components for deep **reactivity** and **interactivity** out-of-the-box.
+Threlte is a renderer and component library for using Three.js in a **declarative** and **state-driven** way in Svelte apps.
 
 Threlte is comprised of six distinct packages to allow you to import only what you need:
 
-- [@threlte/core](/docs/reference/core/getting-started) is the heart of Threlte, providing simple transparent Svelte binding to Three.js:
+## Packages
 
-  - [`<T>`](/docs/reference/core/t) is the **main building block** of any Threlte application. It is a thin wrapper around any Three.js
-    object and provides a declarative API to build and render your Threlte app.
+### [@threlte/core](/docs/reference/core/getting-started)
 
-  - [Plugins](/docs/learn/advanced/plugins) make it easy to extend Threlte with custom code and logic. Whether you want to implement an ECS or add a single property to every instance of `<T>`, plugins are the way to go.
+This is the heart of Threlte, providing simple transparent Svelte binding to Three.js
 
-- [@threlte/extras](/docs/reference/extras/getting-started) is a collection of plugins and components that extend Threlte with additional functionality.
+### [@threlte/extras](/docs/reference/extras/getting-started)
 
-- [@threlte/gltf](/docs/reference/gltf/getting-started) is a command-line tool that turns GLTF assets into declarative and re-usable Threlte components.
+A collection of components, plugins and hooks that extend Threlte with additional functionality.
 
-- [@threlte/rapier](/docs/reference/rapier/getting-started) provides components to enable performant physics in your Threlte application through the [Rapier engine](https://rapier.rs/)
+### [@threlte/rapier](/docs/reference/rapier/getting-started)
 
-- [@threlte/theatre](/docs/reference/theatre/getting-started) provides components to enable animations in your Threlte application through the [Theatre.js animation library](https://www.theatrejs.com/)
+Provides components to enable performant physics in your Threlte application through the [Rapier engine](https://rapier.rs/)
 
-- [@threlte/xr](/docs/reference/xr/getting-started) provides components for VR and AR.
+### [@threlte/theatre](/docs/reference/theatre/getting-started)
 
-- [@threlte/flex](/docs/reference/flex/getting-started) provides components to easily use the flex engine [`yoga-layout`](https://yogalayout.com/) with Threlte.
+provides components to enable animations in your Threlte application through the [Theatre.js animation library](https://www.theatrejs.com/)
+
+### [@threlte/xr](/docs/reference/xr/getting-started)
+
+provides components for VR and AR.
+
+### [@threlte/flex](/docs/reference/flex/getting-started)
+
+provides components to easily use the flex engine [`yoga-layout`](https://yogalayout.com/) with Threlte.
+
+## CLI
+
+### [@threlte/gltf](/docs/reference/gltf/getting-started)
+
+is a command-line tool that turns GLTF assets into declarative and re-usable Threlte components.

--- a/apps/docs/src/content/learn/getting-started/your-first-scene.mdx
+++ b/apps/docs/src/content/learn/getting-started/your-first-scene.mdx
@@ -1,6 +1,7 @@
 ---
-category: Start Here
+category: Basics
 title: Your First Scene
+order: 100
 ---
 
 <Tip type="info">

--- a/apps/docs/src/content/learn/getting-started/your-first-scene.mdx
+++ b/apps/docs/src/content/learn/getting-started/your-first-scene.mdx
@@ -1,5 +1,5 @@
 ---
-category: Getting Started
+category: Start Here
 title: Your First Scene
 ---
 

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -41,7 +41,7 @@ const activeLinkStyles = '!text-orange'
     class="border-b-orange/25 fixed z-40 mx-auto hidden h-[70px] w-full flex-row items-center justify-between gap-6 border-b bg-[#0A0F19] px-6 md:flex"
     transition:name="desktop_nav"
   >
-    <div class="justify flex items-center justify-start gap-6 xl:gap-12">
+    <div class="justify flex items-center justify-between gap-6 xl:gap-12 grow">
       <a
         href="/"
         data-astro-prefetch
@@ -50,115 +50,14 @@ const activeLinkStyles = '!text-orange'
           src={Logo}
           alt="threlte logo"
           width={200}
-          class="h-[37px] w-auto md:hidden lg:block object-contain"
+          class="h-[37px] w-auto object-contain"
           loading="eager"
-        />
-        <Image
-          src={LogoOnly}
-          alt="threlte logo"
-          width={200}
-          class="h-[37px] w-[37px] hidden md:block lg:hidden object-contain"
-          loading="lazy"
         />
       </a>
 
-      <div class="flex h-[30px] flex-row items-center justify-start gap-4 lg:gap-6">
-        <a
-          href="/docs/learn/getting-started/introduction"
-          class={c(linkStyles, activeUrlPathName.includes('/docs/learn') && activeLinkStyles)}
-          data-astro-prefetch
-        >
-          <Book class="h-[16px] hidden lg:block" />Learn
-        </a>
-
-        <a
-          href="/docs/examples/examples"
-          class={c(linkStyles, activeUrlPathName.includes('/docs/examples') && activeLinkStyles)}
-          data-astro-prefetch
-        >
-          <Circles class="h-[16px] hidden lg:block" />Examples
-        </a>
-
-        <div class="h-full w-px bg-gray-500/70"></div>
-
-        <div class="relative flex items-center gap-6">
-          <a
-            href="/docs/reference/core/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/core') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />core</a
-          >
-          <a
-            href="/docs/reference/extras/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/extras') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />extras</a
-          >
-          <a
-            href="/docs/reference/gltf/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/gltf') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />gltf</a
-          >
-          <a
-            href="/docs/reference/rapier/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/rapier') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />rapier</a
-          >
-          <a
-            href="/docs/reference/theatre/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/theatre') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />theatre</a
-          >
-          <a
-            href="/docs/reference/xr/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/xr') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />xr
-          </a>
-          <a
-            href="/docs/reference/flex/getting-started"
-            class={c(
-              linkStyles,
-              activeUrlPathName.includes('/docs/reference/flex') && activeLinkStyles
-            )}
-            data-astro-prefetch
-          >
-            <Package class="h-[16px] hidden md:block" />flex
-          </a>
-        </div>
-      </div>
-    </div>
-
-    <div class="flex flex-1 flex-row items-center justify-end gap-6">
-      <div class="hidden max-w-[280px] flex-1 xl:flex">
-        <Search client:media="(min-width: 1280px)" />
+      <div class="flex h-[30px] flex-row items-center justify-end gap-4 lg:gap-6">
+				<Search/>
+				<Socials github twitter discord small/>
       </div>
     </div>
   </header>
@@ -184,15 +83,9 @@ const activeLinkStyles = '!text-orange'
     class="grid min-h-[66vh] md:grid-cols-[var(--left-sidebar-width)_1fr] lg:grid-cols-[var(--left-sidebar-width)_1fr_var(--right-sidebar-width)]"
   >
     <aside
-      class="fixed top-0 z-10 row-span-2 hidden h-[calc(100vh-70px)] min-w-[var(--left-sidebar-width)] place-self-start justify-self-stretch overflow-hidden md:top-[70px] md:block lg:row-span-1"
+      class="mt-6 fixed top-0 z-10 row-span-2 hidden h-[calc(100vh-70px)] min-w-[var(--left-sidebar-width)] place-self-start justify-self-stretch overflow-hidden md:top-[70px] md:block lg:row-span-1"
       transition:name="left_sidebar"
     >
-      <div class="mx-6 mb-6 mt-6 flex flex-1 xl:hidden flex-col gap-3">
-				<div class="lg:hidden">
-					<Socials github discord twitter/>
-				</div>
-        <Search client:media="(min-width: 768px) and (max-width: 1280px)" />
-      </div>
       <LeftSidebar />
     </aside>
 
@@ -210,9 +103,7 @@ const activeLinkStyles = '!text-orange'
       class="fixed top-0 right-0 z-10 row-span-2 hidden h-[calc(100vh-70px)] place-self-start justify-self-stretch overflow-hidden lg:top-[var(--docs-navbar-height)] lg:block lg:w-[var(--right-sidebar-width)]"
       transition:name="right_sidebar"
     >
-      <RightSidebar entry={Astro.props.entry} >
-				<Socials github discord twitter/>
-			</RightSidebar>
+      <RightSidebar entry={Astro.props.entry} />
     </aside>
   </main>
 </AppLayout>


### PR DESCRIPTION
Experimenting. heading towards a layout that looks similar to astro/starlight.

1. Top nav has most content removed.
2. search is always in the top nav. The socials are next to it on larger screens.
3. The introductory page lists the packages for navigation.

WIP:
- Currently working towards having a `leftsidenav` that swaps some of its contents in/out