### PR TITLE
[next] Meshline fixes

### DIFF
--- a/.changeset/short-toys-smile.md
+++ b/.changeset/short-toys-smile.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fix issues with MeshLine

--- a/packages/extras/src/lib/components/MeshLine/MeshLineGeometry.svelte
+++ b/packages/extras/src/lib/components/MeshLine/MeshLineGeometry.svelte
@@ -47,7 +47,7 @@
     width.setX(i2, w)
     width.setX(i2 + 1, w)
 
-    uv.setXYZW(i3, i / (pointCount - 1), 0, i / (pointCount - 1), 1)
+    uv.setXYZW(i2, i / (pointCount - 1), 0, i / (pointCount - 1), 1)
 
     if (i < pointCount - 1) {
       const n = i * 2

--- a/packages/extras/src/lib/components/MeshLine/fragment.ts
+++ b/packages/extras/src/lib/components/MeshLine/fragment.ts
@@ -15,6 +15,10 @@ varying vec2 vUV;
 varying vec4 vColor;
 varying float vCounters;
 
+vec4 LinearTosRGB( in vec4 value ) {
+	return vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );
+}
+
 void main()	{
 	#include <logdepthbuf_fragment>
 	#include <${revision < 154 ? 'encodings_fragment' : 'colorspace_fragment'}>

--- a/packages/extras/src/lib/components/MeshLine/fragment.ts
+++ b/packages/extras/src/lib/components/MeshLine/fragment.ts
@@ -15,7 +15,7 @@ varying vec2 vUV;
 varying vec4 vColor;
 varying float vCounters;
 
-vec4 LinearTosRGB( in vec4 value ) {
+vec4 CustomLinearTosRGB( in vec4 value ) {
 	return vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );
 }
 
@@ -31,6 +31,6 @@ void main()	{
 			c.a *= ceil(mod(vCounters + dashOffset, dashArray) - (dashArray * dashRatio));
 	}
 
-	gl_FragColor = LinearTosRGB(c);
+	gl_FragColor = CustomLinearTosRGB(c);
 }
 `


### PR DESCRIPTION
A couple of fixes for MeshLineGeometry/MeshLineMaterial.

**First problem** can be seen in console here:
https://next.threlte.xyz/docs/reference/extras/meshline-geometry

Also reported here: https://github.com/threlte/threlte/issues/1086

I'm not sure why this ever worked because the LinearTosRGB function was not defined. Perhaps in older versions of three there was a LinearTosRGB function in a shader chunk that has been removed? Anyway I have added a function to the fragment shader so it should work with any version of three.

**Second problem** is that the uv buffer attribute is currently not being set properly:

![meshline](https://github.com/user-attachments/assets/df4f576f-dd79-4cbc-8bb5-f7c07ccac410)

I think the problem was introduced a few months ago when switching from a custom setXYZW function to three's Buffer Attribute .setXYZW method which works slightly differently.