### PR TITLE
[next] Remove forwardEventHandlers usage

### DIFF
--- a/.changeset/eleven-trainers-work.md
+++ b/.changeset/eleven-trainers-work.md
@@ -1,0 +1,5 @@
+---
+"@threlte/gltf": patch
+---
+
+Remove forwardEventHandlers from generated svelte files

--- a/apps/docs/src/content/learn/advanced/custom-abstractions.mdx
+++ b/apps/docs/src/content/learn/advanced/custom-abstractions.mdx
@@ -150,7 +150,7 @@ Addtionally, let's create a bindable `ref` and pass it to any child components:
   </T.Mesh>
 
   <!-- 2x2 Floor -->
-  <T.Mesh rotation.x={-90 * DEG2RAD}>
+  <T.Mesh rotation.x={-90 * MathUtils.DEG2RAD}>
     <T.PlaneGeometry args={[2, 2]} />
     <T.MeshStandardMaterial />
   </T.Mesh>

--- a/apps/docs/src/content/learn/advanced/custom-abstractions.mdx
+++ b/apps/docs/src/content/learn/advanced/custom-abstractions.mdx
@@ -15,28 +15,25 @@ in multiple places. As an example, let's create a component that is made up from
 ```svelte title="Tile.svelte"
 <script>
   import { T } from '@threlte/threlte'
-  import { DEG2RAD } from 'three/src/math/MathUtils.js'
+  import { MathUtils } from 'three'
+  
+  let { children } = $props()
 </script>
 
 <T.Group>
   <!-- 1x1x1 Cube -->
-  <T.Mesh
-    position.y={0.5}
-  >
+  <T.Mesh position.y={0.5}>
     <T.BoxGeometry />
     <T.MeshStandardMaterial />
   </T.Mesh>
 
   <!-- 2x2 Floor -->
-  <T.Mesh
-    rotation.x={-90 * DEG2RAD}
-  >
+  <T.Mesh rotation.x={-90 * MathUtils.DEG2RAD}>
     <T.PlaneGeometry args={[2, 2]} />
     <T.MeshStandardMaterial />
   </T.Mesh>
 
-  <!-- A slot to nest objects in -->
-  <slot />
+  {@render children()}
 </T.Group>
 ```
 {/* prettier-ignore-end */}
@@ -68,32 +65,31 @@ We can do that by passing a `position` prop to the `<Tile>` component:
 ```
 
 The component `<Tile>` internally needs to use the `position` prop in order to set the position of the `<T>` components. We can do that by
-[spreading `$$restProps` on the `<T.Group>`](https://svelte.dev/tutorial/spread-props) component at the root hierarchy of `<Tile>`:
+[spreading `props` on the `<T.Group>`](https://svelte.dev/tutorial/spread-props) component at the root hierarchy of `<Tile>`:
 
 {/* prettier-ignore-start */}
-```svelte title="Tile.svelte" {6}m
+```svelte title="Tile.svelte" {5}m
 <script>
   import { T } from '@threlte/threlte'
-  import { DEG2RAD } from 'three/src/math/MathUtils.js'
+  import { MathUtils } from 'three'
+
+  let { children, ...props } = $props()
 </script>
 
-<T.Group {...$$restProps}>
+<T.Group {...props}>
   <!-- 1x1x1 Cube -->
-  <T.Mesh
-    position.y={0.5}
-  >
+  <T.Mesh position.y={0.5}>
     <T.BoxGeometry />
     <T.MeshStandardMaterial />
   </T.Mesh>
 
   <!-- 2x2 Floor -->
-  <T.Mesh rotation.x={-90 * DEG2RAD}>
+  <T.Mesh rotation.x={-90 * MathUtils.DEG2RAD}>
     <T.PlaneGeometry args={[2, 2]} />
     <T.MeshStandardMaterial />
   </T.Mesh>
 
-  <!-- A slot to nest objects in -->
-  <slot />
+  {@render children()}
 </T.Group>
 ```
 {/* prettier-ignore-end */}
@@ -106,7 +102,7 @@ The last thing we need to do is to add types to our custom abstraction so that e
 We will create a `Tile.d.ts` file next to the `Tile.svelte` file and add the following content:
 
 ```ts title="Tile.d.ts"
-import type { Events, Props, Slots } from '@threlte/core'
+import type { Props } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
 import type { Group } from 'three'
 
@@ -114,15 +110,7 @@ export type TileProps = Props<Group> & {
   // Define extra props here.
 }
 
-export type TileEvents = Events<Mesh> & {
-  // Define extra events here.
-}
-
-export type TileSlots = Slots<Mesh> & {
-  // Define extra slots here.
-}
-
-export default class Tile extends SvelteComponent<TileProps, TileEvents, TileSlots> {}
+export default class Tile extends SvelteComponent<TileProps> {}
 ```
 
 Now we can use the `<Tile>` component in our scene and get autocompletion and type checking:
