### PR TITLE
Remove encoding-related code to allow compatibility with r162

### DIFF
--- a/.changeset/tricky-poems-beam.md
+++ b/.changeset/tricky-poems-beam.md
@@ -1,6 +1,10 @@
 ---
-"@threlte/extras": minor
-"@threlte/core": minor
+'@threlte/extras': minor
+'@threlte/core': minor
 ---
 
-Remove deprecated encoding-related code
+Remove deprecated encoding-related code to allow compatibility with r162.
+
+### Migration
+
+Three.js r152 or later is now required.

--- a/.changeset/tricky-poems-beam.md
+++ b/.changeset/tricky-poems-beam.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": minor
+"@threlte/core": minor
+---
+
+Remove deprecated encoding-related code

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "svelte": ">=4",
-    "three": ">=0.133"
+    "three": ">=0.152"
   },
   "type": "module",
   "exports": {
@@ -58,9 +58,7 @@
   "types": "./src/lib/index.ts",
   "svelte": "./src/lib/index.ts",
   "publishOverrides": {
-    "files": [
-      "dist"
-    ],
+    "files": ["dist"],
     "svelte": "./dist/index.js",
     "exports": {
       ".": {

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -1,38 +1,12 @@
 import { writable } from 'svelte/store'
 import {
   ColorManagement,
-  LinearEncoding,
   PCFSoftShadowMap,
-  sRGBEncoding,
   WebGLRenderer,
-  type ColorSpace,
-  type TextureEncoding,
   type WebGLRendererParameters
 } from 'three'
-import { revision } from './revision'
 import type { ThrelteContext } from '../lib/contexts'
 import { watch } from './storeUtils'
-
-/**
- * March 2023: Three.js is making a transition to a new color management system. Part of
- * that is that the renderer will accept a `colorSpace` property rather than a
- * property `encoding`. As a fallback for older three versions, we need to map
- * the new `colorSpace` to the old `encoding`. We're expecting a TS error because P3 wasn't
- * supported in older versions of three.
- */
-
-// @ts-expect-error P3 is not supported in older versions of three
-const colorSpaceToEncoding: Record<ColorSpace, TextureEncoding> = {
-  srgb: sRGBEncoding,
-  'srgb-linear': LinearEncoding,
-  '': LinearEncoding
-}
-
-const rendererHasOutputColorSpaceProperty = (
-  renderer: any
-): renderer is { outputColorSpace: string } => {
-  return renderer.outputColorSpace !== undefined
-}
 
 /**
  * ### `useRenderer`
@@ -67,28 +41,13 @@ export const useRenderer = (ctx: ThrelteContext) => {
   }
 
   watch([ctx.colorManagementEnabled], ([colorManagementEnabled]) => {
-    if (revision >= 150) {
-      ColorManagement.enabled = colorManagementEnabled
-    } else {
-      ;(ColorManagement as any).legacyMode = !colorManagementEnabled
-    }
+    ColorManagement.enabled = colorManagementEnabled
   })
 
   watch([renderer, ctx.colorSpace], ([renderer, colorSpace]) => {
     if (!renderer) return
 
-    // check if the renderer has a colorSpace property, if so, use that
-    // otherwise, use the old encoding property
-    if (rendererHasOutputColorSpaceProperty(renderer)) {
-      renderer.outputColorSpace = colorSpace
-    } else {
-      const encoding = colorSpaceToEncoding[colorSpace]
-      if (!encoding) {
-        console.warn('No encoding found for colorSpace', colorSpace)
-      } else {
-        ;(renderer as any).outputEncoding = encoding
-      }
-    }
+    renderer.outputColorSpace = colorSpace
   })
 
   watch([renderer, ctx.dpr], ([renderer, dpr]) => {
@@ -120,10 +79,8 @@ export const useRenderer = (ctx: ThrelteContext) => {
   watch([renderer, ctx.useLegacyLights], ([renderer, useLegacyLights]) => {
     if (!renderer) return
 
-    if (revision >= 150 && useLegacyLights) {
+    if (useLegacyLights) {
       renderer.useLegacyLights = useLegacyLights
-    } else if (revision < 150) {
-      ;(renderer as any).physicallyCorrectLights = !useLegacyLights
     }
   })
 

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -44,12 +44,7 @@
   },
   "peerDependencies": {
     "svelte": ">=4",
-    "three": ">=0.133"
-  },
-  "peerDependenciesMeta": {
-    "three-mesh-bvh": {
-      "optional": true
-    }
+    "three": ">=0.152"
   },
   "type": "module",
   "exports": {
@@ -61,9 +56,7 @@
   "types": "./src/lib/index.ts",
   "svelte": "./src/lib/index.ts",
   "publishOverrides": {
-    "files": [
-      "dist"
-    ],
+    "files": ["dist"],
     "svelte": "./dist/index.js",
     "exports": {
       ".": {

--- a/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
+++ b/packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte
@@ -52,12 +52,7 @@
   const renderTarget = useMemo(() => {
     const rt = new WebGLRenderTarget(resolution, resolution)
     rt.texture.generateMipmaps = false
-    if ('colorSpace' in rt.texture) {
-      rt.texture.colorSpace = renderer.outputColorSpace
-    } else {
-      // deprecated in three.js r152
-      rt.texture.encoding = renderer.outputEncoding
-    }
+    rt.texture.colorSpace = renderer.outputColorSpace
     return rt
   })
   $: renderTarget.memoize(resolution)

--- a/packages/extras/src/lib/components/Environment/Environment.svelte
+++ b/packages/extras/src/lib/components/Environment/Environment.svelte
@@ -7,10 +7,10 @@
     CubeTextureLoader,
     EquirectangularReflectionMapping,
     FloatType,
-    LinearEncoding,
-    sRGBEncoding,
     Texture,
-    TextureLoader
+    TextureLoader,
+    SRGBColorSpace,
+    LinearSRGBColorSpace
   } from 'three'
   import { HDRCubeTextureLoader } from 'three/examples/jsm/loaders/HDRCubeTextureLoader'
   import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
@@ -25,7 +25,7 @@
   export let isBackground: Props['isBackground'] = undefined
   export let groundProjection: Props['groundProjection'] = undefined
   export let format: Props['format'] = undefined
-  export let encoding: Props['encoding'] = undefined
+  export let colorSpace: Props['colorSpace'] = undefined
 
   const isScene = (obj: any): obj is Scene => !!obj.isScene
 
@@ -75,10 +75,10 @@
           })
         })
       )
-    }, cacheKey)) as any
+    }, cacheKey)) as Texture
 
     texture.mapping = isCubeMap ? CubeReflectionMapping : EquirectangularReflectionMapping
-    texture.encoding = encoding || isCubeMap ? LinearEncoding : sRGBEncoding
+    texture.colorSpace = colorSpace ?? isCubeMap ? LinearSRGBColorSpace : SRGBColorSpace
     previousEnvMap = texture
     scene.environment = previousEnvMap
     if (isBackground) scene.background = previousEnvMap

--- a/packages/extras/src/lib/components/Environment/Environment.svelte.d.ts
+++ b/packages/extras/src/lib/components/Environment/Environment.svelte.d.ts
@@ -1,7 +1,7 @@
 import { SvelteComponent } from 'svelte'
 import type { Props } from '@threlte/core'
-import type { TextureEncoding } from 'three'
 import type { GroundProjectedEnv } from 'three/examples/jsm/objects/GroundProjectedEnv'
+import { ColorSpace } from 'three'
 
 export type EnvironmentProps = {
   /**
@@ -25,9 +25,9 @@ export type EnvironmentProps = {
    */
   format?: 'ldr' | 'hdr'
   /**
-   * Envmap `TextureEncoding`. If not provided it defaults to `sRGBEncoding` for cubemap and `LinearEncoding` for equirectangular
+   * Envmap color space. If not provided it defaults to `srgb` for cubemap and `srgb-linear` for equirectangular
    */
-  encoding?: TextureEncoding
+  colorSpace?: ColorSpace
 }
 
 export default class Environment extends SvelteComponent<EnvironmentProps> {}

--- a/packages/extras/src/lib/components/Grid/Grid.svelte
+++ b/packages/extras/src/lib/components/Grid/Grid.svelte
@@ -3,7 +3,6 @@
   import { T, forwardEventHandlers, useThrelte } from '@threlte/core'
   import { Color, DoubleSide, type Mesh } from 'three'
   import type { GridEvents, GridProps, GridSlots } from './Grid.svelte'
-  import { revision } from '../../lib/revision'
   import { gridComponentShaders } from './gridShaders'
 
   type $$Props = Required<GridProps>
@@ -174,9 +173,6 @@
     {uniforms}
     transparent
     side={DoubleSide}
-    defines={{
-      USE_COLORSPACE_FRAGMENT: revision >= 154 ? '' : undefined
-    }}
   />
   <slot {ref}>
     <T.PlaneGeometry args={typeof gridSize == 'number' ? [gridSize, gridSize] : gridSize} />

--- a/packages/extras/src/lib/components/Grid/gridShaders.ts
+++ b/packages/extras/src/lib/components/Grid/gridShaders.ts
@@ -1,4 +1,5 @@
 // Credits to Evan Wallace https://madebyevan.com/shaders/grid/ //
+import { revision } from '../../lib/revision'
 
 const vertexShader = /*glsl*/ `
 	varying vec3 worldPosition;
@@ -147,14 +148,7 @@ const fragmentShader = /*glsl*/ `
 		if(gl_FragColor.a <= 0.0) discard;
 
 		#include <tonemapping_fragment>
-
-		#ifdef USE_COLORSPACE_FRAGMENT
-			#include <colorspace_fragment>
-		#else
-			#include <encodings_fragment>
-		#endif
-
-
+		#include <${revision < 154 ? 'encodings_fragment' : 'colorspace_fragment'}>
 	}
 `
 

--- a/packages/extras/src/lib/hooks/useTexture.ts
+++ b/packages/extras/src/lib/hooks/useTexture.ts
@@ -19,13 +19,7 @@ export const useTexture = <Input extends UseLoaderLoadInput>(
   return loader.load(input, {
     ...options,
     transform: (res) => {
-      if ('colorSpace' in res) {
-        // >= r152
-        res.colorSpace = renderer.outputColorSpace
-      } else {
-        // < r152
-        ;(res as any).encoding = (renderer as any).outputEncoding
-      }
+      res.colorSpace = renderer.outputColorSpace
       res.needsUpdate = true
       return options?.transform?.(res) ?? res
     }

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "svelte": ">=4",
-    "three": ">=0.133"
+    "three": ">=0.152"
   },
   "type": "module",
   "exports": {
@@ -59,9 +59,7 @@
   "types": "./src/lib/index.ts",
   "svelte": "./src/lib/index.ts",
   "publishOverrides": {
-    "files": [
-      "dist"
-    ],
+    "files": ["dist"],
     "svelte": "./dist/index.js",
     "exports": {
       ".": {

--- a/packages/rapier/package.json
+++ b/packages/rapier/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@dimforge/rapier3d-compat": ">=0.11",
     "svelte": ">=4",
-    "three": ">=0.133"
+    "three": ">=0.152"
   },
   "type": "module",
   "exports": {
@@ -56,9 +56,7 @@
   "types": "./src/lib/index.ts",
   "svelte": "./src/lib/index.ts",
   "publishOverrides": {
-    "files": [
-      "dist"
-    ],
+    "files": ["dist"],
     "svelte": "./dist/index.js",
     "exports": {
       ".": {

--- a/packages/rapier/package.json
+++ b/packages/rapier/package.json
@@ -36,6 +36,7 @@
     "svelte-check": "^3.6.3",
     "svelte-preprocess": "^5.1.3",
     "svelte2tsx": "^0.7.0",
+    "three": "^0.160.1",
     "tslib": "^2.6.2",
     "type-fest": "^4.10.1",
     "typescript": "^5.3.3",

--- a/packages/theatre/package.json
+++ b/packages/theatre/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "svelte": ">=4",
-    "three": ">=0.133",
+    "three": ">=0.152",
     "@threlte/core": ">=6.0.3",
     "@threlte/extras": ">=5.1.0",
     "@theatre/core": ">=0.6",
@@ -60,9 +60,7 @@
   "types": "./src/lib/index.ts",
   "svelte": "./src/lib/index.ts",
   "publishOverrides": {
-    "files": [
-      "dist"
-    ],
+    "files": ["dist"],
     "svelte": "./dist/index.js",
     "exports": {
       ".": {

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "svelte": ">=4",
-    "three": ">=0.133"
+    "three": ">=0.152"
   },
   "type": "module",
   "exports": {
@@ -49,11 +49,7 @@
   "types": "./src/lib/index.ts",
   "svelte": "./src/lib/index.ts",
   "publishOverrides": {
-    "files": [
-      "dist",
-      "!dist/**/*.test.*",
-      "!dist/**/*.spec.*"
-    ],
+    "files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
     "svelte": "./dist/index.js",
     "exports": {
       ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,10 +616,6 @@ importers:
         version: 5.0.1
 
   packages/rapier:
-    dependencies:
-      three:
-        specifier: '>=0.133'
-        version: 0.153.0
     devDependencies:
       '@dimforge/rapier3d-compat':
         specifier: ^0.11.2
@@ -687,6 +683,9 @@ importers:
       svelte2tsx:
         specifier: ^0.7.0
         version: 0.7.0(svelte@4.2.9)(typescript@5.3.3)
+      three:
+        specifier: ^0.160.1
+        version: 0.160.1
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -11606,10 +11605,6 @@ packages:
 
   /three@0.122.0:
     resolution: {integrity: sha512-bgYMo0WdaQhf7DhLE8OSNN/rVFO5J4K1A2VeeKqoV4MjjuHjfCP6xLpg8Xedhns7NlEnN3sZ6VJROq19Qyl6Sg==}
-    dev: false
-
-  /three@0.153.0:
-    resolution: {integrity: sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==}
     dev: false
 
   /three@0.158.0:


### PR DESCRIPTION
This PR removes encoding-related code and bumps the required Three.js version to greater than or equal to r152.

I also fixed the shader deprecation warning for grid.