### PR TITLE
Docs: font fix

### DIFF
--- a/.changeset/chatty-crews-glow.md
+++ b/.changeset/chatty-crews-glow.md
@@ -1,0 +1,6 @@
+---
+"@threlte/flex": patch
+"@threlte/docs": patch
+---
+
+Removed font-family property

--- a/apps/docs/src/examples/flex/examples/App.svelte
+++ b/apps/docs/src/examples/flex/examples/App.svelte
@@ -93,18 +93,6 @@
 <style>
   :global(body) {
     margin: 0;
-    font-family:
-      system-ui,
-      -apple-system,
-      BlinkMacSystemFont,
-      'Segoe UI',
-      Roboto,
-      Oxygen,
-      Ubuntu,
-      Cantarell,
-      'Open Sans',
-      'Helvetica Neue',
-      sans-serif;
   }
 
   nav {

--- a/packages/flex/src/routes/+page.svelte
+++ b/packages/flex/src/routes/+page.svelte
@@ -107,18 +107,6 @@
   :global(body) {
     background: #333333;
     margin: 0;
-    font-family:
-      system-ui,
-      -apple-system,
-      BlinkMacSystemFont,
-      'Segoe UI',
-      Roboto,
-      Oxygen,
-      Ubuntu,
-      Cantarell,
-      'Open Sans',
-      'Helvetica Neue',
-      sans-serif;
   }
 
   nav {


### PR DESCRIPTION
Fix for this issue: https://github.com/threlte/threlte/issues/920

I've removed the font-family properties that are being applied globally. I couldn't see anywhere in the flex examples where they were being used.