### PR TITLE
add MarchingCubes "lava lamp" example

### DIFF
--- a/apps/docs/src/content/examples/marching-cubes/LavaLamp.mdx
+++ b/apps/docs/src/content/examples/marching-cubes/LavaLamp.mdx
@@ -1,6 +1,8 @@
+A small [MarchingCubes](https://en.wikipedia.org/wiki/Marching_cubes) example using [Threejs's marching cubes addon](https://threejs.org/examples/webgl_marchingcubes.html).
+
 <Example path="marching-cubes/lava-lamp" />
 
-[Threejs's marching cubes addon](https://threejs.org/examples/webgl_marchingcubes.html) is a little too limited to be ported into a component but this example shows how it might be incorported into threlte.
+The addon is a little too limited to be ported into a component but this example shows how it might be incorported into threlte.
 
 ## Placement
 

--- a/apps/docs/src/content/examples/marching-cubes/LavaLamp.mdx
+++ b/apps/docs/src/content/examples/marching-cubes/LavaLamp.mdx
@@ -1,0 +1,67 @@
+<Example path="marching-cubes/lava-lamp" />
+
+[Threejs's marching cubes addon](https://threejs.org/examples/webgl_marchingcubes.html) is a little too limited to be ported into a component but this example shows how it might be incorported into threlte.
+
+## Placement
+
+`MarchingCubes` defines a space from -1 to 1 for all 3 axes.
+
+### MarchingPlane
+
+The original example only allows for planes positioned at x = -1, y = -1, and z = -1.
+
+### MarchingCube
+
+`<MarchingCube>`s can be placed anywhere in the `MarchingCubes` space. If they are placed outside this range they mab be cutoff or not show altogether.
+
+<Tip type="info">
+  Even though `MarchingCube` appears as a ball, it is called __Cube__ to be inline with [drei's
+  MarchingCubes abstration](https://drei.docs.pmnd.rs/abstractions/marching-cubes).
+</Tip>
+
+## Materials
+
+The example above utilizes vertex coloring but the original threejs example has support for any kind of material. Vertex coloring requires a little more memory since each vertex now carries a color with it. If you're not using vertex colors, you can leave `enableColors` turned off. The `<MarchingCubes>` component uses the same default material that `Three.Mesh`es do. Setting different materials is the same process as setting different materials for `<T.Mesh>`.
+
+```svelte
+<MarchingCubes>
+  <T.MeshNormalMaterial />
+  <MarchingCube />
+</MarchingCubes>
+```
+
+or
+
+```svelte
+<script>
+  import { MeshNormalMaterial } from 'three'
+
+  const material = new MeshNormalMaterial()
+</script>
+
+<MarchingCubes {material}>
+  <MarchingCube />
+</MarchingCubes>
+```
+
+If you're using a material with a texture, you will need to set `enableUvs` to true.
+
+```svelte
+<MarchingCubes enableUvs>
+  <T.MeshNormalMaterial map={texture} />
+  <MarchingCube />
+</MarchingCubes>
+```
+
+Note that the example above enables both uvs and vertex coloring for demonstration purposes. You can set these to false in the constructor to save on space.
+
+```svelte title="MarchingCubes.svelte" {5}
+<script>
+  // ...
+
+  // don't allocate buffers for vertex colors nor uvs
+  const marchingCubes = new MarchingCubes(resolution, material, false, false, 20_000)
+
+  // ...
+</script>
+```

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/App.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/App.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { Canvas } from '@threlte/core'
+  import Scene from './Scene.svelte'
+  import { Pane, Folder, List, Slider } from 'svelte-tweakpane-ui'
+  import type { Axis } from './MarchingPlane'
+
+  let ballCount = $state(15)
+  let isolation = $state(80)
+  let planeAxis: Axis = $state('y')
+  let resolution = $state(35)
+
+  type AxisOptions = {
+    [Key in Axis]: Key
+  }
+
+  const axisOptions: AxisOptions = {
+    x: 'x',
+    y: 'y',
+    z: 'z'
+  }
+</script>
+
+<div>
+  <Pane
+    position="fixed"
+    title="Lava Lamp"
+  >
+    <Slider
+      label="ball count"
+      bind:value={ballCount}
+      min={3}
+      max={25}
+      step={1}
+    />
+    <Slider
+      label="isolation"
+      bind:value={isolation}
+      min={40}
+      max={100}
+      step={1}
+    />
+    <Slider
+      label="resolution"
+      bind:value={resolution}
+      min={10}
+      max={50}
+      step={1}
+    />
+    <Folder title="Plane">
+      <List
+        label="Axis"
+        bind:value={planeAxis}
+        options={axisOptions}
+      />
+    </Folder>
+  </Pane>
+  <Canvas>
+    <Scene
+      {ballCount}
+      {planeAxis}
+      {resolution}
+      {isolation}
+    />
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
@@ -1,58 +1,17 @@
-<script
-  lang="ts"
-  context="module"
->
-  import { Vector3 } from 'three'
-
-  const position = new Vector3()
-</script>
-
 <script lang="ts">
-  import type { Color } from 'three'
-  import { Group } from 'three'
-  import { getMarchingCubesContext, isMarchingCubes } from './MarchingCubes.svelte'
   import type { Props } from '@threlte/core'
-  import { T, useParent, useTask } from '@threlte/core'
+  import { MarchingCube } from './MarchingCube'
+  import { T } from '@threlte/core'
 
-  const parent = useParent()
+  type MarchingCubeProps = Props<MarchingCube>
 
-  if (!isMarchingCubes($parent)) {
-    throw new Error('Parent of <MarchingCube> must be a <MarchingCubes>.')
-  }
-
-  type MarchingCubeProps = {
-    strength?: number
-    subtract?: number
-    color?: Color
-  } & Props<Group>
-
-  const group = new Group()
-
-  let {
-    color,
-    strength = 0.5,
-    subtract = 12,
-    children,
-    ref = $bindable(),
-    ...props
-  }: MarchingCubeProps = $props()
-
-  const task = getMarchingCubesContext()
-
-  useTask(
-    () => {
-      group.getWorldPosition(position)
-      position.addScalar(1).multiplyScalar(0.5)
-      parent.current.addBall(position.x, position.y, position.z, strength, subtract, color)
-    },
-    { after: task }
-  )
+  let { ref = $bindable(), children, ...props }: MarchingCubeProps = $props()
 </script>
 
 <T
-  is={group}
+  is={MarchingCube}
   bind:ref
   {...props}
 >
-  {@render children?.({ ref: group })}
+  {@render children?.({ ref })}
 </T>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
@@ -20,7 +20,7 @@
     throw new Error('Parent of <MarchingCube> must be a <MarchingCubes>.')
   }
 
-  type MarchingPlaneProps = {
+  type MarchingCubeProps = {
     strength?: number
     subtract?: number
     color?: Color
@@ -35,7 +35,7 @@
     children,
     ref = $bindable(),
     ...props
-  }: MarchingPlaneProps = $props()
+  }: MarchingCubeProps = $props()
 
   const task = getMarchingCubesContext()
 

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
@@ -1,0 +1,58 @@
+<script
+  lang="ts"
+  context="module"
+>
+  import { Vector3 } from 'three'
+
+  const position = new Vector3()
+</script>
+
+<script lang="ts">
+  import type { Color } from 'three'
+  import { Group } from 'three'
+  import { getMarchingCubesContext, isMarchingCubes } from './MarchingCubes.svelte'
+  import type { Props } from '@threlte/core'
+  import { T, useParent, useTask } from '@threlte/core'
+
+  const parent = useParent()
+
+  if (!isMarchingCubes($parent)) {
+    throw new Error('Parent of <MarchingCube> must be a <MarchingCubes>.')
+  }
+
+  type MarchingPlaneProps = {
+    strength?: number
+    subtract?: number
+    color?: Color
+  } & Props<Group>
+
+  const group = new Group()
+
+  let {
+    color,
+    strength = 0.5,
+    subtract = 12,
+    children,
+    ref = $bindable(),
+    ...props
+  }: MarchingPlaneProps = $props()
+
+  const task = getMarchingCubesContext()
+
+  useTask(
+    () => {
+      group.getWorldPosition(position)
+      position.addScalar(1).multiplyScalar(0.5)
+      parent.current.addBall(position.x, position.y, position.z, strength, subtract, color)
+    },
+    { after: task }
+  )
+</script>
+
+<T
+  is={group}
+  bind:ref
+  {...props}
+>
+  {@render children?.({ ref: group })}
+</T>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.ts
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.ts
@@ -1,0 +1,12 @@
+import type { Color } from 'three'
+import { Group } from 'three'
+
+export class MarchingCube extends Group {
+  constructor(
+    public strength = 0.5,
+    public subtract = 12,
+    public color?: Color
+  ) {
+    super()
+  }
+}

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCubes.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCubes.svelte
@@ -2,31 +2,30 @@
   lang="ts"
   context="module"
 >
-  import { MarchingCubes } from 'three/examples/jsm/Addons.js'
-  import { setContext as svelteSetContext, getContext as svelteGetContext } from 'svelte'
-  import type { Task } from '@threlte/core'
+  import type { MarchingPlaneAxis } from './MarchingPlane'
+  import { Vector3 } from 'three'
 
-  const KEY = Symbol('marching-cubes')
-
-  type Context = Task
-
-  const setMarchingCubesContext = (task: Task): Context => {
-    return svelteSetContext<Context>(KEY, task)
+  type addAxisMap = {
+    [Key in MarchingPlaneAxis]: `addPlane${Uppercase<Key>}`
   }
 
-  export const getMarchingCubesContext = (): Context => {
-    return svelteGetContext<Context>(KEY)
+  const map: addAxisMap = {
+    x: 'addPlaneX',
+    y: 'addPlaneY',
+    z: 'addPlaneZ'
   }
 
-  export const isMarchingCubes = (a: any): a is MarchingCubes => {
-    return a.isMarchingCubes
-  }
+  // reusable for calculating world position of `<MarchingCube>`s
+  const position = new Vector3()
 
   const defaultResolution = 50
 </script>
 
 <script lang="ts">
   import type { Props } from '@threlte/core'
+  import { MarchingCube } from './MarchingCube'
+  import { MarchingCubes } from 'three/examples/jsm/Addons.js'
+  import { MarchingPlane } from './MarchingPlane'
   import { MeshBasicMaterial } from 'three'
   import { T, useTask } from '@threlte/core'
 
@@ -53,12 +52,29 @@
     }
   })
 
-  const { task } = useTask(() => {
-    marchingCubes.update()
+  useTask(() => {
     marchingCubes.reset()
+    for (const child of marchingCubes.children) {
+      switch (true) {
+        case child instanceof MarchingCube:
+          child.getWorldPosition(position)
+          position.addScalar(1).multiplyScalar(0.5) // center it
+          marchingCubes.addBall(
+            position.x,
+            position.y,
+            position.z,
+            child.strength,
+            child.subtract,
+            child.color
+          )
+          break
+        case child instanceof MarchingPlane:
+          marchingCubes[map[child.axis]](child.strength, child.subtract)
+          break
+      }
+    }
+    marchingCubes.update()
   })
-
-  setMarchingCubesContext(task)
 
   // cleanup default material if marchingCubes.material has been set to something else
   $effect(() => {

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCubes.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCubes.svelte
@@ -1,0 +1,79 @@
+<script
+  lang="ts"
+  context="module"
+>
+  import { MarchingCubes } from 'three/examples/jsm/Addons.js'
+  import { setContext as svelteSetContext, getContext as svelteGetContext } from 'svelte'
+  import type { Task } from '@threlte/core'
+
+  const KEY = Symbol('marching-cubes')
+
+  type Context = Task
+
+  const setMarchingCubesContext = (task: Task): Context => {
+    return svelteSetContext<Context>(KEY, task)
+  }
+
+  export const getMarchingCubesContext = (): Context => {
+    return svelteGetContext<Context>(KEY)
+  }
+
+  export const isMarchingCubes = (a: any): a is MarchingCubes => {
+    return a.isMarchingCubes
+  }
+
+  const defaultResolution = 50
+</script>
+
+<script lang="ts">
+  import type { Props } from '@threlte/core'
+  import { MeshBasicMaterial } from 'three'
+  import { T, useTask } from '@threlte/core'
+
+  type MarchingCubesProps = {
+    resolution?: number
+    enableUvs?: boolean
+    enableColors?: boolean
+    isolation?: number
+  } & Props<MarchingCubes>
+
+  let {
+    resolution = defaultResolution,
+    children,
+    ref = $bindable(),
+    ...props
+  }: MarchingCubesProps = $props()
+
+  const material = new MeshBasicMaterial()
+  const marchingCubes = new MarchingCubes(defaultResolution, material, true, true, 20_000)
+
+  $effect(() => {
+    if (resolution !== marchingCubes.resolution) {
+      marchingCubes.init(resolution)
+    }
+  })
+
+  const { task } = useTask(() => {
+    marchingCubes.update()
+    marchingCubes.reset()
+  })
+
+  setMarchingCubesContext(task)
+
+  // cleanup default material if marchingCubes.material has been set to something else
+  $effect(() => {
+    return () => {
+      if (marchingCubes.material !== material) {
+        material.dispose()
+      }
+    }
+  })
+</script>
+
+<T
+  is={marchingCubes}
+  bind:ref
+  {...props}
+>
+  {@render children?.({ ref: marchingCubes })}
+</T>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
@@ -1,44 +1,17 @@
-<script
-  lang="ts"
-  context="module"
->
-  import { getMarchingCubesContext, isMarchingCubes } from './MarchingCubes.svelte'
-
-  export type Axis = 'x' | 'y' | 'z'
-  type addAxisMap = {
-    [Key in Axis]: `addPlane${Uppercase<Key>}`
-  }
-
-  const map: addAxisMap = {
-    x: 'addPlaneX',
-    y: 'addPlaneY',
-    z: 'addPlaneZ'
-  }
-</script>
-
 <script lang="ts">
-  import { useParent, useTask } from '@threlte/core'
+  import type { Props } from '@threlte/core'
+  import { T } from '@threlte/core'
+  import { MarchingPlane } from './MarchingPlane'
 
-  const parent = useParent()
+  type MarchingPlaneProps = Props<MarchingPlane>
 
-  if (!isMarchingCubes($parent)) {
-    throw new Error('Parent of <MarchingPlane> must be a <MarchingCubes>.')
-  }
-
-  type MarchingPlaneProps = {
-    axis?: Axis
-    strength?: number
-    subtract?: number
-  }
-
-  let { axis = 'x', strength = 0.5, subtract = 12 }: MarchingPlaneProps = $props()
-
-  const task = getMarchingCubesContext()
-
-  useTask(
-    () => {
-      parent.current[map[axis]](strength, subtract)
-    },
-    { after: task }
-  )
+  let { ref = $bindable(), children, ...props }: MarchingPlaneProps = $props()
 </script>
+
+<T
+  is={MarchingPlane}
+  bind:ref
+  {...props}
+>
+  {@render children?.({ ref })}
+</T>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
@@ -1,0 +1,44 @@
+<script
+  lang="ts"
+  context="module"
+>
+  import { getMarchingCubesContext, isMarchingCubes } from './MarchingCubes.svelte'
+
+  export type Axis = 'x' | 'y' | 'z'
+  type addAxisMap = {
+    [Key in Axis]: `addPlane${Uppercase<Key>}`
+  }
+
+  const map: addAxisMap = {
+    x: 'addPlaneX',
+    y: 'addPlaneY',
+    z: 'addPlaneZ'
+  }
+</script>
+
+<script lang="ts">
+  import { useParent, useTask } from '@threlte/core'
+
+  const parent = useParent()
+
+  if (!isMarchingCubes($parent)) {
+    throw new Error('Parent of <MarchingPlane> must be a <MarchingCubes>.')
+  }
+
+  type MarchingPlaneProps = {
+    axis?: Axis
+    strength?: number
+    subtract?: number
+  }
+
+  let { axis = 'x', strength = 0.5, subtract = 12 }: MarchingPlaneProps = $props()
+
+  const task = getMarchingCubesContext()
+
+  useTask(
+    () => {
+      parent.current[map[axis]](strength, subtract)
+    },
+    { after: task }
+  )
+</script>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.ts
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.ts
@@ -1,0 +1,13 @@
+import { Group } from 'three'
+
+export type MarchingPlaneAxis = 'x' | 'y' | 'z'
+
+export class MarchingPlane extends Group {
+  constructor(
+    public axis: MarchingPlaneAxis = 'x',
+    public strength = 0.5,
+    public subtract = 12
+  ) {
+    super()
+  }
+}

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/Scene.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/Scene.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import MarchingCube from './MarchingCube.svelte'
+  import MarchingCubes from './MarchingCubes.svelte'
+  import MarchingPlane from './MarchingPlane.svelte'
+  import type { Axis } from './MarchingPlane.svelte'
+  import { Color, Vector2 } from 'three'
+  import { OrbitControls } from '@threlte/extras'
+  import { T, useTask } from '@threlte/core'
+
+  type SceneProps = {
+    ballCount?: number
+    isolation?: number
+    planeAxis: Axis
+    resolution: number
+  }
+
+  let { ballCount = 5, isolation = 80, planeAxis = 'y', resolution = 50 }: SceneProps = $props()
+
+  type Ball = {
+    color: Color
+    position: Vector2
+  }
+
+  /**
+   * creates `count` randomly colored balls that are evenly distributed around a unit circle scaled by `scale`
+   */
+  const createBalls = (count: number, scale = 0.5): Ball[] => {
+    const balls: Ball[] = []
+    const m = (2 * Math.PI) / count
+    for (let i = 0; i < count; i += 1) {
+      const r = m * i
+      const x = Math.cos(r)
+      const y = Math.sin(r)
+      const position = new Vector2(x, y).multiplyScalar(scale)
+      const color = new Color().setRGB(Math.random(), Math.random(), Math.random())
+      balls.push({ position, color })
+    }
+    return balls
+  }
+
+  let time = $state(0)
+  useTask((delta) => {
+    time += delta
+  })
+
+  const balls = $derived(createBalls(ballCount))
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position.z={5}
+>
+  <OrbitControls autoRotate />
+</T.PerspectiveCamera>
+
+<T.AmbientLight />
+
+<MarchingCubes
+  enableColors
+  {resolution}
+  {isolation}
+>
+  <T.MeshStandardMaterial vertexColors />
+  {#each balls as { position, color }, i}
+    <MarchingCube
+      position.x={position.x}
+      position.z={position.y}
+      position.y={0.5 * Math.sin(time + i) - 0.5}
+      {color}
+    />
+  {/each}
+  <MarchingPlane axis={planeAxis} />
+</MarchingCubes>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/Scene.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/Scene.svelte
@@ -2,7 +2,7 @@
   import MarchingCube from './MarchingCube.svelte'
   import MarchingCubes from './MarchingCubes.svelte'
   import MarchingPlane from './MarchingPlane.svelte'
-  import type { Axis } from './MarchingPlane.svelte'
+  import type { MarchingPlaneAxis } from './MarchingPlane'
   import { Color, Vector2 } from 'three'
   import { OrbitControls } from '@threlte/extras'
   import { T, useTask } from '@threlte/core'
@@ -10,7 +10,7 @@
   type SceneProps = {
     ballCount?: number
     isolation?: number
-    planeAxis: Axis
+    planeAxis: MarchingPlaneAxis
     resolution: number
   }
 


### PR DESCRIPTION
based on the threejs example example [here](https://threejs.org/examples/#webgl_marchingcubes). 

[drei makes this a component](https://drei.docs.pmnd.rs/abstractions/marching-cubes) but in my opinion it's too restrictive to be a component and works best as an example.

i elaborate a little [here](https://discord.com/channels/985983540804091964/986233334747254854/1294518941833625610)

i tried to make the example pretty comprehensive but the MarchingCubes api is a little _strange_ in some places.

~~one thing i'd like to clear is the flickering that occurs when adjusting the resolution slider but i'm not sure how to achieve that in the current design.~~

Let me know if this needs a changeset and i'll add one.