### PR TITLE
docs: fix rapier links

### DIFF
--- a/apps/docs/src/content/reference/rapier/about-joints.mdx
+++ b/apps/docs/src/content/reference/rapier/about-joints.mdx
@@ -11,19 +11,19 @@ To start off, get yourself comfortable with the [basic concepts of Joints](https
 Currently Rapier supports these joints:
 
 - **Fixed joint**
-  - [`useFixedJoint` hook](/rapier/use-fixed-joint)
+  - [`useFixedJoint` hook](/docs/reference/rapier/use-fixed-joint)
   - [Rapier Documentation](https://rapier.rs/docs/user_guides/javascript/joints#fixed-joint)
   - [Rapier Reference](https://rapier.rs/javascript3d/classes/FixedImpulseJoint.html)
 - **Revolute joint**
-  - [`useRevoluteJoint` hook](/rapier/use-revolute-joint)
+  - [`useRevoluteJoint` hook](/docs/reference/rapier/use-revolute-joint)
   - [Rapier Documentation](https://rapier.rs/docs/user_guides/javascript/joints#revolute-joint)
   - [Rapier Reference](https://rapier.rs/javascript3d/classes/RevoluteImpulseJoint.html)
 - **Prismatic joint**
-  - [`usePrismaticJoint` hook](/rapier/use-prismatic-joint)
+  - [`usePrismaticJoint` hook](/docs/reference/rapier/use-prismatic-joint)
   - [Rapier Documentation](https://rapier.rs/docs/user_guides/javascript/joints#prismatic-joint)
   - [Rapier Reference](https://rapier.rs/javascript3d/classes/PrismaticImpulseJoint.html)
 - **Spherical joint**
-  - [`useSphericalJoint` hook](/rapier/use-spherical-joint)
+  - [`useSphericalJoint` hook](/docs/reference/rapier/use-spherical-joint)
   - [Rapier Documentation](https://rapier.rs/docs/user_guides/javascript/joints#spherical-joint)
   - [Rapier Reference](https://rapier.rs/javascript3d/classes/SphericalImpulseJoint.html)
 

--- a/apps/docs/src/content/reference/rapier/use-collision-groups.mdx
+++ b/apps/docs/src/content/reference/rapier/use-collision-groups.mdx
@@ -6,7 +6,7 @@ sourcePath: 'packages/rapier/src/lib/hooks/useCollisionGroups.ts'
 type: 'hook'
 ---
 
-This hook can be used in conjunction with the component [`<CollisionGroups>`](/rapier/collision-groups). It uses the collision groups provided by a parent `<CollisionGroups>` component and lets you easily apply them to colliders.
+This hook can be used in conjunction with the component [`<CollisionGroups>`](/docs/reference/rapier/collision-groups). It uses the collision groups provided by a parent `<CollisionGroups>` component and lets you easily apply them to colliders.
 
 ```svelte
 <script>

--- a/apps/docs/src/content/reference/rapier/use-joint.mdx
+++ b/apps/docs/src/content/reference/rapier/use-joint.mdx
@@ -10,7 +10,7 @@ Use this hook to initialize any [Rapier joint](https://rapier.rs/docs/user_guide
 
 <Tip type="tip">
   This example initializes a `RevoluteImpulseJoint` manually. Most of the times you'd want to use a
-  shortcut hook (like ['useRevoluteJoint'](/rapier/use-revolute-joint)) to initialize a joint. This
+  shortcut hook (like ['useRevoluteJoint'](/docs/reference/rapier/use-revolute-joint)) to initialize a joint. This
   hook is used internally to initialize the currently available joints.
 </Tip>
 

--- a/apps/docs/src/content/reference/rapier/use-rigid-body.mdx
+++ b/apps/docs/src/content/reference/rapier/use-rigid-body.mdx
@@ -6,7 +6,7 @@ name: 'useRigidBody'
 type: 'hook'
 ---
 
-This hook provides access to the `RAPIER.RigidBody` from a parent [`<RigidBody>`](/rapier/rigid-body) component.
+This hook provides access to the `RAPIER.RigidBody` from a parent [`<RigidBody>`](/docs/reference/rapier/rigid-body) component.
 
 Use this hook to e.g. add custom colliders to a `RAPIER.RigidBody` defined by a parent `<RigidBody>` component.
 


### PR DESCRIPTION
Just a random find while browsing the docs,
Rapier reference links returning 404s.
Thanks!