@@ -136,29 +124,27 @@ Now we can use the `<Tile>` component in our scene and get autocompletion and ty
 <Tile position={[0, 0, 0]} />
 ```
 
-Let's cross check the types inside our `Tile.svelte` file by implementing `$$Props`, `$$Events` and `$$Slots`. We immediately see that we forgot to
-pass the slot prop `ref` to our `<slot />`, let's add that:
+Let's cross check the types inside our `Tile.svelte` file by typing the `$props` rune.
+
+Addtionally, let's create a bindable `ref` and pass it to any child components:
 
 {/* prettier-ignore-start */}
-```svelte title="Tile.svelte" {1,13,30}m {4,6-8}+
+```svelte title="Tile.svelte" {10,13,26}m {4,8}+
 <script lang="ts">
-  import { T, forwardEventHandlers } from '@threlte/threlte'
-  import { DEG2RAD } from 'three/src/math/MathUtils.js'
-  import type { TileProps, TileEvents, TileSlots } from './Tile.svelte'
+  import { T } from '@threlte/threlte'
+  import { MathUtils } from 'three'
+  import type { TileProps } from './Tile.svelte'
 
-  type $$Props = TileProps
-  type $$Events = TileEvents
-  type $$Slots = TileSlots
-
-  const component = forwardEventHandlers()
+  let {
+    children,
+    ref = $bindable(),
+    ...props,
+  }: TileProps = $props()
 </script>
 
-<T.Group {...$$restProps} let:ref>
+<T.Group {...props} bind:ref>
   <!-- 1x1x1 Cube -->
-  <T.Mesh
-    position.y={0.5}
-    bind:this={$component}
-  >
+  <T.Mesh position.y={0.5}>
     <T.BoxGeometry />
     <T.MeshStandardMaterial />
   </T.Mesh>
@@ -169,8 +155,7 @@ pass the slot prop `ref` to our `<slot />`, let's add that:
     <T.MeshStandardMaterial />
   </T.Mesh>
 
-  <!-- A slot to nest objects in -->
-  <slot {ref} />
+  {@render children(ref)}
 </T.Group>
 ```
 {/* prettier-ignore-end */}

--- a/apps/docs/src/examples/shaders/useFboScope/world/Ducks.svelte
+++ b/apps/docs/src/examples/shaders/useFboScope/world/Ducks.svelte
@@ -10,7 +10,7 @@ Title: duck floaty
 <script lang="ts">
   import type * as THREE from 'three'
   import { Group } from 'three'
-  import { T, type Props, type Events, type Slots, forwardEventHandlers } from '@threlte/core'
+  import { T, type Props, type Events, type Slots } from '@threlte/core'
   import { useGltf, InstancedMeshes } from '@threlte/extras'
 
   type $$Props = Props<THREE.Group>
@@ -48,7 +48,7 @@ Title: duck floaty
       meshes={gltf.nodes}
       let:components={{ Object_4, Object_6 }}
     >
-      {#each { length: 200 } as _, i}
+      {#each { length: 200 } as _}
         {@const posX = Math.random() * duckSpread - duckSpread / 2}
         {@const posZ = Math.random() * duckSpread - 300}
         <T.Group

--- a/apps/docs/src/examples/shaders/useFboScope/world/Island.svelte
+++ b/apps/docs/src/examples/shaders/useFboScope/world/Island.svelte
@@ -10,7 +10,7 @@ Title: Issum, The town on Capital Isle
 <script lang="ts">
   import type * as THREE from 'three'
   import { Group } from 'three'
-  import { T, type Props, type Events, type Slots, forwardEventHandlers } from '@threlte/core'
+  import { T, type Props, type Events, type Slots } from '@threlte/core'
   import { useGltf } from '@threlte/extras'
 
   type $$Props = Props<THREE.Group>
@@ -713,15 +713,12 @@ Title: Issum, The town on Capital Isle
   const gltf = useGltf<GLTFResult>('/models/issum_the_town_on_capital_isle-transformed.glb', {
     useDraco: true
   })
-
-  const component = forwardEventHandlers()
 </script>
 
 <T
   is={ref}
   dispose={false}
   {...$$restProps}
-  bind:this={$component}
 >
   {#await gltf}
     <slot name="fallback" />

--- a/apps/docs/src/examples/test/Box.svelte
+++ b/apps/docs/src/examples/test/Box.svelte
@@ -1,32 +1,32 @@
 <script lang="ts">
-  import { forwardEventHandlers, T } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useCursor } from '@threlte/extras'
   import { spring } from 'svelte/motion'
 
-  let color = 'white'
+  let { ...props } = $props()
+
+  let color = $state('white')
 
   const scale = spring(1)
-  const component = forwardEventHandlers()
 
   const { onPointerEnter, onPointerLeave } = useCursor()
 </script>
 
 <T.Group
   scale={$scale}
-  {...$$restProps}
-  bind:this={$component}
+  {...props}
 >
   <T.Mesh
     position.y={0.5}
-    on:pointerenter={onPointerEnter}
-    on:pointerleave={onPointerLeave}
     on:pointerenter={() => {
       $scale = 2
       color = '#FE3D00'
+      onPointerEnter()
     }}
     on:pointerleave={() => {
       $scale = 1
       color = 'white'
+      onPointerLeave()
     }}
   >
     <T.BoxGeometry />

--- a/apps/docs/src/examples/test/Camera.svelte
+++ b/apps/docs/src/examples/test/Camera.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-  import { forwardEventHandlers, T, useThrelte } from '@threlte/core'
+  import { T, useThrelte } from '@threlte/core'
 
   const { invalidate } = useThrelte()
 
   const el = document.getElementById('int-target')
-
-  const component = forwardEventHandlers()
 </script>
 
 <T.OrthographicCamera
@@ -15,7 +13,6 @@
   let:ref
 >
   <T.OrbitControls
-    bind:this={$component}
     args={[ref, el]}
     on:change={invalidate}
     enableZoom={false}

--- a/apps/docs/src/examples/tutorials/animating-a-spaceship/models/spaceship.svelte
+++ b/apps/docs/src/examples/tutorials/animating-a-spaceship/models/spaceship.svelte
@@ -8,7 +8,7 @@ Title: Rusty Spaceship - Orange
 -->
 <script>
   import { AddEquation, CustomBlending, Group, LessEqualDepth, OneFactor } from 'three'
-  import { T, forwardEventHandlers } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useGltf } from '@threlte/extras'
   import { useTexture } from '@threlte/extras'
 
@@ -28,15 +28,12 @@ Title: Rusty Spaceship - Orange
     alphaFix(model.materials.spaceship_racer)
     alphaFix(model.materials.cockpit)
   })
