### PR TITLE
[next] <Detailed>

### DIFF
--- a/.changeset/little-pants-cover.md
+++ b/.changeset/little-pants-cover.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": minor
+"@threlte/docs": minor
+---
+
+adds a <Detailed> component that can be used for displaying different level-of-detail for scene objects

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -19,7 +19,7 @@ Notice how as the mesh's distance from the camera increases, a mesh with less ve
   creation tools.
 </Tip>
 
-Children of <Detailed> accept a distance prop. This prop determines the visibility of each child based on its distance from the camera. If not specified, distance defaults to 0.
+Children of `<Detailed>` accept a distance prop. This prop determines the visibility of each child based on its distance from the camera. If not specified, distance defaults to 0.
 
 ```svelte
 <Detailed>
@@ -32,7 +32,7 @@ Children of <Detailed> accept a distance prop. This prop determines the visibili
 </Detailed>
 ```
 
-Children of <Detailed> accept a hysteresis prop to prevent flickering at LOD boundaries. If not specified, hysteresis defaults to 0.
+Children of `<Detailed>` accept a hysteresis prop to prevent flickering at LOD boundaries. If not specified, hysteresis defaults to 0.
 
 ```svelte
 <Detailed>

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -1,0 +1,42 @@
+---
+order: 6.6
+category: '@threlte/extras'
+sourcePath: 'packages/extras/src/lib/components/Detailed/Detailed.svelte'
+name: '<Detailed>'
+type: 'component'
+componentSignature:
+  {
+    extends:
+      {
+        type: 'LOD',
+        url: 'https://threejs.org/docs/#api/en/objects/LOD'
+      },
+    props:
+      [
+        {
+					name: 'distances',
+					type: 'number[]',
+					default: '[]',
+					required: false,
+					description: 'distances from the camera at which to show each object. the length of `distances` should match the number of children'},
+        {
+          name: 'hysteresis',
+          type: 'number',
+          default: '0',
+          required: false,
+          description: 'passed along to the internal LOD object.'
+        },
+      ]
+  }
+---
+
+
+`<Detailed>` is a wrapper around ThreeJS's LOD component. A common technique to improve performance is to swap out high-detail models or meshes for low-detail ones at large distances.
+
+<Example path="extras/detailed" />
+
+Notice how as the mesh's distance from the camera increases, a mesh with less vertices is renderered.
+
+<Tip type="tip">
+It is fairly common to export a high-detail, medium-detail, and low-detail model from 3D asset creation tools.
+</Tip>

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -19,7 +19,7 @@ Notice how as the mesh's distance from the camera increases, a mesh with less ve
   creation tools.
 </Tip>
 
-Children of `<Detailed>` can be passed a `distance` prop which dictates at what distance the child should be visible and others should not. `distance` defaults to 0 if it is not provided.
+Children of <Detailed> accept a distance prop. This prop determines the visibility of each child based on its distance from the camera. If not specified, distance defaults to 0.
 
 ```svelte
 <Detailed>
@@ -32,7 +32,7 @@ Children of `<Detailed>` can be passed a `distance` prop which dictates at what 
 </Detailed>
 ```
 
-Children of `<Detailed>` can be passed a `hysteresis` prop which is used to avoid flickering at LOD boundaries. `hysteresis` defaults to 0 if it is not provided.
+Children of <Detailed> accept a hysteresis prop to prevent flickering at LOD boundaries. If not specified, hysteresis defaults to 0.
 
 ```svelte
 <Detailed>

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -8,15 +8,14 @@ componentSignature:
   { extends: { type: 'LOD', url: 'https://threejs.org/docs/#api/en/objects/LOD' }, props: [] }
 ---
 
-`<Detailed>` is a wrapper around ThreeJS's [LOD](https://threejs.org/docs/#api/en/objects/LOD). A common technique to improve performance is to swap out high-detail models or meshes for low-detail ones at large distances.
+`<Detailed>` is an abstraction around ThreeJS's [LOD](https://threejs.org/docs/#api/en/objects/LOD). A common technique to improve performance is to swap out high-detail models or meshes for low-detail ones at large distances.
 
 <Example path="extras/detailed" />
 
