### PR TITLE
[next] Fix events

### DIFF
--- a/.changeset/dry-guests-wonder.md
+++ b/.changeset/dry-guests-wonder.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": patch
+---
+
+Fix event cleanup of <T>

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,1 +1,2 @@
 README.md
+CHANGELOG.md

--- a/packages/core/src/lib/components/T/utils/useEvents.ts
+++ b/packages/core/src/lib/components/T/utils/useEvents.ts
@@ -26,30 +26,26 @@ export const useEvents = <T>(props: Props = {}) => {
     }
   }
 
-  const addedEventListeners: string[] = []
-
-  const cleanupEventListeners = (ref: EventDispatcher) => {
-    for (let i = 0; i < addedEventListeners.length; i++) {
-      const eventName = addedEventListeners[i]
-      ref.removeEventListener(eventName, eventHandlerProxy)
-    }
-    addedEventListeners.length = 0
-  }
-
   const addEventListeners = (ref: EventDispatcher, props: Props) => {
+    const eventNames: string[] = []
+
     for (const eventName of Object.keys(props)) {
       if (eventName.startsWith('on')) {
         ref.addEventListener(eventName.slice(2), eventHandlerProxy)
-        addedEventListeners.push(eventName)
+        eventNames.push(eventName)
+      }
+    }
+
+    return () => {
+      for (let i = 0; i < eventNames.length; i++) {
+        ref.removeEventListener(eventNames[i], eventHandlerProxy)
       }
     }
   }
 
   const updateRef = (ref: MaybeInstance<T>) => {
     if (!isEventDispatcher(ref)) return
-
-    addEventListeners(ref, props)
-    return () => cleanupEventListeners(ref)
+    return addEventListeners(ref, props)
   }
 
   return {

--- a/packages/core/src/lib/components/T/utils/useEvents.ts
+++ b/packages/core/src/lib/components/T/utils/useEvents.ts
@@ -26,18 +26,21 @@ export const useEvents = <T>(props: Props = {}) => {
     }
   }
 
-  const cleanupEventListeners = (ref: EventDispatcher, props: Props) => {
-    for (const eventName of Object.keys(props)) {
-      if (eventName.startsWith('on')) {
-        ref.removeEventListener(eventName.slice(2), eventHandlerProxy)
-      }
+  const addedEventListeners: string[] = []
+
+  const cleanupEventListeners = (ref: EventDispatcher) => {
+    for (let i = 0; i < addedEventListeners.length; i++) {
+      const eventName = addedEventListeners[i]
+      ref.removeEventListener(eventName, eventHandlerProxy)
     }
+    addedEventListeners.length = 0
   }
 
   const addEventListeners = (ref: EventDispatcher, props: Props) => {
     for (const eventName of Object.keys(props)) {
       if (eventName.startsWith('on')) {
         ref.addEventListener(eventName.slice(2), eventHandlerProxy)
+        addedEventListeners.push(eventName)
       }
     }
   }
@@ -46,7 +49,7 @@ export const useEvents = <T>(props: Props = {}) => {
     if (!isEventDispatcher(ref)) return
 
     addEventListeners(ref, props)
-    return () => cleanupEventListeners(ref, props)
+    return () => cleanupEventListeners(ref)
   }
 
   return {

--- a/packages/extras/.prettierignore
+++ b/packages/extras/.prettierignore
@@ -1,1 +1,2 @@
 README.md
+CHANGELOG.md

--- a/packages/flex/.prettierignore
+++ b/packages/flex/.prettierignore
@@ -1,1 +1,2 @@
 README.md
+CHANGELOG.md

--- a/packages/rapier/.prettierignore
+++ b/packages/rapier/.prettierignore
@@ -1,1 +1,2 @@
 README.md
+CHANGELOG.md

--- a/packages/studio/.prettierignore
+++ b/packages/studio/.prettierignore
@@ -1,1 +1,2 @@
 README.md
+CHANGELOG.md

--- a/packages/theatre/.prettierignore
+++ b/packages/theatre/.prettierignore
@@ -1,1 +1,2 @@
 README.md
+CHANGELOG.md

--- a/packages/xr/.prettierignore
+++ b/packages/xr/.prettierignore
@@ -1,2 +1,3 @@
 README.md
+CHANGELOG.md
 .svelte-kit/**/*


### PR DESCRIPTION
Due to an odd behavior of SvelteKit, the props might be undefined at the time of unmounting. To account for that, we track what events are actually being added manually.