### PR TITLE
Nice to have: Gizmo props for custom labels

### DIFF
--- a/.changeset/forty-bugs-divide.md
+++ b/.changeset/forty-bugs-divide.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": minor
+---
+
+<xLabel>, <yLabel> and <zLabel> props have been added to the Gizmo component. This gives you the option to use custom labels ones such as ('N', 'E', 'W'), or ('y','x','z') instead of the default ('X', 'Y','Z')  
+

--- a/apps/docs/src/examples/extras/gizmo/App.svelte
+++ b/apps/docs/src/examples/extras/gizmo/App.svelte
@@ -24,6 +24,10 @@
   let size = 128
   let paddingX = 20
   let paddingY = 20
+  let zLabel = 'z'
+  let yLabel = 'y'
+  let xLabel = 'x'
+
 
   let orbitControls: ThreeOrbitControls
   let center: CurrentWritable<[number, number, number]> = currentWritable([0, 0, 0])
@@ -134,6 +138,9 @@
       {size}
       {paddingX}
       {paddingY}
+      {zLabel}
+      {yLabel}
+      {xLabel}
     />
   </Canvas>
 </div>

--- a/apps/docs/src/examples/extras/gizmo/App.svelte
+++ b/apps/docs/src/examples/extras/gizmo/App.svelte
@@ -28,7 +28,6 @@
   let yLabel = 'y'
   let xLabel = 'x'
 
-
   let orbitControls: ThreeOrbitControls
   let center: CurrentWritable<[number, number, number]> = currentWritable([0, 0, 0])
 </script>

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
@@ -27,4 +27,4 @@ export type GizmoEvents = Record<string, never>
 
 export type GizmoSlots = Record<string, never>
 
-export default class Gizmo extends SvelteComponent<GizmoProps, GizmoEvents, GizmoSlots> { }
+export default class Gizmo extends SvelteComponent<GizmoProps, GizmoEvents, GizmoSlots> {}

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
@@ -18,6 +18,9 @@ export type GizmoProps = {
   toneMapped?: boolean
   paddingX?: number
   paddingY?: number
+	yLabel?: 'Y'
+	xLabel?: 'X'
+	zLabel?: 'Z'
 }
 
 export type GizmoEvents = Record<string, never>

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
@@ -18,9 +18,9 @@ export type GizmoProps = {
   toneMapped?: boolean
   paddingX?: number
   paddingY?: number
-	yLabel?: 'Y'
-	xLabel?: 'X'
-	zLabel?: 'Z'
+	yLabel?: string
+	xLabel?: string
+	zLabel?: string
 }
 
 export type GizmoEvents = Record<string, never>

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.d.ts
@@ -18,13 +18,13 @@ export type GizmoProps = {
   toneMapped?: boolean
   paddingX?: number
   paddingY?: number
-	yLabel?: string
-	xLabel?: string
-	zLabel?: string
+  yLabel?: string
+  xLabel?: string
+  zLabel?: string
 }
 
 export type GizmoEvents = Record<string, never>
 
 export type GizmoSlots = Record<string, never>
 
-export default class Gizmo extends SvelteComponent<GizmoProps, GizmoEvents, GizmoSlots> {}
+export default class Gizmo extends SvelteComponent<GizmoProps, GizmoEvents, GizmoSlots> { }

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
@@ -332,7 +332,7 @@
       userData.targetEuler={[0, Math.PI * 0.5, 0]}
     >
       <T.SpriteMaterial
-        map={getSpriteTexture(textureSize, xColor, 'X')}
+        map={getSpriteTexture(textureSize, xColor, '${xLabel}')}
         opacity={p[0] >= 0 ? 1 : 0.5}
       />
     </T.Sprite>
@@ -374,7 +374,7 @@
       userData.targetEuler={[-Math.PI * 0.5, 0, 0]}
     >
       <T.SpriteMaterial
-        map={getSpriteTexture(textureSize, yColor, 'Y')}
+        map={getSpriteTexture(textureSize, yColor, '${yLabel}')}
         opacity={p[1] >= 0 ? 1 : 0.5}
       />
     </T.Sprite>
@@ -417,7 +417,7 @@
       userData.targetEuler={[0, 0, 0]}
     >
       <T.SpriteMaterial
-        map={getSpriteTexture(textureSize, zColor, 'Z')}
+        map={getSpriteTexture(textureSize, zColor, '${zLabel})}
         opacity={p[2] >= 0 ? 1 : 0.5}
       />
     </T.Sprite>

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
@@ -332,7 +332,7 @@
       userData.targetEuler={[0, Math.PI * 0.5, 0]}
     >
       <T.SpriteMaterial
-        map={getSpriteTexture(textureSize, xColor, '${xLabel}')}
+        map={getSpriteTexture(textureSize, xColor, xLabel)}
         opacity={p[0] >= 0 ? 1 : 0.5}
       />
     </T.Sprite>
@@ -374,7 +374,7 @@
       userData.targetEuler={[-Math.PI * 0.5, 0, 0]}
     >
       <T.SpriteMaterial
-        map={getSpriteTexture(textureSize, yColor, '${yLabel}')}
+        map={getSpriteTexture(textureSize, yColor, yLabel)}
         opacity={p[1] >= 0 ? 1 : 0.5}
       />
     </T.Sprite>
@@ -417,7 +417,7 @@
       userData.targetEuler={[0, 0, 0]}
     >
       <T.SpriteMaterial
-        map={getSpriteTexture(textureSize, zColor, '${zLabel})}
+        map={getSpriteTexture(textureSize, zColor, zLabel)}
         opacity={p[2] >= 0 ? 1 : 0.5}
       />
     </T.Sprite>

--- a/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
+++ b/packages/extras/src/lib/components/Gizmo/Gizmo.svelte
@@ -38,6 +38,9 @@
   export let toneMapped: Required<$$Props>['toneMapped'] = false
   export let paddingX: Required<$$Props>['paddingX'] = 0
   export let paddingY: Required<$$Props>['paddingY'] = 0
+  export let xLabel: Required<$$Props>['xLabel'] = 'X'
+  export let yLabel: Required<$$Props>['yLabel'] = 'Y'
+  export let zLabel: Required<$$Props>['zLabel'] = 'Z'
 
   $: centerVec = new Vector3(...center)
 


### PR DESCRIPTION
Following this discussion:
https://github.com/threlte/threlte/issues/1089#issue-2495485226

This is a minor update of Extras/Gizmo component to add xLabel, yLabel and zLabel as props (insted of hardcoded 'X', 'Y', 'Z' values) to this component. 

Please forgive me if I messed something up or of this is not the propper way to proceed with this change. This is actually my first PR in Github, but I think Threlte is pretty neat! 


