### PR TITLE
Remove `useLegacyLights` props

### DIFF
--- a/.changeset/small-ravens-watch.md
+++ b/.changeset/small-ravens-watch.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": patch
+"@threlte/core": patch
+---
+
+Remove useLegacyLights prop

--- a/apps/docs/src/content/reference/core/canvas.mdx
+++ b/apps/docs/src/content/reference/core/canvas.mdx
@@ -41,13 +41,6 @@ componentSignature:
           required: false
         },
         {
-          name: 'useLegacyLights',
-          type: 'boolean',
-          default: 'true',
-          required: false,
-          description: 'Whether to use legacy lighting mode or physically correct lighting mode. Physically correct lighting mode is more physically accurate, but legacy lighting mode may be more intuitive.'
-        },
-        {
           name: 'renderMode',
           type: "'always' | 'on-demand' | 'manual'",
           default: "'on-demand'",

--- a/apps/docs/src/content/reference/core/use-threlte.mdx
+++ b/apps/docs/src/content/reference/core/use-threlte.mdx
@@ -36,25 +36,24 @@ toneMapping.set(THREE.LinearToneMapping)
 
 ```ts
 const {
-  size,                    // Readable<Size>
-  camera,                  // CurrentWritable<Camera>
-  scene,                   // Scene
-  dpr,                     // CurrentWritable<number>
-  useLegacyLights,         // CurrentWritable<boolean>
-  renderer,                // WebGLRenderer
-  renderMode,              // CurrentWritable<'always' | 'on-demand' | 'manual'>
-  autoRender,              // CurrentWritable<boolean>
-  invalidate,              // () => void
-  advance,                 // () => void
-  scheduler,               // Scheduler
-  mainStage,               // Stage
-  renderStage,             // Stage
-  autoRenderTask,          // Task
-  shouldRender,            // () => boolean
-  colorManagementEnabled,  // CurrentWritable<boolean>
-  colorSpace,              // CurrentWritable<ColorSpace>
-  toneMapping,             // CurrentWritable<ToneMapping>
-  shadows                  // CurrentWritable<boolean | ShadowMapType>
+  size, // Readable<Size>
+  camera, // CurrentWritable<Camera>
+  scene, // Scene
+  dpr, // CurrentWritable<number>
+  renderer, // WebGLRenderer
+  renderMode, // CurrentWritable<'always' | 'on-demand' | 'manual'>
+  autoRender, // CurrentWritable<boolean>
+  invalidate, // () => void
+  advance, // () => void
+  scheduler, // Scheduler
+  mainStage, // Stage
+  renderStage, // Stage
+  autoRenderTask, // Task
+  shouldRender, // () => boolean
+  colorManagementEnabled, // CurrentWritable<boolean>
+  colorSpace, // CurrentWritable<ColorSpace>
+  toneMapping, // CurrentWritable<ToneMapping>
+  shadows // CurrentWritable<boolean | ShadowMapType>
 } = useThrelte()
 ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "svelte": ">=5",
-    "three": ">=0.152"
+    "three": ">=0.155"
   },
   "type": "module",
   "exports": {

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -14,7 +14,6 @@
   import SceneGraphObject from './internal/SceneGraphObject.svelte'
   import { browser } from './lib/browser'
   import { createCache } from './lib/cache'
-  import { revision } from './lib/revision'
   import { watch } from './lib/storeUtils'
   import { useRenderer } from './lib/useRenderer'
   import { useThrelteInternal } from './hooks/useThrelteInternal'

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -69,14 +69,6 @@
     toneMapping?: ToneMapping
 
     /**
-     * This property is not reactive and must be set at initialization.
-     *
-     * @default false if greater than or equal to r155, true if less than 155
-     * @see https://github.com/mrdoob/three.js/pull/26392
-     */
-    useLegacyLights?: boolean
-
-    /**
      * By default, Threlte will automatically render the scene. To implement
      * custom render pipelines, set this to `false`.
      *
@@ -96,7 +88,6 @@
     shadows = PCFSoftShadowMap,
     size,
     toneMapping = ACESFilmicToneMapping,
-    useLegacyLights = revision >= 155 ? false : true,
     autoRender = true,
     ctx = $bindable()
   }: Props = $props()
@@ -120,7 +111,6 @@
     autoRender,
     shadows,
     toneMapping,
-    useLegacyLights,
     userSize
   })
   const internalCtx = useThrelteInternal()

--- a/packages/core/src/lib/lib/contexts.ts
+++ b/packages/core/src/lib/lib/contexts.ts
@@ -24,7 +24,6 @@ export type ThrelteContext = {
   camera: CurrentWritable<Camera>
   scene: Scene
   dpr: CurrentWritable<number>
-  useLegacyLights: CurrentWritable<boolean>
   renderer: WebGLRenderer
   /**
    * If set to 'on-demand', the scene will only be rendered when the current frame is invalidated
@@ -144,7 +143,6 @@ export const createThrelteContext = (options: {
   autoRender: boolean
   shadows: boolean | ShadowMapType
   colorManagementEnabled: boolean
-  useLegacyLights: boolean
 }): ThrelteContext => {
   const internalCtx: ThrelteInternalContext = {
     frameInvalidated: true,
@@ -235,7 +233,6 @@ export const createThrelteContext = (options: {
     colorSpace: currentWritable(options.colorSpace),
     toneMapping: currentWritable(options.toneMapping),
     dpr: currentWritable(options.dpr),
-    useLegacyLights: currentWritable(options.useLegacyLights),
     shadows: currentWritable(options.shadows),
     colorManagementEnabled: currentWritable(options.colorManagementEnabled),
     renderMode: currentWritable(options.renderMode),

--- a/packages/core/src/lib/lib/useRenderer.ts
+++ b/packages/core/src/lib/lib/useRenderer.ts
@@ -21,7 +21,6 @@ import { currentWritable, memoize, watch } from './storeUtils'
  * - `size`
  * - `shadows`
  * - `toneMapping`
- * - `useLegacyLights`
  */
 export const useRenderer = (ctx: ThrelteContext) => {
   const renderer = currentWritable<WebGLRenderer | undefined>(undefined)
@@ -89,14 +88,6 @@ export const useRenderer = (ctx: ThrelteContext) => {
     if (!renderer) return
 
     renderer.toneMapping = toneMapping
-  })
-
-  watch([renderer, ctx.useLegacyLights], ([renderer, useLegacyLights]) => {
-    if (!renderer) return
-
-    if (useLegacyLights) {
-      renderer.useLegacyLights = useLegacyLights
-    }
   })
 
   return {

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "svelte": ">=5",
-    "three": ">=0.152"
+    "three": ">=0.155"
   },
   "type": "module",
   "exports": {

--- a/packages/extras/src/lib/components/CSM/CSM.svelte
+++ b/packages/extras/src/lib/components/CSM/CSM.svelte
@@ -34,7 +34,7 @@
   const enabledStore = writable(enabled)
   $: enabledStore.set(enabled)
 
-  const { camera: defaultCamera, scene, size, useLegacyLights } = useThrelte()
+  const { camera: defaultCamera, scene, size } = useThrelte()
 
   const csm = currentWritable<CSM | undefined>(undefined)
 
@@ -89,19 +89,16 @@
   const lightColorStore = writable<typeof lightColor>(lightColor)
   $: lightColorStore.set(lightColor)
 
-  watch(
-    [csm, lightIntensityStore, lightColorStore, useLegacyLights],
-    ([csm, intensity, color, useLegacyLights]) => {
-      csm?.lights.forEach((light) => {
-        if (intensity !== undefined) {
-          light.intensity = intensity / (useLegacyLights ? 1 : Math.PI)
-        }
-        if (color !== undefined) {
-          light.color.set(color)
-        }
-      })
-    }
-  )
+  watch([csm, lightIntensityStore, lightColorStore], ([csm, intensity, color]) => {
+    csm?.lights.forEach((light) => {
+      if (intensity !== undefined) {
+        light.intensity = intensity / Math.PI
+      }
+      if (color !== undefined) {
+        light.color.set(color)
+      }
+    })
+  })
 
   const lightDirectionStore = writable(lightDirection)
   $: lightDirectionStore.set(lightDirection)

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "svelte": ">=5",
-    "three": ">=0.152"
+    "three": ">=0.155"
   },
   "type": "module",
   "exports": {

--- a/packages/theatre/package.json
+++ b/packages/theatre/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "svelte": ">=4",
-    "three": ">=0.152",
+    "three": ">=0.155",
     "@threlte/core": ">=8.0.0-next.0",
     "@threlte/extras": ">=9.0.0-next.0",
     "@theatre/core": ">=0.6",

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "svelte": ">=5",
-    "three": ">=0.152"
+    "three": ">=0.155"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
Three.js has completely removed this prop in `r165`. It's set to false by default in `155`, which is our new minimum supported version.