### PR TITLE
[next] update Yoga to new major version

### DIFF
--- a/.changeset/spotty-insects-develop.md
+++ b/.changeset/spotty-insects-develop.md
@@ -1,0 +1,5 @@
+---
+"@threlte/flex": minor
+---
+
+bump Yoga 2.0 > Yoga 3.1

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "mitt": "^3.0.1",
-    "yoga-layout": "^2.0.1"
+    "yoga-layout": "^3.1.0"
   },
   "peerDependencies": {
     "svelte": ">=5",

--- a/packages/flex/src/lib/Flex/Flex.svelte
+++ b/packages/flex/src/lib/Flex/Flex.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { loadYoga, type Yoga } from 'yoga-layout'
+  import { loadYoga, type Yoga } from 'yoga-layout/load'
   import type { FlexProps } from './Flex.svelte'
   import InnerFlex from './InnerFlex.svelte'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,10 +297,10 @@ importers:
         version: 5.0.0-next.181
       svelte-check:
         specifier: ^3.6.9
-        version: 3.6.9(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.38)(sass@1.77.7)(svelte@5.0.0-next.181)
+        version: 3.6.9(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.39)(sass@1.77.7)(svelte@5.0.0-next.181)
       svelte-preprocess:
         specifier: ^5.1.3
-        version: 5.1.3(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.38)(sass@1.77.7)(svelte@5.0.0-next.181)(typescript@5.4.5)
+        version: 5.1.3(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.39)(sass@1.77.7)(svelte@5.0.0-next.181)(typescript@5.4.5)
       svelte2tsx:
         specifier: ^0.7.6
         version: 0.7.6(svelte@5.0.0-next.181)(typescript@5.4.5)
@@ -475,8 +475,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       yoga-layout:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.2.0
@@ -537,10 +537,10 @@ importers:
         version: 5.0.0-next.181
       svelte-check:
         specifier: ^3.6.9
-        version: 3.6.9(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.39)(sass@1.77.7)(svelte@5.0.0-next.181)
+        version: 3.6.9(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.38)(sass@1.77.7)(svelte@5.0.0-next.181)
       svelte-preprocess:
         specifier: ^5.1.3
-        version: 5.1.3(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.39)(sass@1.77.7)(svelte@5.0.0-next.181)(typescript@5.4.5)
+        version: 5.1.3(@babel/core@7.24.7)(postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.8.2(@types/node@20.12.7)(typescript@5.4.5)))(postcss@8.4.38)(sass@1.77.7)(svelte@5.0.0-next.181)(typescript@5.4.5)
       svelte2tsx:
         specifier: ^0.7.6
         version: 0.7.6(svelte@5.0.0-next.181)(typescript@5.4.5)
@@ -7773,8 +7773,8 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
 
-  yoga-layout@2.0.1:
-    resolution: {integrity: sha512-tT/oChyDXelLo2A+UVnlW9GU7CsvFMaEnd9kVFsaiCQonFAXd3xrHhkLYu+suwwosrAEQ746xBU+HvYtm1Zs2Q==}
+  yoga-layout@3.1.0:
+    resolution: {integrity: sha512-auzJ8lEovThZIpR8wLGWNo/JEj4VTO79q9/gOJ0dWb3shAYPFdX3t9VN0fC0v+jeQF77STUdCzebLwRMqzn5gQ==}
 
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
@@ -15903,7 +15903,7 @@ snapshots:
 
   yocto-queue@1.0.0: {}
 
-  yoga-layout@2.0.1: {}
+  yoga-layout@3.1.0: {}
 
   zimmerframe@1.1.2: {}
 


### PR DESCRIPTION
Yoga had a major update in March that came with a lot of improvements to layouting accuaracy etc.

Blog posts:

[Major - 3.0](https://www.yogalayout.dev/blog/announcing-yoga-3.0)
[3.1](https://www.yogalayout.dev/blog/announcing-yoga-3.1)

The examples work, and after looking over their blog posts I think there should be no regression.
