### PR TITLE
Next runtime errors

### DIFF
--- a/packages/core/src/lib/components/T/T.svelte
+++ b/packages/core/src/lib/components/T/T.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" generics="Type">
   import { useIsContext } from './utils/useIsContext'
   import DisposableObject from '../../internal/DisposableObject.svelte'
   import SceneGraphObject from '../../internal/SceneGraphObject.svelte'
@@ -12,8 +12,6 @@
   import { useProps } from './utils/useProps'
   import type { Props } from './types'
   import Camera from './Camera.svelte'
-
-  type Type = $$Generic
 
   type AllProps = {
     is: Type
@@ -34,7 +32,6 @@
 
   // We can't create the object in a reactive statement due to providing context
   let internalRef = $derived(determineRef<Type>(is, args))
-  ref = internalRef
 
   const parent = useParent()
 

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
@@ -16,6 +16,7 @@
     Vector4,
     type ColorRepresentation,
     type Intersection,
+    type Object3DEventMap,
     type Sprite
   } from 'three'
   import type { GizmoProps } from './Gizmo.svelte'
@@ -123,12 +124,12 @@
     clickTarget.style.width = `${size}px`
   })
 
-  let posX: Sprite
-  let posY: Sprite
-  let posZ: Sprite
-  let negX: Sprite
-  let negY: Sprite
-  let negZ: Sprite
+  let posX: Sprite<Object3DEventMap> | undefined = $state(undefined)
+  let posY: Sprite<Object3DEventMap> | undefined = $state(undefined)
+  let posZ: Sprite<Object3DEventMap> | undefined = $state(undefined)
+  let negX: Sprite<Object3DEventMap> | undefined = $state(undefined)
+  let negY: Sprite<Object3DEventMap> | undefined = $state(undefined)
+  let negZ: Sprite<Object3DEventMap> | undefined = $state(undefined)
 
   const targetPosition = new Vector3()
   const targetQuaternion = new Quaternion()
@@ -202,6 +203,11 @@
 
     raycaster.setFromCamera(mouse, orthoCam)
 
+    // Gaurd against undefined axis sprites otherwise TS will complain
+    if (!posX || !posY || !posZ || !negX || !negY || !negZ) {
+      return
+    }
+
     const intersects = raycaster.intersectObjects([posX, posY, posZ, negX, negY, negZ])
 
     if (intersects.length > 0) {
@@ -226,7 +232,7 @@
 
   // Used to test which axis (pos or neg) are closer to the camera.
   const point = new Vector3()
-  let p = [0, 0, 0]
+  let p = $state([0, 0, 0])
 
   useTask(
     animationTask?.key ?? Symbol('threlte-extras-gizmo-animation'),

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -79,6 +79,7 @@
     ref = $bindable(),
     visible = $bindable(),
     style,
+    children,
     ...props
   }: HTMLProps = $props()
 
@@ -91,8 +92,8 @@
   let element = document.createElement(as)
   let oldZoom = 0
   let oldPosition = [0, 0]
-  let transformOuterRef: HTMLDivElement
-  let transformInnerRef: HTMLDivElement
+  let transformOuterRef: HTMLDivElement | undefined = $state()
+  let transformInnerRef: HTMLDivElement | undefined = $state()
   let isMeshSizeSet = false
 
   const occlusionMesh = new Mesh()
@@ -174,7 +175,7 @@
 
       element.style.zIndex = `${objectZIndex(group, camera.current as OrthographicCamera | PerspectiveCamera, zRange)}`
 
-      if (transform) {
+      if (transform && transformOuterRef && transformInnerRef) {
         const { isOrthographicCamera, top, left, bottom, right } =
           camera.current as OrthographicCamera
         const cameraMatrix = getCameraCSSMatrix(camera.current.matrixWorldInverse)
@@ -214,7 +215,7 @@
     }
 
     if (!isRayCastOcclusion && !isMeshSizeSet) {
-      if (transform) {
+      if (transform && transformOuterRef) {
         const el = transformOuterRef.children[0]
 
         console.log(el.clientWidth, el.clientHeight)
@@ -344,7 +345,9 @@
           class={props.class}
           style={props.style}
         >
-          <slot />
+          {#if children}
+            {@render children()}
+          {/if}
         </div>
       </div>
     </div>
@@ -359,7 +362,9 @@
       style={props.style}
       class={props.class}
     >
-      <slot />
+      {#if children}
+        {@render children()}
+      {/if}
     </div>
   {/if}
 </svelte:element>

--- a/packages/extras/src/lib/components/HTML/HTML.svelte.d.ts
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte.d.ts
@@ -1,5 +1,5 @@
 import type { Events, Props, Slots } from '@threlte/core'
-import { SvelteComponent } from 'svelte'
+import { SvelteComponent, type Snippet } from 'svelte'
 import type { Camera, Group, Object3D } from 'three'
 
 export type HTMLProps = Props<Group> & {
@@ -36,6 +36,7 @@ export type HTMLProps = Props<Group> & {
   occlude?: boolean | Object3D[] | boolean | 'raycast' | 'blending'
   castShadow?: boolean // Cast shadow for occlusion plane
   receiveShadow?: boolean // Receive shadow for occlusion plane
+  children?: Snippet
 }
 
 export type HTMLEvents = Events<Group>


### PR DESCRIPTION
closes #1022 

Fixed runtime error in:
- Gizmo.svelte
- HTML.svelte

Attempts were made to eliminate all runtime errors occurring in `T.svelte`. However, these errors fall outside the scope of this issue. I hope others are able to resolve the last issues