-Notice how as the mesh's distance from the camera increases, a mesh with less vertices is renderered.
+Notice how as the mesh's distance from the camera increases, a geometry with less vertices is shown.
 
-<Tip type="tip">
-  It is fairly common to export a high-detail, medium-detail, and low-detail model from 3D asset
-  creation tools.
+<Tip type="warning">
+The distance between the camera and the `<Detailed>` component itself is what determines which level-of-detail to use. You can set positions for children but they will not be used in the distance calculation.
 </Tip>
 
 Children of `<Detailed>` accept a distance prop. This prop determines the visibility of each child based on its distance from the camera. If not specified, distance defaults to 0.
@@ -32,7 +31,7 @@ Children of `<Detailed>` accept a distance prop. This prop determines the visibi
 </Detailed>
 ```
 
-Children of `<Detailed>` accept a hysteresis prop to prevent flickering at LOD boundaries. If not specified, hysteresis defaults to 0.
+Children of `<Detailed>` accept a hysteresis prop which can be used to prevent flickering at LOD boundaries. If not specified, hysteresis defaults to 0.
 
 ```svelte
 <Detailed>
@@ -41,3 +40,8 @@ Children of `<Detailed>` accept a hysteresis prop to prevent flickering at LOD b
   </T.Mesh>
 </Detailed>
 ```
+
+<Tip type="tip">
+  It is fairly common to export a high-detail, medium-detail, and low-detail model from 3D asset
+  creation tools.
+</Tip>

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -6,30 +6,26 @@ name: '<Detailed>'
 type: 'component'
 componentSignature:
   {
-    extends:
-      {
-        type: 'LOD',
-        url: 'https://threejs.org/docs/#api/en/objects/LOD'
-      },
+    extends: { type: 'LOD', url: 'https://threejs.org/docs/#api/en/objects/LOD' },
     props:
       [
         {
-					name: 'distances',
-					type: 'number[]',
-					default: '[]',
-					required: false,
-					description: 'distances from the camera at which to show each object. the length of `distances` should match the number of children'},
+          name: 'distances',
+          type: 'number[]',
+          default: '[]',
+          required: false,
+          description: 'distances from the camera at which to show each object. the length of `distances` should match the number of children'
+        },
         {
           name: 'hysteresis',
           type: 'number',
           default: '0',
           required: false,
           description: 'passed along to the internal LOD object.'
-        },
+        }
       ]
   }
 ---
-
 
 `<Detailed>` is a wrapper around ThreeJS's LOD component. A common technique to improve performance is to swap out high-detail models or meshes for low-detail ones at large distances.
 
@@ -38,5 +34,6 @@ componentSignature:
 Notice how as the mesh's distance from the camera increases, a mesh with less vertices is renderered.
 
 <Tip type="tip">
-It is fairly common to export a high-detail, medium-detail, and low-detail model from 3D asset creation tools.
+  It is fairly common to export a high-detail, medium-detail, and low-detail model from 3D asset
+  creation tools.
 </Tip>

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -5,29 +5,10 @@ sourcePath: 'packages/extras/src/lib/components/Detailed/Detailed.svelte'
 name: '<Detailed>'
 type: 'component'
 componentSignature:
-  {
-    extends: { type: 'LOD', url: 'https://threejs.org/docs/#api/en/objects/LOD' },
-    props:
-      [
-        {
-          name: 'distances',
-          type: 'number[]',
-          default: '[]',
-          required: false,
-          description: 'distances from the camera at which to show each object. the length of `distances` should match the number of children'
-        },
-        {
-          name: 'hysteresis',
-          type: 'number',
-          default: '0',
-          required: false,
-          description: 'passed along to the internal LOD object.'
-        }
-      ]
-  }
+  { extends: { type: 'LOD', url: 'https://threejs.org/docs/#api/en/objects/LOD' }, props: [] }
 ---
 
-`<Detailed>` is a wrapper around ThreeJS's LOD component. A common technique to improve performance is to swap out high-detail models or meshes for low-detail ones at large distances.
+`<Detailed>` is a wrapper around ThreeJS's [LOD](https://threejs.org/docs/#api/en/objects/LOD). A common technique to improve performance is to swap out high-detail models or meshes for low-detail ones at large distances.
 
 <Example path="extras/detailed" />
 
@@ -37,3 +18,26 @@ Notice how as the mesh's distance from the camera increases, a mesh with less ve
   It is fairly common to export a high-detail, medium-detail, and low-detail model from 3D asset
   creation tools.
 </Tip>
+
+Children of `<Detailed>` can be passed a `distance` prop which dictates at what distance the child should be visible and others should not. `distance` defaults to 0 if it is not provided.
+
+```svelte
+<Detailed>
+  <T.Mesh>
+    <T.BoxGeometry />
+  </T.Mesh>
+  <T.Mesh distance={10}>
+    <T.BoxGeometry />
+  </T.Mesh>
+</Detailed>
+```
+
+Children of `<Detailed>` can be passed a `hysteresis` prop which is used to avoid flickering at LOD boundaries. `hysteresis` defaults to 0 if it is not provided.
+
+```svelte
+<Detailed>
+  <T.Mesh hysteresis={0.5}>
+    <T.BoxGeometry />
+  </T.Mesh>
+</Detailed>
+```

--- a/apps/docs/src/examples/extras/detailed/App.svelte
+++ b/apps/docs/src/examples/extras/detailed/App.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Canvas } from '@threlte/core'
+  import Scene from './Scene.svelte'
+</script>
+
+<div>
+  <Canvas>
+    <Scene />
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/detailed/Scene.svelte
+++ b/apps/docs/src/examples/extras/detailed/Scene.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Detailed, interactivity, OrbitControls } from '@threlte/extras'
+  import { Detailed, OrbitControls } from '@threlte/extras'
   import { IcosahedronGeometry } from 'three'
   import { T } from '@threlte/core'
 
@@ -13,8 +13,6 @@
     { color: 0x00_ff_00, distance: 5 },
     { color: 0x00_00_ff, distance: 10 }
   ]
-
-  interactivity()
 </script>
 
 <T.PerspectiveCamera

--- a/apps/docs/src/examples/extras/detailed/Scene.svelte
+++ b/apps/docs/src/examples/extras/detailed/Scene.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+  import { Detailed, OrbitControls } from '@threlte/extras'
+  import { IcosahedronGeometry } from 'three'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position.z={3}
+>
+  <OrbitControls />
+</T.PerspectiveCamera>
+
+<Detailed distances={[0, 5, 10]}>
+  <T.Mesh
+    geometry={new IcosahedronGeometry(1, 2)}
+    material.wireframe={true}
+    material.color={0xff_00_00}
+  />
+  <T.Mesh
+    geometry={new IcosahedronGeometry(1, 1)}
+    material.wireframe={true}
+    material.color={0x00_ff_00}
+  />
+  />
+  <T.Mesh
+    geometry={new IcosahedronGeometry(1, 0)}
+    material.wireframe={true}
+    material.color={0x00_00_ff}
+  />
+</Detailed>

--- a/apps/docs/src/examples/extras/detailed/Scene.svelte
+++ b/apps/docs/src/examples/extras/detailed/Scene.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
-  import { T } from '@threlte/core'
-  import { Detailed, OrbitControls } from '@threlte/extras'
+  import { Detailed, interactivity, OrbitControls } from '@threlte/extras'
   import { IcosahedronGeometry } from 'three'
+  import { T } from '@threlte/core'
+
+  type DetailItem = {
+    color: number
+    distance: number
+  }
+
+  const items: DetailItem[] = [
+    { color: 0xff_00_00, distance: 0 },
+    { color: 0x00_ff_00, distance: 5 },
+    { color: 0x00_00_ff, distance: 10 }
+  ]
+
+  interactivity()
 </script>
 
 <T.PerspectiveCamera
@@ -11,21 +24,14 @@
   <OrbitControls />
 </T.PerspectiveCamera>
 
-<Detailed distances={[0, 5, 10]}>
-  <T.Mesh
-    geometry={new IcosahedronGeometry(1, 2)}
-    material.wireframe={true}
-    material.color={0xff_00_00}
-  />
-  <T.Mesh
-    geometry={new IcosahedronGeometry(1, 1)}
-    material.wireframe={true}
-    material.color={0x00_ff_00}
-  />
-  />
-  <T.Mesh
-    geometry={new IcosahedronGeometry(1, 0)}
-    material.wireframe={true}
-    material.color={0x00_00_ff}
-  />
+<Detailed>
+  {#each items as { color, distance }, i}
+    {@const detail = items.length - i - 1}
+    <T.Mesh
+      {distance}
+      geometry={new IcosahedronGeometry(1, detail)}
+      material.wireframe={true}
+      material.color={color}
+    />
+  {/each}
 </Detailed>

--- a/apps/docs/src/examples/extras/detailed/Scene.svelte
+++ b/apps/docs/src/examples/extras/detailed/Scene.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Detailed, OrbitControls } from '@threlte/extras'
+  import { Detailed } from '@threlte/extras'
   import { IcosahedronGeometry } from 'three'
-  import { T } from '@threlte/core'
+  import { T, useTask } from '@threlte/core'
 
   type DetailItem = {
     color: number
@@ -13,16 +13,21 @@
     { color: 0x00_ff_00, distance: 5 },
     { color: 0x00_00_ff, distance: 10 }
   ]
+
+  let time = $state(0)
+  const z = $derived(5 + 10 * Math.sin(time))
+
+  useTask((delta) => {
+    time += delta
+  })
 </script>
 
 <T.PerspectiveCamera
   makeDefault
-  position.z={3}
->
-  <OrbitControls />
-</T.PerspectiveCamera>
+  position.z={18}
+/>
 
-<Detailed>
+<Detailed position.z={z}>
   {#each items as { color, distance }, i}
     {@const detail = items.length - i - 1}
     <T.Mesh

--- a/packages/extras/src/lib/components/Detailed/Detailed.svelte
+++ b/packages/extras/src/lib/components/Detailed/Detailed.svelte
@@ -1,27 +1,47 @@
 <script lang="ts">
   import type { DetailedProps } from './Detailed.svelte'
   import { LOD } from 'three'
-  import { injectPlugin, T } from '@threlte/core'
-  import { onMount } from 'svelte'
+  import { T, injectPlugin, useParent } from '@threlte/core'
 
-  let {
-    distances = [],
-    hysteresis = 0,
-    ref = $bindable(),
-    children,
-    ...props
-  }: DetailedProps = $props()
+  let { ref = $bindable(), children, ...props }: DetailedProps = $props()
 
   const lod = new LOD()
-  injectPlugin('detailed', ({ ref }) => {
-    onMount(() => {
-      if (ref.parent === lod) {
-        lod.levels.length = 0
-        lod.children.forEach((object, index) => {
-          lod.levels.push({ object, hysteresis, distance: distances[index] })
-        })
+
+  injectPlugin('detailed', ({ ref, props }) => {
+    const parent = useParent()
+    if (parent.current === lod) {
+      let currentRef = ref
+      let currentDistance = props.distance ?? 0
+      let currentHysteresis = props.hysteresis ?? 0
+
+      return {
+        onPropsChange(props) {
+          const distance = props.distance ?? currentDistance
+          const hysteresis = props.hysteresis ?? currentHysteresis
+          // only update lod.levels if props have changed
+          if (distance !== currentDistance || hysteresis !== currentHysteresis) {
+            const object = lod.levels.find((level) => level === currentRef)
+            if (object !== undefined) {
+              object.distance = distance
+              object.hysteresis = hysteresis
+            }
+          }
+          currentDistance = distance
+          currentHysteresis = hysteresis
+        },
+        onRefChange(ref) {
+          lod.addLevel(ref, currentDistance, currentHysteresis)
+          currentRef = ref
+          return () => {
+            const i = lod.levels.findIndex((l) => l.object === currentRef)
+            if (i > -1) {
+              lod.levels.splice(i, 0)
+            }
+          }
+        },
+        pluginProps: ['distance', 'hysteresis']
       }
-    })
+    }
   })
 </script>
 

--- a/packages/extras/src/lib/components/Detailed/Detailed.svelte
+++ b/packages/extras/src/lib/components/Detailed/Detailed.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { DetailedProps } from './Detailed.svelte'
+  import { LOD } from 'three'
+  import { injectPlugin, T } from '@threlte/core'
+  import { onMount } from 'svelte'
+
+  let {
+    distances = [],
+    hysteresis = 0,
+    ref = $bindable(),
+    children,
+    ...props
+  }: DetailedProps = $props()
+
+  const lod = new LOD()
+  injectPlugin('detailed', ({ ref }) => {
+    onMount(() => {
+      if (ref.parent === lod) {
+        lod.levels.length = 0
+        lod.children.forEach((object, index) => {
+          lod.levels.push({ object, hysteresis, distance: distances[index] })
+        })
+      }
+    })
+  })
+</script>
+
+<T
+  is={lod}
+  bind:ref
+  {...props}
+>
+  {@render children?.({ ref: lod })}
+</T>

--- a/packages/extras/src/lib/components/Detailed/Detailed.svelte.d.ts
+++ b/packages/extras/src/lib/components/Detailed/Detailed.svelte.d.ts
@@ -2,15 +2,6 @@ import type { LOD } from 'three'
 import type { Props } from '@threlte/core'
 import { SvelteComponent } from 'svelte'
 
-export type DetailedProps = Props<LOD> & {
-  /**
-   * distances from the camera. the ith child of `Detailed` will display at distances[i]
-   */
-  distances?: number[]
-  /**
-   * passed along to the internal LOD object
-   */
-  hysteresis?: number
-}
+export type DetailedProps = Props<LOD>
 
 export default class Detailed extends SvelteComponent<DetailedProps> {}

--- a/packages/extras/src/lib/components/Detailed/Detailed.svelte.d.ts
+++ b/packages/extras/src/lib/components/Detailed/Detailed.svelte.d.ts
@@ -1,0 +1,16 @@
+import type { LOD } from 'three'
+import type { Props } from '@threlte/core'
+import { SvelteComponent } from 'svelte'
+
+export type DetailedProps = Props<LOD> & {
+  /**
+   * distances from the camera. the ith child of `Detailed` will display at distances[i]
+   */
+  distances?: number[]
+  /**
+   * passed along to the internal LOD object
+   */
+  hysteresis?: number
+}
+
+export default class Detailed extends SvelteComponent<DetailedProps> {}

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -45,6 +45,7 @@ export { default as Text3DGeometry } from './components/Text3DGeometry/Text3DGeo
 export { default as PerfMonitor } from './components/PerfMonitor/PerfMonitor.svelte'
 export { default as Outlines } from './components/Outlines/Outlines.svelte'
 export { default as Mask } from './components/Mask/Mask.svelte'
+export { default as Detailed } from './components/Detailed/Detailed.svelte'
 
 // suspense
 export { default as Suspense } from './suspense/Suspense.svelte'


### PR DESCRIPTION
Named after drei's [\<Detailed\> component](https://drei.docs.pmnd.rs/performances/detailed)

Differs from drei's in that you specify the distance for the mesh as a prop. drei's requires that you pass an array of distances to the parent. I thought it might be annoying to keep the children and distances array in sync.

```svelte
<Detailed>
  <T.Mesh />
  <T.Mesh distance={5} />
</Detailed>
```

The first child mesh is will be visible until the camera is 5 units away from the mesh. At that point, the first mesh is swapped out for the second.

If no distance is provided, as in the example above, it will default to 0.

Individual meshes can define their own hysteresis values. It is an optional prop and defaults to 0 if it is not provided. Details on what hysteresis is can be fount in [three's LOD docs](https://threejs.org/docs/#api/en/objects/LOD).

---

Note that although i haven't removed the LOD example, it can definitely be removed if this gets merged because it'll be redundant.