### PR TITLE
Tweakpane expansion work-around

### DIFF
--- a/apps/docs/src/examples/camera/camera-controls/App.svelte
+++ b/apps/docs/src/examples/camera/camera-controls/App.svelte
@@ -6,6 +6,7 @@
   import { DEG2RAD } from 'three/src/math/MathUtils.js'
 
   let camera
+  let paneExpanded = false
 
   $: if ($cameraControls) {
     camera = $cameraControls._camera
@@ -15,7 +16,7 @@
 <Pane
   title="Camera Controls"
   position="fixed"
-  expanded={false}
+  bind:expanded={paneExpanded}
 >
   <Button
     title="rotate theta 45deg"

--- a/apps/docs/src/examples/extras/environment/App.svelte
+++ b/apps/docs/src/examples/extras/environment/App.svelte
@@ -48,12 +48,14 @@
   let scale = { x: 100, y: 100, z: 100 }
   let radius = 100
   let height = 5
+
+  let paneExpanded = false
 </script>
 
 <Pane
   title="Environment"
   position="fixed"
-  expanded={false}
+  bind:expanded={paneExpanded}
 >
   <Folder title="core">
     <Checkbox

--- a/apps/docs/src/examples/extras/grid/App.svelte
+++ b/apps/docs/src/examples/extras/grid/App.svelte
@@ -51,6 +51,8 @@
   let cellDividers = 6
   let sectionDividers = 2
 
+  let paneExpanded = false
+
   const terrainSize = 30
   const geometry = new PlaneGeometry(terrainSize, terrainSize, 100, 100)
   const noise = createNoise2D()
@@ -67,7 +69,7 @@
 <Pane
   title="Grid"
   position="fixed"
-  expanded={false}
+  bind:expanded={paneExpanded}
 >
   <Folder title="Cells">
     <Slider

--- a/apps/docs/src/examples/extras/image-material/App.svelte
+++ b/apps/docs/src/examples/extras/image-material/App.svelte
@@ -38,7 +38,6 @@
 <Pane
   title="Image"
   position="fixed"
-  expanded={true}
 >
   <Folder title="Color processing">
     <Slider

--- a/apps/docs/src/examples/misc/gaussian-splatting/Scene.svelte
+++ b/apps/docs/src/examples/misc/gaussian-splatting/Scene.svelte
@@ -21,6 +21,8 @@
   // Car
   let showPorsche = true
 
+  let paneExpanded = false
+
   let gltfMaterials: Record<string, MeshStandardMaterial> | undefined
   $: if (gltfMaterials) {
     Object.values(gltfMaterials).forEach((material) => {
@@ -69,7 +71,7 @@
 <Pane
   position="fixed"
   title="Gaussian Splatting"
-  expanded={false}
+  bind:expanded={paneExpanded}
 >
   <Folder
     userExpandable={false}


### PR DESCRIPTION
This PR prevents Tweakpane `<Pane>` components from being locked in an expanded or collapsed state. This was affecting several examples and documentation pages, I'd guess the original authors intended to define the initial state of a pane's expansion vs. its perpetual state.

`expanded` might be a cleaner name for the bound variable and could simplify the binding site, but with all the things going on in the Threlte examples `paneExpanded` seemed more distinctive.

This is related to https://github.com/kitschpatrol/svelte-tweakpane-ui/issues/4. Pardon the need for a work-around, I'll ping back here if I figure out a more elegant fix in the `svelte-tweakpane-ui` library itself at a later date.