### PR TITLE
Grid improvements

### DIFF
--- a/.changeset/clever-coats-rhyme.md
+++ b/.changeset/clever-coats-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Minor grid improvements

--- a/apps/docs/src/content/reference/extras/grid.mdx
+++ b/apps/docs/src/content/reference/extras/grid.mdx
@@ -65,7 +65,8 @@
             default: '2',
             required: false,
             description: "'polar' only. Specifies the number of lines that will subdivide the polar grid. For instance, 2 dividers will quarter the grid into 4 sections of 90° each, while 6 dividers will divide the grid into 12 segments, each measuring 30°."
-          }
+          },
+          { name: 'side', type: 'THREE.Side', default: 'THREE.DoubleSide', required: false }
         ]
     }
 }

--- a/apps/docs/src/examples/extras/grid/App.svelte
+++ b/apps/docs/src/examples/extras/grid/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Canvas, T } from '@threlte/core'
-  import { Grid } from '@threlte/extras'
+  import { Grid, Gizmo } from '@threlte/extras'
   import { Pane, Slider, Checkbox, Folder, List, Color } from 'svelte-tweakpane-ui'
   import Scene from './Scene.svelte'
   import { PlaneGeometry } from 'three'
@@ -211,6 +211,12 @@
 
 <div>
   <Canvas>
