### PR TITLE
Update vertex.ts to fix ERROR: 0:167: 'isPerspectiveMatrix' : no matc…

### DIFF
--- a/.changeset/selfish-bobcats-guess.md
+++ b/.changeset/selfish-bobcats-guess.md
@@ -1,5 +1,5 @@
 ---
-'@threlte/extras': major
+'@threlte/extras': patch
 ---
 
 Update vertex.ts to fix ERROR: 0:167: 'isPerspectiveMatrix' : no matching overloaded function found

--- a/.changeset/selfish-bobcats-guess.md
+++ b/.changeset/selfish-bobcats-guess.md
@@ -1,0 +1,5 @@
+---
+'@threlte/extras': major
+---
+
+Update vertex.ts to fix ERROR: 0:167: 'isPerspectiveMatrix' : no matching overloaded function found

--- a/packages/extras/src/lib/components/MeshLine/vertex.ts
+++ b/packages/extras/src/lib/components/MeshLine/vertex.ts
@@ -1,6 +1,7 @@
 import { ShaderChunk } from 'three'
 
 export const vertexShader = `
+	  #include <common>
     ${ShaderChunk.logdepthbuf_pars_vertex}
     ${ShaderChunk.fog_pars_vertex}
 


### PR DESCRIPTION
This PR fixes failed shader compilation with MeshLineGeometry . 

It fails at shader compilation with ERROR: 0:167: 'isPerspectiveMatrix' : no matching overloaded function found, see related discussions:
https://github.com/spite/THREE.MeshLine/issues/123
https://github.com/lume/three-meshline/pull/15

It was never merged to THREE.MeshLine 