### PR TITLE
fix: correct type for `scale` in `PerfMonitor`

### DIFF
--- a/.changeset/happy-dogs-bark.md
+++ b/.changeset/happy-dogs-bark.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fixed type of `scale` in `PerfMonitor`

--- a/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte.d.ts
+++ b/packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte.d.ts
@@ -50,7 +50,7 @@ export type PerfMonitorProps = {
    * Scale of the stats block html element.
    * @default 1
    */
-  scale?: 1 // stats block scale [default 1]
+  scale?: number // stats block scale [default 1]
   /**
    * Stats html element horizontal anchor.
    * @default "left"


### PR DESCRIPTION
Scale type was harcoded to `1` which is changed into a number.