### PR TITLE
Fix typo in docs

### DIFF
--- a/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
+++ b/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
@@ -7,63 +7,26 @@
   type: 'component',
   'componentSignature':
     {
-      extends:
-        {
-          type: 'ShaderMaterial',
-          url: 'https://threejs.org/docs/index.html#api/en/materials/ShaderMaterial'
-        },
+      extends: { type: 'ShaderMaterial', url: 'https://threejs.org/docs/index.html#api/en/materials/ShaderMaterial' },
       'props':
         [
-          { name: 'envMap', type: 'CubeTexture | Texture', required: true },
-          {
-            name: 'bounces',
-            type: 'number',
-            default: '2',
-            required: false,
-            description: 'Number of ray-cast bounces, it can be expensive to have too many'
-          },
-          {
-            name: 'ior',
-            type: 'number',
-            default: '2.4',
-            required: false,
-            description: 'Refraction index'
-          },
-          {
-            name: 'fresnel',
-            type: 'number',
-            default: '0.0',
-            required: false,
-            description: 'Fresnel (strip light)'
-          },
-          {
-            name: 'aberrationStrength',
-            type: 'number',
-            default: '0.0',
-            required: false,
-            description: 'RGB shift intensity, can be expensive'
-          },
-          { name: 'color', type: 'ColorRepresentation', default: 'white', required: false },
-          {
-            name: 'fastChrome',
-            type: 'boolean',
-            default: 'true',
-            required: false,
-            description: 'If this is on it uses fewer ray casts for the RGB shift sacrificing physical accuracy'
-          }
+					{ name: 'envMap', type: 'CubeTexture | Texture', required: true },
+          { name: 'bounces', type: 'number', default: '2', required: false, description: 'Number of ray-cast bounces, it can be expensive to have too many' },
+          { name: 'ior', type: 'number', default: '2.4', required: false, description: 'Refraction index' },
+          { name: 'fresnel', type: 'number', default: '0.0', required: false, description: 'Fresnel (strip light)' },
+					{ name: 'aberrationStrength', type: 'number', default: '0.0', required: false, description: 'RGB shift intensity, can be expensive' },
+					{ name: 'color', type: 'ColorRepresentation', default: 'white', required: false },
+					{ name: 'fastChrome', type: 'boolean', default: 'true', required: false, description: 'If this is on it uses fewer ray casts for the RGB shift sacrificing physical accuracy' },
         ]
     }
 }
 ---
-
 <Tip type="info">
-  To use this component you need to install the seperate library `three-mesh-bvh`, please run `npm
-  install three-mesh-bvh` before adding this component to your project.
+  To use this component you need to install the seperate library `three-mesh-bvh`, please run `npm install three-mesh-bvh` before adding this component to your project.
 </Tip>
 
 <Tip type="experimental">
-  This material may not work reliably on some devices or browsers. We're investigating possible
-  fixes.
+	This material may not work reliably on some devices or browsers. We're investigating possible fixes.
 </Tip>
 
 This component is a port of [drei's `<MeshRefractionMaterial>`
@@ -87,10 +50,10 @@ You can either pass in a texture to use as the environment:
 </script>
 
 {#await env then texture}
-  <T.Mesh>
-    <MeshRefractionMaterial envMap={texture} />
-    <T.IcosahedronGeometry args={[4, 0]} />
-  </T.Mesh>
+	<T.Mesh>
+		<MeshRefractionMaterial envMap={texture}/>
+		<T.IcosahedronGeometry args={[4, 0]} />
+	</T.Mesh>
 {/await}
 ```
 

--- a/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
+++ b/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
@@ -7,26 +7,63 @@
   type: 'component',
   'componentSignature':
     {
-      extends: { type: 'ShaderMaterial', url: 'https://threejs.org/docs/index.html#api/en/materials/ShaderMaterial' },
+      extends:
+        {
+          type: 'ShaderMaterial',
+          url: 'https://threejs.org/docs/index.html#api/en/materials/ShaderMaterial'
+        },
       'props':
         [
-					{ name: 'envMap', type: 'CubeTexture | Texture', required: true },
-          { name: 'bounces', type: 'number', default: '2', required: false, description: 'Number of ray-cast bounces, it can be expensive to have too many' },
-          { name: 'ior', type: 'number', default: '2.4', required: false, description: 'Refraction index' },
-          { name: 'fresnel', type: 'number', default: '0.0', required: false, description: 'Fresnel (strip light)' },
-					{ name: 'aberrationStrength', type: 'number', default: '0.0', required: false, description: 'RGB shift intensity, can be expensive' },
-					{ name: 'color', type: 'ColorRepresentation', default: 'white', required: false },
-					{ name: 'fastChrome', type: 'boolean', default: 'true', required: false, description: 'If this is on it uses fewer ray casts for the RGB shift sacrificing physical accuracy' },
+          { name: 'envMap', type: 'CubeTexture | Texture', required: true },
+          {
+            name: 'bounces',
+            type: 'number',
+            default: '2',
+            required: false,
+            description: 'Number of ray-cast bounces, it can be expensive to have too many'
+          },
+          {
+            name: 'ior',
+            type: 'number',
+            default: '2.4',
+            required: false,
+            description: 'Refraction index'
+          },
+          {
+            name: 'fresnel',
+            type: 'number',
+            default: '0.0',
+            required: false,
+            description: 'Fresnel (strip light)'
+          },
+          {
+            name: 'aberrationStrength',
+            type: 'number',
+            default: '0.0',
+            required: false,
+            description: 'RGB shift intensity, can be expensive'
+          },
+          { name: 'color', type: 'ColorRepresentation', default: 'white', required: false },
+          {
+            name: 'fastChrome',
+            type: 'boolean',
+            default: 'true',
+            required: false,
+            description: 'If this is on it uses fewer ray casts for the RGB shift sacrificing physical accuracy'
+          }
         ]
     }
 }
 ---
+
 <Tip type="info">
-  To use this component you need to install the seperate library `three-mesh-bvh`, please run `npm install three-mesh-bvh` before adding this component to your project.
+  To use this component you need to install the seperate library `three-mesh-bvh`, please run `npm
+  install three-mesh-bvh` before adding this component to your project.
 </Tip>
 
 <Tip type="experimental">
-	This material may not work reliably on some devices or browsers. We're investigating possible fixes.
+  This material may not work reliably on some devices or browsers. We're investigating possible
+  fixes.
 </Tip>
 
 This component is a port of [drei's `<MeshRefractionMaterial>`
@@ -50,10 +87,10 @@ You can either pass in a texture to use as the environment:
 </script>
 
 {#await env then texture}
-	<T.Mesh>
-		<MeshRefractionMaterial envMap={texture}/>
-		<T.IcosahedronGeometry args={[4, 0]} />
-	</T.Mesh>
+  <T.Mesh>
+    <MeshRefractionMaterial envMap={texture} />
+    <T.IcosahedronGeometry args={[4, 0]} />
+  </T.Mesh>
 {/await}
 ```
 

--- a/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
+++ b/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
@@ -22,7 +22,7 @@
 }
 ---
 <Tip type="info">
-  To use this component you need to install the seperate library `three-mesh-bhv`, please run `npm install three-mesh-bhv` before adding this component to your project.
+  To use this component you need to install the seperate library `three-mesh-bvh`, please run `npm install three-mesh-bvh` before adding this component to your project.
 </Tip>
 
 <Tip type="experimental">


### PR DESCRIPTION
The name of the library is called 'three-mesh-b**vh**', not 'three-mesh-b**hv**'