### PR TITLE
Bufix: Remove 'filter' prop from <InstancedSprite/>

### DIFF
--- a/.changeset/stupid-masks-report.md
+++ b/.changeset/stupid-masks-report.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Remove unused 'filter' prop from InstancedSprite

--- a/apps/docs/src/content/reference/extras/instanced-sprite.mdx
+++ b/apps/docs/src/content/reference/extras/instanced-sprite.mdx
@@ -43,13 +43,6 @@
             required: true,
             description: 'Number of instances'
           },
-					{
-            name: 'filter',
-            type: "'nearest' | 'linear'",
-            required: false,
-            default: "'nearest'",
-            description: 'The texture filtering applied to the spritesheet.'
-          },
           {
             name: 'fps',
             type: 'boolean',
@@ -140,7 +133,6 @@ Other than it's own props, `<InstanedSprite/>` extends and accepts all propertie
 | `billboarding` | Sets the default global billboarding (sprites always facing the camera) state that is used unless the setAt was called on the instance. |
 | `playmode` | Sets playmode for all instances. `"FORWARD" | "REVERSE" | "PAUSE" | "PINGPONG"` |
 | `fps` | The desired frames per second of the animation |
-| `filter` | The texture filtering applied to the spritesheet. |
 | `alphaTest` | Sets the alpha value to be used when running an alpha test |
 | `transparent` | Whether or not the material should be transparent |
 | `randomPlaybackOffset` | Offset each sprite's animation timer by a random number of milliseconds. If `true`, randomness is within 0-100ms range. Providing the prop with a number sets the upper range of the offset - `randomPlaybackOffset={2000}` means that the animation will be offset by 0-2000ms  |

--- a/packages/extras/src/lib/components/InstancedSprite/InstancedSprite.svelte
+++ b/packages/extras/src/lib/components/InstancedSprite/InstancedSprite.svelte
@@ -31,9 +31,7 @@
   export let fps: $$Props['fps'] = 15
   export let billboarding: $$Props['billboarding']
   export let playmode: $$Props['playmode'] = 'FORWARD'
-
   export let count: $$Props['count'] = 1000
-  export let filter: $$Props['filter'] = 'nearest'
   export let alphaTest: $$Props['alphaTest'] = 0.1
   export let transparent: $$Props['transparent'] = true
   export let hueShift:

--- a/packages/extras/src/lib/components/InstancedSprite/InstancedSprite.svelte.d.ts
+++ b/packages/extras/src/lib/components/InstancedSprite/InstancedSprite.svelte.d.ts
@@ -64,13 +64,6 @@ export type InstancedSpriteProps = Props<InstancedMesh> & {
   fps?: number
 
   /**
-   * The texture filtering applied to the spritesheet.
-   *
-   * @default 'nearest'
-   */
-  filter?: 'nearest' | 'linear'
-
-  /**
    * Sets the alpha value to be used when running an alpha test.
    *
    * @see https://threejs.org/docs/#api/en/materials/Material.alphaTest


### PR DESCRIPTION
Texture loading happens outside of the component and it's an overlooked leftover from one of the first versions.

Closes #917 