### PR TITLE
[next] more docs clean up

### DIFF
--- a/apps/docs/src/content/learn/basics/disposing-objects.mdx
+++ b/apps/docs/src/content/learn/basics/disposing-objects.mdx
@@ -10,7 +10,7 @@ Freeing resources is a [manual chore in three.js](https://threejs.org/docs/index
 
 ```svelte
 <script>
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useTexture } from '@threlte/extras'
 
   const map = useTexture('/some/texture')
@@ -38,7 +38,7 @@ You can switch off automatic disposal by placing `dispose={false}` onto componen
 
 ```svelte
 <script>
-  import { Mesh, useTexture } from '@threlte/core'
+  import { T, useTexture } from '@threlte/core'
   import { BoxBufferGeometry, MeshStandardMaterial } from 'three'
 
   const map = useTexture('/some/texture')

--- a/apps/docs/src/content/reference/extras/edges.mdx
+++ b/apps/docs/src/content/reference/extras/edges.mdx
@@ -34,14 +34,14 @@ Edges are displayed when the angle between two faces exceeds the angle defined b
 ```svelte
 <script lang="ts">
   import { BoxBufferGeometry, MeshBasicMaterial } from 'three'
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { Edges } from '@threlte/extras'
 </script>
 
-<Mesh
+<T.Mesh
   geometry={new BoxBufferGeometry(1, 1, 1)}
   material={new MeshBasicMaterial()}
 >
   <Edges color="black" />
-</Mesh>
+</T.Mesh>
 ```

--- a/apps/docs/src/content/reference/extras/outlines.mdx
+++ b/apps/docs/src/content/reference/extras/outlines.mdx
@@ -62,14 +62,14 @@ An ornamental component that extracts the geometry from its parent and displays 
 ```svelte
 <script lang="ts">
   import { BoxBufferGeometry, MeshBasicMaterial } from 'three'
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { Outlines } from '@threlte/extras'
 </script>
 
-<Mesh
+<T.Mesh
   geometry={new BoxBufferGeometry(1, 1, 1)}
   material={new MeshBasicMaterial()}
 >
   <Outlines color="black" />
-</Mesh>
+</T.Mesh>
 ```

--- a/apps/docs/src/content/reference/extras/use-cursor.mdx
+++ b/apps/docs/src/content/reference/extras/use-cursor.mdx
@@ -20,7 +20,7 @@ Provide arguments to determine the cursor style. The defaults are`'pointer'` for
 
 ```svelte
 <script lang="ts">
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useCursor } from '@threlte/extras'
   import { BoxBufferGeometry, MeshBasicMaterial } from 'three'
 
@@ -30,8 +30,7 @@ Provide arguments to determine the cursor style. The defaults are`'pointer'` for
   const { onPointerEnter, onPointerLeave } = useCursor('grab', 'crosshair')
 </script>
 
-<Mesh
-  interactive
+<T.Mesh
   on:pointerenter={onPointerEnter}
   geometry={new BoxBufferGeometry(1, 1, 1)}
   material={new MeshBasicMaterial()}
@@ -44,7 +43,7 @@ You can rename the event handlers to resolve naming conflicts. Additionally Svel
 
 ```svelte
 <script lang="ts">
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useCursor } from '@threlte/extras'
   import { BoxBufferGeometry, MeshBasicMaterial } from 'three'
 
@@ -58,8 +57,7 @@ You can rename the event handlers to resolve naming conflicts. Additionally Svel
   }
 </script>
 
-<Mesh
-  interactive
+<T.Mesh
   on:pointerenter={cursorEnter}
   on:pointerenter={onPointerEnter}
   geometry={new BoxBufferGeometry(1, 1, 1)}
@@ -73,15 +71,14 @@ If you want to implement custom logic, you can use the returned svelte store to 
 
 ```svelte
 <script lang="ts">
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useCursor } from '@threlte/extras'
   import { BoxBufferGeometry, MeshBasicMaterial } from 'three'
 
   const { hovering } = useCursor()
 </script>
 
-<Mesh
-  interactive
+<T.Mesh
   on:pointerenter={() => ($hovering = true)}
   on:pointerleave={() => ($hovering = false)}
   geometry={new BoxBufferGeometry(1, 1, 1)}
@@ -95,7 +92,7 @@ Provide svelte stores to change the cursor style also while hovering:
 
 ```svelte
 <script lang="ts">
-  import { Mesh } from '@threlte/core'
+  import { T } from '@threlte/core'
   import { useCursor } from '@threlte/extras'
   import { BoxBufferGeometry, MeshBasicMaterial } from 'three'
   import { writable } from 'svelte/store'
@@ -108,8 +105,7 @@ Provide svelte stores to change the cursor style also while hovering:
   onPointerOverCursor.set('grabbing')
 </script>
 
-<Mesh
-  interactive
+<T.Mesh
   on:pointerenter={onPointerEnter}
   geometry={new BoxBufferGeometry(1, 1, 1)}
   material={new MeshBasicMaterial()}


### PR DESCRIPTION
there was some `import { Mesh } from '@threlte/core'` which is no longer a thing. `interactive` prop removed too.