### PR TITLE
Docs: Fixes typo

### DIFF
--- a/apps/docs/src/content/reference/extras/meshline-material.mdx
+++ b/apps/docs/src/content/reference/extras/meshline-material.mdx
@@ -120,7 +120,7 @@ You can use a combination of `dashArray`, `dashRatio` and `dashOffset` to create
 
 ### Alpha map
 
-You can pass a texture to the `alphaMap` property to use as an alpha mask along the length of the line, where black is invisible and black is visible.
+You can pass a texture to the `alphaMap` property to use as an alpha mask along the length of the line, where black is invisible and white is visible.
 In the example below we load a paint brush texture with the `useTexture` hook.
 
 <Example path="extras/meshline-material/alpha-map" />


### PR DESCRIPTION
Description of Alpha map stated "black is invisible and black is visible". Commit fixes this to "white is visible"