### PR TITLE
[next] Migrate Billboard to runes

### DIFF
--- a/.changeset/light-rockets-confess.md
+++ b/.changeset/light-rockets-confess.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Migrate Billboard to runes mode"

--- a/apps/docs/src/content/reference/extras/billboard.mdx
+++ b/apps/docs/src/content/reference/extras/billboard.mdx
@@ -7,19 +7,13 @@ type: 'component'
 componentSignature:
   {
     extends: { type: 'Group', url: 'https://threejs.org/docs/index.html#api/en/objects/Group' },
-    props:
-      [
-        { name: 'follow', type: 'boolean', default: 'true', required: false },
-        { name: 'lockX', type: 'boolean', default: 'false', required: false },
-        { name: 'lockY', type: 'boolean', default: 'false', required: false },
-        { name: 'lockZ', type: 'boolean', default: 'false', required: false }
-      ]
+    props: [{ name: 'follow', type: 'boolean | THREE.Object3D', default: 'true', required: false }]
   }
 ---
 
 This component is a port of [drei's `<Billboard>`
 component](https://github.com/pmndrs/drei#billboard) which rotates its contents
-to always face the camera.
+to always face the camera or specified object.
 
 <Example path="extras/billboard" />
 
@@ -43,20 +37,3 @@ to always face the camera.
 
 To disable the billboard from rotating its contents to face the camera, you can
 optionally pass in a `follow` prop set to `false`.
-
-You can also optionally pass in a `lockX`, `lockY`, or `lockZ` prop to lock the
-rotation of the billboard on a specific axis.
-
-```svelte title="BillboardLocked.svelte"
-<script lang="ts">
-  import { T } from '@threlte/core'
-  import { Billboard } from '@threlte/extras'
-</script>
-
-<Billboard lockX>
-  <T.Mesh>
-    <T.MeshStandardMaterial />
-    <T.PlaneGeometry args={[2, 2]} />
-  </T.Mesh>
-</Billboard>
-```

--- a/apps/docs/src/examples/extras/billboard/App.svelte
+++ b/apps/docs/src/examples/extras/billboard/App.svelte
@@ -4,9 +4,6 @@
   import Scene from './Scene.svelte'
 
   let follow = true
-  let lockX = false
-  let lockY = false
-  let lockZ = false
 </script>
 
 <Pane
@@ -17,28 +14,11 @@
     label="follow"
     bind:value={follow}
   />
-  <Checkbox
-    label="lockX"
-    bind:value={lockX}
-  />
-  <Checkbox
-    label="lockY"
-    bind:value={lockY}
-  />
-  <Checkbox
-    label="lockZ"
-    bind:value={lockZ}
-  />
 </Pane>
 
 <div>
   <Canvas>
-    <Scene
-      {follow}
-      {lockX}
-      {lockY}
-      {lockZ}
-    />
+    <Scene {follow} />
   </Canvas>
 </div>
 

--- a/apps/docs/src/examples/extras/billboard/App.svelte
+++ b/apps/docs/src/examples/extras/billboard/App.svelte
@@ -1,11 +1,44 @@
 <script lang="ts">
+  import { Pane, Checkbox } from 'svelte-tweakpane-ui'
   import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
+
+  let follow = true
+  let lockX = false
+  let lockY = false
+  let lockZ = false
 </script>
+
+<Pane
+  title="Billboard"
+  position="fixed"
+>
+  <Checkbox
+    label="follow"
+    bind:value={follow}
+  />
+  <Checkbox
+    label="lockX"
+    bind:value={lockX}
+  />
+  <Checkbox
+    label="lockY"
+    bind:value={lockY}
+  />
+  <Checkbox
+    label="lockZ"
+    bind:value={lockZ}
+  />
+</Pane>
 
 <div>
   <Canvas>
-    <Scene />
+    <Scene
+      {follow}
+      {lockX}
+      {lockY}
+      {lockZ}
+    />
   </Canvas>
 </div>
 

--- a/apps/docs/src/examples/extras/billboard/Scene.svelte
+++ b/apps/docs/src/examples/extras/billboard/Scene.svelte
@@ -1,20 +1,47 @@
 <script lang="ts">
   import { T } from '@threlte/core'
   import { OrbitControls, Grid, Billboard } from '@threlte/extras'
+
+  export let follow = true
+  export let lockX = false
+  export let lockY = false
+  export let lockZ = false
 </script>
 
-<Billboard>
-  <T.Mesh position={[3, 1, 0]}>
+<Billboard
+  {follow}
+  {lockX}
+  {lockY}
+  {lockZ}
+  position={[3, 1, 0]}
+>
+  <T.Mesh>
     <T.MeshBasicMaterial color="red" />
     <T.PlaneGeometry args={[2, 3]} />
   </T.Mesh>
+</Billboard>
 
-  <T.Mesh position={[-4, 3, 0]}>
+<Billboard
+  {follow}
+  {lockX}
+  {lockY}
+  {lockZ}
+  position={[-4, 3, 0]}
+>
+  <T.Mesh>
     <T.MeshBasicMaterial color="green" />
     <T.PlaneGeometry args={[3, 2]} />
   </T.Mesh>
+</Billboard>
 
-  <T.Mesh position={[-1, 5, 2]}>
+<Billboard
+  {follow}
+  {lockX}
+  {lockY}
+  {lockZ}
+  position={[-1, 5, 2]}
+>
+  <T.Mesh>
     <T.MeshBasicMaterial color="blue" />
     <T.PlaneGeometry args={[2, 2]} />
   </T.Mesh>

--- a/apps/docs/src/examples/extras/billboard/Scene.svelte
+++ b/apps/docs/src/examples/extras/billboard/Scene.svelte
@@ -3,16 +3,10 @@
   import { OrbitControls, Grid, Billboard } from '@threlte/extras'
 
   export let follow = true
-  export let lockX = false
-  export let lockY = false
-  export let lockZ = false
 </script>
 
 <Billboard
   {follow}
-  {lockX}
-  {lockY}
-  {lockZ}
   position={[3, 1, 0]}
 >
   <T.Mesh>
@@ -23,9 +17,6 @@
 
 <Billboard
   {follow}
-  {lockX}
-  {lockY}
-  {lockZ}
   position={[-4, 3, 0]}
 >
   <T.Mesh>
@@ -36,9 +27,6 @@
 
 <Billboard
   {follow}
-  {lockX}
-  {lockY}
-  {lockZ}
   position={[-1, 5, 2]}
 >
   <T.Mesh>

--- a/packages/extras/src/lib/components/Billboard/Billboard.svelte
+++ b/packages/extras/src/lib/components/Billboard/Billboard.svelte
@@ -12,7 +12,7 @@
   type $$Events = BillboardEvents
   type $$Slots = BillboardSlots
 
-  let { follow = true, ...props }: BillboardProps = $props()
+  let { follow = true, ref = $bindable(), ...props }: BillboardProps = $props()
 
   const inner = new Group()
   const localRef = new Group()
@@ -49,6 +49,7 @@
 
 <T
   is={localRef}
+  bind:ref
   matrixAutoUpdate={false}
   matrixWorldAutoUpdate={false}
   {...props}

--- a/packages/extras/src/lib/components/Billboard/Billboard.svelte
+++ b/packages/extras/src/lib/components/Billboard/Billboard.svelte
@@ -1,59 +1,59 @@
+<script context="module">
+  import { type Stage, T, useTask, useThrelte } from '@threlte/core'
+
+  let stage: Stage | undefined
+</script>
+
 <script lang="ts">
   import { Euler, Group, Quaternion } from 'three'
-  import { T, useTask, useThrelte } from '@threlte/core'
+
   import type { BillboardEvents, BillboardProps, BillboardSlots } from './Billboard.svelte'
 
-  type $$Props = Required<BillboardProps>
   type $$Events = BillboardEvents
   type $$Slots = BillboardSlots
 
-  export let follow: $$Props['follow'] = true
-  export let lockX: $$Props['lockX'] = false
-  export let lockY: $$Props['lockY'] = false
-  export let lockZ: $$Props['lockZ'] = false
+  let { follow = true, ...props }: BillboardProps = $props()
 
-  let inner: Group
-  let localRef: Group
+  const inner = new Group()
+  const localRef = new Group()
 
-  const { camera } = useThrelte()
+  const { camera, scheduler, renderStage } = useThrelte()
 
   const q = new Quaternion()
 
-  const prevRotation = new Euler()
+  const nullRotation = new Euler()
+
+  let followObject = $derived(follow === true ? $camera : follow === false ? undefined : follow)
+
+  stage ??= scheduler.createStage(Symbol('billboard-stage'), { before: renderStage })
 
   const { start, stop } = useTask(
     () => {
-      // save previous rotation in case we're locking an axis
-      prevRotation.copy(localRef.rotation)
-
-      // always face the camera
+      // always face the follow object
       localRef.updateMatrix()
       localRef.updateWorldMatrix(false, false)
       localRef.getWorldQuaternion(q)
-      $camera.getWorldQuaternion(inner.quaternion).premultiply(q.invert())
-
-      // readjust any axis that is locked
-      if (lockX) localRef.rotation.x = prevRotation.x
-      if (lockY) localRef.rotation.y = prevRotation.y
-      if (lockZ) localRef.rotation.z = prevRotation.z
+      followObject?.getWorldQuaternion(inner.quaternion).premultiply(q.invert())
     },
-    { autoStart: false }
+    { autoStart: false, stage }
   )
 
-  $: if (follow && localRef) {
-    start()
-  } else {
-    stop()
-  }
+  $effect.pre(() => {
+    if (follow) {
+      start()
+    } else {
+      stop()
+    }
+  })
 </script>
 
-<T.Group
-  bind:ref={localRef}
+<T
+  is={localRef}
   matrixAutoUpdate={false}
   matrixWorldAutoUpdate={false}
-  {...$$restProps}
+  {...props}
 >
-  <T.Group bind:ref={inner}>
+  <T is={inner}>
     <slot ref={localRef} />
-  </T.Group>
-</T.Group>
+  </T>
+</T>

--- a/packages/extras/src/lib/components/Billboard/Billboard.svelte
+++ b/packages/extras/src/lib/components/Billboard/Billboard.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <script lang="ts">
-  import { Euler, Group, Quaternion } from 'three'
+  import { Group, Quaternion } from 'three'
 
   import type { BillboardEvents, BillboardProps, BillboardSlots } from './Billboard.svelte'
 
@@ -20,8 +20,6 @@
   const { camera, scheduler, renderStage } = useThrelte()
 
   const q = new Quaternion()
-
-  const nullRotation = new Euler()
 
   let followObject = $derived(follow === true ? $camera : follow === false ? undefined : follow)
 

--- a/packages/extras/src/lib/components/Billboard/Billboard.svelte.d.ts
+++ b/packages/extras/src/lib/components/Billboard/Billboard.svelte.d.ts
@@ -1,12 +1,9 @@
 import type { Events, Props, Slots } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
-import type { Group } from 'three'
+import type { Group, Object3D } from 'three'
 
 export type BillboardProps = Props<Group> & {
-  follow?: boolean
-  lockX?: boolean
-  lockY?: boolean
-  lockZ?: boolean
+  follow?: boolean | Object3D
 }
 
 export type BillboardEvents = Events<Group>


### PR DESCRIPTION
### Overview

This PR migrates `<Billboard>` to runes mode.

`lockX`, `lockY` and `lockZ` are broken both here and on the drei component, and so they have been temporarily removed from the component and the docs. Locking to a specific axis will require more than reseting an Euler angle since this is susceptible to gimbal lock problems.