### PR TITLE
convert &lt; and &gt; characters to < and > in search results

### DIFF
--- a/apps/docs/src/components/Search/Markprompt.tsx
+++ b/apps/docs/src/components/Search/Markprompt.tsx
@@ -51,6 +51,11 @@ function Search({ visible }: { visible: boolean }) {
               visible: false
             }}
             search={{
+              getTitle(ref) {
+                return ref.hierarchy.lvl1.replace(/&[lg]t;/g, (match) =>
+                  match === '&lt;' ? '<' : '>'
+                )
+              },
               enabled: true,
               provider: {
                 name: 'algolia',


### PR DESCRIPTION
closes #1024

to test, open the search modal and type __text__. verify that __\<Text>__ is shown and not __\&lt;Text\&gt;__.