### PR TITLE
Fix broken link

### DIFF
--- a/apps/docs/src/content/learn/getting-started/your-first-scene.mdx
+++ b/apps/docs/src/content/learn/getting-started/your-first-scene.mdx
@@ -29,7 +29,7 @@ As a first step we're creating a new Svelte file called `App.svelte` where we ar
 The `<Canvas>` component is the root component of your Threlte application. It creates a
 renderer and sets up some sensible defaults for you like antialiasing and color management.
 It also creates a default camera and provides the context in which your Threlte application
-will run. For improving access to this runtime context, it's <a href="/docs/learn/basics/context">best practice</a>
+will run. For improving access to this runtime context, it's <a href="/docs/learn/basics/app-structure">best practice</a>
 to create a seperate component called `Scene.svelte` and including it in our `App.svelte` file.
 
 ## Creating Objects


### PR DESCRIPTION
Just a simple broken link fix.

In:
```
it’s [best practice](https://threlte.xyz/docs/learn/basics/context) to create a seperate component called Scene.svelte and including it in our App.svelte file
```
the `best practice` link 404s. This PR changes it to https://threlte.xyz/docs/learn/basics/app-structure. 