### PR TITLE
Remove Svelte component proxies from theater package

### DIFF
--- a/.changeset/curly-trees-train.md
+++ b/.changeset/curly-trees-train.md
@@ -1,0 +1,5 @@
+---
+"@threlte/theatre": patch
+---
+
+Remove svelte component proxies.

--- a/packages/theatre/src/lib/sheetObject/SheetObject.svelte
+++ b/packages/theatre/src/lib/sheetObject/SheetObject.svelte
@@ -4,8 +4,8 @@
 	- Potentially Providing a sheet object
 -->
 <script lang="ts">
+  import { createSheetObjectContext } from '../../lib/useSheetObject'
   import { useStudio } from '../studio/useStudio'
-
   import type { ISheetObject, UnknownShorthandCompoundProps } from '@theatre/core'
   import {
     createRawEventDispatcher,
@@ -103,35 +103,7 @@
     }
   }
 
-  const augmentConstructorArgs = (args: any) => {
-    return {
-      ...args,
-      props: {
-        ...args.props,
-        sheetObject,
-        addProps,
-        removeProps
-      }
-    }
-  }
-
-  const proxySyncComponent = new Proxy(Sync, {
-    construct(_target, [args]) {
-      return new Sync(augmentConstructorArgs(args))
-    }
-  })
-
-  const proxyTransformComponent = new Proxy(Transform, {
-    construct(_target, [args]) {
-      return new Transform(augmentConstructorArgs(args))
-    }
-  })
-
-  const proxyDeclareComponent = new Proxy(Declare, {
-    construct(_target, [args]) {
-      return new Declare(augmentConstructorArgs(args))
-    }
-  })
+  createSheetObjectContext(sheetObject, addProps, removeProps)
 
   let values = $sheetObject?.value
   watch(sheetObject, (sheetObject) => {
@@ -173,7 +145,7 @@
   {select}
   {deselect}
   sheetObject={$sheetObject}
-  Sync={proxySyncComponent}
-  Transform={proxyTransformComponent}
-  Declare={proxyDeclareComponent}
+  {Sync}
+  {Transform}
+  {Declare}
 />

--- a/packages/theatre/src/lib/sheetObject/declare/Declare.svelte
+++ b/packages/theatre/src/lib/sheetObject/declare/Declare.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { useSheetObject } from '../../useSheetObject'
   import type { ISheetObject, UnknownShorthandCompoundProps } from '@theatre/core'
   import { watch, type CurrentWritable } from '@threlte/core'
   import { onDestroy } from 'svelte'
@@ -7,12 +8,7 @@
 
   export let props: P
 
-  /** @package */
-  export let sheetObject: CurrentWritable<ISheetObject<P>>
-  /** @package */
-  export let addProps: (props: UnknownShorthandCompoundProps) => void
-  /** @package */
-  export let removeProps: (propNames: string[]) => void
+  const { sheetObject, addProps, removeProps } = useSheetObject()
 
   let values = $sheetObject?.value
 

--- a/packages/theatre/src/lib/sheetObject/sync/Sync.svelte
+++ b/packages/theatre/src/lib/sheetObject/sync/Sync.svelte
@@ -10,17 +10,12 @@
   import { parsePropLabel } from './utils/parsePropLabel'
   import { isStringProp } from './utils/isStringProp'
   import { useStudio } from '../../studio/useStudio'
+  import { useSheetObject } from '../../useSheetObject'
 
   // used for type hinting auto props
   export let type: any = undefined
 
-  /** @package */
-  export let sheetObject: CurrentWritable<ISheetObject>
-  /** @package */
-  export let addProps: (props: UnknownShorthandCompoundProps) => void
-  /** @package */
-  export let removeProps: (propNames: string[]) => void
-
+  const { sheetObject, addProps, removeProps } = useSheetObject()
   const parent = useParent()
 
   // serves as a map to map (custom) prop names to object target properties

--- a/packages/theatre/src/lib/sheetObject/transform/Transform.svelte
+++ b/packages/theatre/src/lib/sheetObject/transform/Transform.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+  import { useSheetObject } from '../../useSheetObject'
   import { types } from '../../theatre'
-  import type { ISheetObject, UnknownShorthandCompoundProps } from '@theatre/core'
   import type { IScrub } from '@theatre/studio'
-  import { T, watch, type CurrentWritable } from '@threlte/core'
+  import { T, watch } from '@threlte/core'
   import { TransformControls } from '@threlte/extras'
   import { onMount, type ComponentProps } from 'svelte'
   import { Group } from 'three'
@@ -24,12 +24,7 @@
   export let rotationSnap: Props['rotationSnap'] = undefined as Props['rotationSnap']
   export let scaleSnap: Props['scaleSnap'] = undefined as Props['scaleSnap']
 
-  /** @package */
-  export let sheetObject: CurrentWritable<ISheetObject>
-  /** @package */
-  export let addProps: (props: UnknownShorthandCompoundProps) => void
-  /** @package */
-  export let removeProps: (propNames: string[]) => void
+  const { sheetObject, addProps, removeProps } = useSheetObject()
 
   let controls: TC | undefined
 

--- a/packages/theatre/src/lib/useSheetObject.ts
+++ b/packages/theatre/src/lib/useSheetObject.ts
@@ -1,0 +1,39 @@
+import { getContext, setContext } from 'svelte'
+import type { CurrentWritable } from '@threlte/core'
+import type { ISheetObject, UnknownShorthandCompoundProps } from '@theatre/core'
+
+const key = Symbol('threlte-theater-sheet-object-context')
+
+export interface SheetObjectContext<T extends UnknownShorthandCompoundProps> {
+  sheetObject: CurrentWritable<ISheetObject<T>>
+  addProps: (props: UnknownShorthandCompoundProps) => void
+  removeProps: (props: string[]) => void
+}
+
+export const createSheetObjectContext = <T extends UnknownShorthandCompoundProps>(
+  sheetObject: CurrentWritable<ISheetObject<T>>,
+  addProps: (props: UnknownShorthandCompoundProps) => void,
+  removeProps: (props: string[]) => void
+) => {
+  const context: SheetObjectContext<T> = {
+    sheetObject,
+    addProps,
+    removeProps
+  }
+
+  setContext<SheetObjectContext<T>>(key, context)
+
+  return context
+}
+
+export const useSheetObject = <T extends UnknownShorthandCompoundProps>() => {
+  const context = getContext<SheetObjectContext<T>>(key)
+
+  if (!context) {
+    throw new Error(
+      'No sheet object context found. Are you using this component within a <SheetObject>?'
+    )
+  }
+
+  return context
+}


### PR DESCRIPTION
### Overview

In Svelte 5 proxying a component becomes a lot more complicated, and mutating / adding / removing props sent to the component from the proxy often breaks (like in the case of $$restProps). This PR gets ahead of the Svelte 5 migration by removing the svelte component proxies created in the Theater package and replaces the props they add with an internal context.