+    <Gizmo
+      horizontalPlacement="left"
+      size={70}
+      paddingX={10}
+      paddingY={10}
+    />
     {#if gridGeometry == 'Terrain'}
       <Grid
         position.y={-2}

--- a/packages/extras/src/lib/components/Grid/Grid.svelte
+++ b/packages/extras/src/lib/components/Grid/Grid.svelte
@@ -44,7 +44,30 @@
 
   const { invalidate, camera } = useThrelte()
 
-  let uniforms = {
+  const gridPlane = new Plane()
+  const upVector = new Vector3(0, 1, 0)
+  const zeroVector = new Vector3(0, 0, 0)
+
+  const axisToInt = {
+    x: 0,
+    y: 1,
+    z: 2
+  } as const
+
+  const planeToAxes = {
+    xz: 'xzy',
+    xy: 'xyz',
+    zy: 'zyx'
+  } as const
+
+  const gridType = {
+    grid: 0,
+    lines: 1,
+    circular: 2,
+    polar: 3
+  } as const
+
+  const uniforms = {
     cellSize: {
       value: cellSize
     },
@@ -70,7 +93,7 @@
       value: fadeStrength
     },
     cellThickness: {
-      value: 1
+      value: cellThickness
     },
     sectionThickness: {
       value: sectionThickness
@@ -91,10 +114,10 @@
       value: 1
     },
     gridType: {
-      value: 0
+      value: gridType.grid as number
     },
     lineGridCoord: {
-      value: 0
+      value: axisToInt[axis as 'x' | 'y' | 'z']
     },
     circleGridMaxRadius: {
       value: maxRadius
@@ -112,18 +135,6 @@
       value: new Vector3()
     }
   }
-
-  const axisToInt = {
-    x: 0,
-    y: 1,
-    z: 2
-  } as const
-
-  const planeToAxes = {
-    xz: 'xzy',
-    xy: 'xyz',
-    zy: 'zyx'
-  } as const
 
   $: {
     // convert axis string to int indexes xzy = [0,2,1]
@@ -152,21 +163,21 @@
   $: {
     switch (type) {
       case 'grid': {
-        uniforms.gridType.value = 0
+        uniforms.gridType.value = gridType.grid
         break
       }
       case 'lines': {
-        uniforms.gridType.value = 1
+        uniforms.gridType.value = gridType.lines
         uniforms.lineGridCoord.value = axisToInt[axis as 'x' | 'y' | 'z']
         break
       }
       case 'circular': {
-        uniforms.gridType.value = 2
+        uniforms.gridType.value = gridType.circular
         uniforms.circleGridMaxRadius.value = maxRadius
         break
       }
       case 'polar': {
-        uniforms.gridType.value = 3
+        uniforms.gridType.value = gridType.polar
         uniforms.circleGridMaxRadius.value = maxRadius
         uniforms.polarCellDividers.value = cellDividers
         uniforms.polarSectionDividers.value = sectionDividers
@@ -175,10 +186,6 @@
     }
     invalidate()
   }
-
-  const gridPlane = new Plane()
-  const upVector = new Vector3(0, 1, 0)
-  const zeroVector = new Vector3(0, 0, 0)
 
   useTask(() => {
     gridPlane.setFromNormalAndCoplanarPoint(upVector, zeroVector).applyMatrix4(ref.matrixWorld)

--- a/packages/extras/src/lib/components/Grid/Grid.svelte.d.ts
+++ b/packages/extras/src/lib/components/Grid/Grid.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { Events, Props, Slots } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
-import type { ColorRepresentation, Mesh, Shape } from 'three'
+import type { ColorRepresentation, Mesh, Side } from 'three'
 
 export type GridProps = Props<Mesh> & {
   plane?: 'xz' | 'xy' | 'zy'
@@ -17,6 +17,7 @@ export type GridProps = Props<Mesh> & {
   infiniteGrid?: boolean
   fadeDistance?: number
   fadeStrength?: number
+  side?: Side
 } & (
     | {
         type?: 'grid'

--- a/packages/extras/src/lib/components/Grid/gridShaders.ts
+++ b/packages/extras/src/lib/components/Grid/gridShaders.ts
@@ -1,34 +1,33 @@
-// Credits to Evan Wallace https://madebyevan.com/shaders/grid/ //
+// Credits to Evan Wallace https://madebyevan.com/shaders/grid/
 import { revision } from '../../lib/revision'
 
-const vertexShader = /*glsl*/ `
+export const vertexShader = /*glsl*/ `
+  varying vec3 localPosition;
   varying vec4 worldPosition;
-	varying vec3 localPosition;
 
-	uniform float uFadeDistance;
-	uniform bool uInfiniteGrid;
-	uniform bool uFollowCamera;
-
-	uniform vec3 worldCamProjPosition;
+  uniform vec3 worldCamProjPosition;
 	uniform vec3 worldPlanePosition;
-	uniform int uCoord0;
-	uniform int uCoord1;
-	uniform int uCoord2;
+	uniform float fadeDistance;
+	uniform bool infiniteGrid;
+	uniform bool followCamera;
+
+	uniform int coord0;
+	uniform int coord1;
+	uniform int coord2;
 
 	void main() {
 		localPosition = vec3(
-		  position[uCoord0],
-			position[uCoord1],
-			position[uCoord2]
+		  position[coord0],
+			position[coord1],
+			position[coord2]
 		);
 
-		if (uInfiniteGrid) {
-		  localPosition *= 1. + uFadeDistance;
+		if (infiniteGrid) {
+		  localPosition *= 1.0 + fadeDistance;
 		}
 
 		worldPosition = modelMatrix * vec4(localPosition, 1.0);
-
-		if (uFollowCamera) {
+		if (followCamera) {
 		  worldPosition.xyz += (worldCamProjPosition - worldPlanePosition);
       localPosition = (inverse(modelMatrix) * worldPosition).xyz;
 		}
@@ -37,66 +36,68 @@ const vertexShader = /*glsl*/ `
 	}
 `
 
-const fragmentShader = /*glsl*/ `
+export const fragmentShader = /*glsl*/ `
   #define PI 3.141592653589793
 
 	varying vec3 localPosition;
 	varying vec4 worldPosition;
 
 	uniform vec3 worldCamProjPosition;
-	uniform float uSize1;
-	uniform float uSize2;
-	uniform vec3 uColor1;
-	uniform vec3 uColor2;
-	uniform vec3 uBackgroundColor;
-	uniform float uBackgroundOpacity;
-	uniform float uFadeDistance;
-	uniform float uFadeStrength;
-	uniform float uThickness1;
-	uniform float uThickness2;
+	uniform float cellSize;
+	uniform float sectionSize;
+	uniform vec3 cellColor;
+	uniform vec3 sectionColor;
+	uniform float fadeDistance;
+	uniform float fadeStrength;
+	uniform float cellThickness;
+	uniform float sectionThickness;
+	uniform vec3 backgroundColor;
+	uniform float backgroundOpacity;
 
-	uniform int uCoord0;
-	uniform int uCoord1;
-	uniform int uCoord2;
+	uniform bool infiniteGrid;
+
+	uniform int coord0;
+	uniform int coord1;
+	uniform int coord2;
 
 	// 0 - default; 1 - lines; 2 - circles; 3 - polar
-	uniform int uGridType;
+	uniform int gridType;
 
   // lineGrid coord for lines
-	uniform int uLineGridCoord;
+	uniform int lineGridCoord;
 
 	// circlegrid max radius
-	uniform float uCircleGridMaxRadius;
+	uniform float circleGridMaxRadius;
 
 	// polar grid dividers
-	uniform float uPolarCellDividers;
-	uniform float uPolarSectionDividers;
+	uniform float polarCellDividers;
+	uniform float polarSectionDividers;
 
 	float getSquareGrid(float size, float thickness, vec3 localPos) {
 		vec2 coord = localPos.xy / size;
 
 		vec2 grid = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);
-		float line = min(grid.x, grid.y) + 1. - thickness;
+		float line = min(grid.x, grid.y) + 1.0 - thickness;
 
-		return 1.0 - min(line, 1.);
+		return 1.0 - min(line, 1.0);
 	}
 
 	float getLinesGrid(float size, float thickness, vec3 localPos) {
-		float coord = localPos[uLineGridCoord] / size;
+		float coord = localPos[lineGridCoord] / size;
 		float line = abs(fract(coord - 0.5) - 0.5) / fwidth(coord) - thickness * 0.2;
 
-		return 1.0 - min(line, 1.);
+		return 1.0 - min(line, 1.0);
 	}
 
 	float getCirclesGrid(float size, float thickness, vec3 localPos) {
 		float coord = length(localPos.xy) / size;
 		float line = abs(fract(coord - 0.5) - 0.5) / fwidth(coord) - thickness * 0.2;
 
-		if (uCircleGridMaxRadius > 0. && coord > uCircleGridMaxRadius + thickness * 0.05) {
+		if (!infiniteGrid && circleGridMaxRadius > 0. && coord > circleGridMaxRadius + thickness * 0.05) {
 		  discard;
 		}
 
-		return 1.0 - min(line, 1.);
+		return 1.0 - min(line, 1.0);
 	}
 
 	float getPolarGrid(float size, float thickness, float polarDividers, vec3 localPos) {
@@ -112,50 +113,50 @@ const fragmentShader = /*glsl*/ `
 		vec2 grid = abs(fract(coord - 0.5) - 0.5) / width;
 		float line = min(grid.x, grid.y);
 
-		if (uCircleGridMaxRadius > 0. && rad > uCircleGridMaxRadius + thickness * 0.05) {
+		if (!infiniteGrid && circleGridMaxRadius > 0. && rad > circleGridMaxRadius + thickness * 0.05) {
 		  discard;
 		}
 
-		return 1.0 - min(line, 1.);
+		return 1.0 - min(line, 1.0);
 	}
 
 	void main() {
-		float g1 = 0.;
-		float g2 = 0.;
+		float g1 = 0.0;
+		float g2 = 0.0;
 
-		vec3 localPos = vec3(localPosition[uCoord0], localPosition[uCoord1], localPosition[uCoord2]);
+		vec3 localPos = vec3(localPosition[coord0], localPosition[coord1], localPosition[coord2]);
 
-		if(uGridType == 0){
-			g1 = getSquareGrid(uSize1, uThickness1, localPos);
-			g2 = getSquareGrid(uSize2, uThickness2, localPos);
+		if (gridType == 0) {
+			g1 = getSquareGrid(cellSize, cellThickness, localPos);
+			g2 = getSquareGrid(sectionSize, sectionThickness, localPos);
 
-		} else if(uGridType == 1){
-			g1 = getLinesGrid(uSize1, uThickness1, localPos);
-			g2 = getLinesGrid(uSize2, uThickness2, localPos);
+		} else if (gridType == 1) {
+			g1 = getLinesGrid(cellSize, cellThickness, localPos);
+			g2 = getLinesGrid(sectionSize, sectionThickness, localPos);
 
-		} else if(uGridType==2){
-			g1 = getCirclesGrid(uSize1, uThickness1, localPos);
-			g2 = getCirclesGrid(uSize2, uThickness2, localPos);
+		} else if (gridType == 2) {
+			g1 = getCirclesGrid(cellSize, cellThickness, localPos);
+			g2 = getCirclesGrid(sectionSize, sectionThickness, localPos);
 
-		} else if(uGridType==3){
-			g1 = getPolarGrid(uSize1, uThickness1, uPolarCellDividers, localPos);
-			g2 = getPolarGrid(uSize2, uThickness2, uPolarSectionDividers, localPos);
+		} else if (gridType == 3) {
+			g1 = getPolarGrid(cellSize, cellThickness, polarCellDividers, localPos);
+			g2 = getPolarGrid(sectionSize, sectionThickness, polarSectionDividers, localPos);
 		}
 
-		vec3 color = mix(uColor1, uColor2, min(1.,uThickness2 * g2));
-
 		float dist = distance(worldCamProjPosition, worldPosition.xyz);
-		float d = 1.0 - min(dist / uFadeDistance, 1.);
-		float fadeFactor = pow(d, uFadeStrength) * 0.95;
+		float d = 1.0 - min(dist / fadeDistance, 1.0);
+		float fadeFactor = pow(d, fadeStrength) * 0.95;
 
-		if (uBackgroundOpacity > 0.0) {
+		vec3 color = mix(cellColor, sectionColor, min(1.0, sectionThickness * g2));
+
+		if (backgroundOpacity > 0.0) {
 			float linesAlpha = clamp((g1 + g2) * fadeFactor, 0.,1.);
-			vec3 finalColor = mix(uBackgroundColor, color, linesAlpha);
-			float blendedAlpha = max(linesAlpha, uBackgroundOpacity * fadeFactor);
+			vec3 finalColor = mix(backgroundColor, color, linesAlpha);
+			float blendedAlpha = max(linesAlpha, backgroundOpacity * fadeFactor);
 			gl_FragColor = vec4(finalColor, blendedAlpha);
 
 		} else {
-			gl_FragColor = vec4(color, (g1 + g2) * pow(d,uFadeStrength));
+			gl_FragColor = vec4(color, (g1 + g2) * pow(d, fadeStrength));
 			gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
 		}
 
@@ -167,8 +168,3 @@ const fragmentShader = /*glsl*/ `
 		#include <${revision < 154 ? 'encodings_fragment' : 'colorspace_fragment'}>
 	}
 `
-
-export const gridComponentShaders = {
-  fragmentShader,
-  vertexShader
-}

--- a/packages/extras/src/lib/components/Grid/gridShaders.ts
+++ b/packages/extras/src/lib/components/Grid/gridShaders.ts
@@ -113,7 +113,7 @@ export const fragmentShader = /*glsl*/ `
 		vec2 grid = abs(fract(coord - 0.5) - 0.5) / width;
 		float line = min(grid.x, grid.y);
 
-		if (!infiniteGrid && circleGridMaxRadius > 0. && rad > circleGridMaxRadius + thickness * 0.05) {
+if (!infiniteGrid && circleGridMaxRadius > 0.0 && rad > circleGridMaxRadius + thickness * 0.05) {
 		  discard;
 		}
 

--- a/packages/extras/src/lib/components/Grid/gridShaders.ts
+++ b/packages/extras/src/lib/components/Grid/gridShaders.ts
@@ -150,7 +150,7 @@ if (!infiniteGrid && circleGridMaxRadius > 0.0 && rad > circleGridMaxRadius + th
 		vec3 color = mix(cellColor, sectionColor, min(1.0, sectionThickness * g2));
 
 		if (backgroundOpacity > 0.0) {
-			float linesAlpha = clamp((g1 + g2) * fadeFactor, 0.,1.);
+			float linesAlpha = clamp((g1 + g2) * fadeFactor, 0.0,1.0);
 			vec3 finalColor = mix(backgroundColor, color, linesAlpha);
 			float blendedAlpha = max(linesAlpha, backgroundOpacity * fadeFactor);
 			gl_FragColor = vec4(finalColor, blendedAlpha);


### PR DESCRIPTION
I use grid a lot, and I loved @jerzakm's last round of improvements. This continues onward with a few bug fixes and new improvements! The list is as follows:

* Fix the somewhat broken `followCamera` prop.
* Fix for line, circular, and polar graph when using different planes like `xy` or `zy`.
* Fix infinite grid for polar and circular grids
* Add the ability to specify material `FrontSide`, `BackSide`, or `DoubleSide`.
* Make reactivity for grid props more granular.
* Reduce a bit of fragment shader work to improve perf.
* Improve fade distance calculation (taken from drei's latest grid component).
