### PR TITLE
Added KTX2Loader.Dispose to prevent memory leak

### DIFF
--- a/.changeset/yellow-needles-jump.md
+++ b/.changeset/yellow-needles-jump.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+dispose ktx2Loader's after load to prevent over-use of memory

--- a/packages/extras/src/lib/hooks/useGltf.ts
+++ b/packages/extras/src/lib/hooks/useGltf.ts
@@ -54,6 +54,7 @@ export function useGltf<
     } {
   const { renderer } = useThrelte()
   const opts = typeof urlOrOptions === 'string' ? options : urlOrOptions
+  const ktx2Loader =  opts?.ktxTranscoderPath ? new KTX2Loader() : null;
   const loader = useLoader(GLTFLoader, {
     extend(loader) {
       if (opts?.useDraco) {
@@ -79,7 +80,6 @@ export function useGltf<
       }
 
       if (opts?.ktxTranscoderPath) {
-        const ktx2Loader = new KTX2Loader()
         ktx2Loader.setTranscoderPath(opts?.ktxTranscoderPath)
         ktx2Loader.detectSupport(renderer)
         loader.setKTX2Loader(ktx2Loader)
@@ -90,6 +90,7 @@ export function useGltf<
   const load = (url: string) => {
     return loader.load(url, {
       transform(result) {
+        ktx2Loader?.dispose();
         return {
           ...result,
           ...buildSceneGraph(result.scene)

--- a/packages/extras/src/lib/hooks/useGltf.ts
+++ b/packages/extras/src/lib/hooks/useGltf.ts
@@ -80,9 +80,9 @@ export function useGltf<
       }
 
       if (opts?.ktxTranscoderPath) {
-        ktx2Loader.setTranscoderPath(opts?.ktxTranscoderPath)
-        ktx2Loader.detectSupport(renderer)
-        loader.setKTX2Loader(ktx2Loader)
+        ktx2Loader!.setTranscoderPath(opts?.ktxTranscoderPath)
+        ktx2Loader!.detectSupport(renderer)
+        loader.setKTX2Loader(ktx2Loader!)
       }
     }
   })

--- a/packages/extras/src/lib/hooks/useGltf.ts
+++ b/packages/extras/src/lib/hooks/useGltf.ts
@@ -54,7 +54,7 @@ export function useGltf<
     } {
   const { renderer } = useThrelte()
   const opts = typeof urlOrOptions === 'string' ? options : urlOrOptions
-  const ktx2Loader =  opts?.ktxTranscoderPath ? new KTX2Loader() : null;
+  const ktx2Loader = opts?.ktxTranscoderPath ? new KTX2Loader() : null
   const loader = useLoader(GLTFLoader, {
     extend(loader) {
       if (opts?.useDraco) {
@@ -90,7 +90,7 @@ export function useGltf<
   const load = (url: string) => {
     return loader.load(url, {
       transform(result) {
-        ktx2Loader?.dispose();
+        ktx2Loader?.dispose()
         return {
           ...result,
           ...buildSceneGraph(result.scene)


### PR DESCRIPTION
Hi, loading multiple GLTF files that has KTX2 textures results in a memory leak. For complex scenes it goes as far as 1GB of data.
![image](https://github.com/threlte/threlte/assets/105135724/bb0ac9fa-11f5-4892-a597-c1564c4cd24a)

This PR disposes KTX2loader instances after the gltf is loaded. 

![image](https://github.com/threlte/threlte/assets/105135724/cc1ed6ff-6f02-45ad-90e3-de6e1a5b9b4a)

I am also curious what is your opinion of disposing draco loader ? I have 20-50 objects that are draco compressed and Draco Loader also stays in memory resulting in 120 MB of memory (4 workers, 30 mb each).

Not disposing KTX2loaders

![image](https://github.com/threlte/threlte/assets/105135724/3fb6ab5d-c889-452b-8b97-df737d10bbbd)

vs

Disposing removes 2GB of data making Threlte very mobile friendly when dealing with GLTFs that are draco compressed and have KTX textures 🙌

![image](https://github.com/threlte/threlte/assets/105135724/7f922279-d573-412e-8201-cdaffbeee82c)


EDIT: I figured that draco loader only uses 30 mb per web worker. So on mobile I can simply setWorkerLimit to minimize extra overhead. So this PR targets KTXLoader only. 