-
-  const component = forwardEventHandlers()
 </script>
 
 <T
   is={ref}
   dispose={false}
   {...$$restProps}
-  bind:this={$component}
 >
   {#await gltf}
     <slot name="fallback" />

--- a/packages/gltf/src/utils/parser.js
+++ b/packages/gltf/src/utils/parser.js
@@ -473,11 +473,9 @@ function parse(fileName, gltf, options = {}) {
 
   const imports = `
 	${options.types ? `\nimport type * as THREE from 'three'` : ''}
-        import { Group } from 'three'
         import { ${[
           'T',
-          options.types && !options.isolated ? 'type Props, type Events, type Slots' : '',
-          !options.isolated && 'forwardEventHandlers'
+          options.types && !options.isolated ? 'type Props' : '',
         ]
           .filter(Boolean)
           .join(', ')} } from '@threlte/core'
@@ -530,18 +528,12 @@ ${
 
 
     <script${options.types ? ' lang="ts"' : ''}>
-
 				${!options.preload ? imports : ''}
 
-        ${options.types && !options.isolated ? 'type $$Props = Props<THREE.Group>' : ''}
-        ${options.types && !options.isolated ? 'type $$Events = Events<THREE.Group>' : ''}
-        ${
-          options.types && !options.isolated
-            ? 'type $$Slots = Slots<THREE.Group> & { fallback: {}; error: { error: any } }'
-            : ''
-        }
-
-        export const ref = new Group()
+        let {
+          ref = $bindable(),
+          ...props
+        }${options.types && !options.isolated ? ': Props<THREE.Group>' : ''} = $props()
 
 				${!options.preload && options.suspense ? 'const suspend = useSuspense()' : ''}
 
@@ -555,11 +547,9 @@ ${
           }(gltf, ref)`
         : ''
     }
-
-			${!options.isolated ? 'const component = forwardEventHandlers()' : ''}
     </script>
 
-		<T is={ref} dispose={false} ${!options.isolated ? '{...$$restProps} bind:this={$component}' : ''}>
+		<T.Group bind:ref dispose={false} ${!options.isolated ? '{...props}' : ''}>
 			{#await gltf}
 				<slot name="fallback" />
 			{:then gltf}

--- a/packages/gltf/src/utils/parser.js
+++ b/packages/gltf/src/utils/parser.js
@@ -475,7 +475,7 @@ function parse(fileName, gltf, options = {}) {
 	${options.types ? `\nimport type * as THREE from 'three'` : ''}
         import { ${[
           'T',
-          options.types && !options.isolated ? 'type Props' : '',
+          options.types && !options.isolated ? 'type Props, type Events, type Slots' : ''
         ]
           .filter(Boolean)
           .join(', ')} } from '@threlte/core'
@@ -529,6 +529,13 @@ ${
 
     <script${options.types ? ' lang="ts"' : ''}>
 				${!options.preload ? imports : ''}
+
+        ${options.types && !options.isolated ? 'type $$Events = Events<THREE.Group>' : ''}
+        ${
+          options.types && !options.isolated
+            ? 'type $$Slots = Slots<THREE.Group> & { fallback: {}; error: { error: any } }'
+            : ''
+        }
 
         let {
           ref = $bindable(),


### PR DESCRIPTION
This PR removes our remaining usage of `forwardEventHandlers` in the docs and in the `gltf` package.

This fixes event forwarding in the `custom-abstractions` and `handling-events` lessons and `svelte` files generated by the GLTF package, which currently do not work due to `forwardEventHandlers` being removed.