### PR TITLE
feat(core): #1164 removes usethrelte dependency in usetask hook

### DIFF
--- a/.changeset/mighty-cycles-buy.md
+++ b/.changeset/mighty-cycles-buy.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": patch
+---
+
+Replace dependency of useThrelte in useTask hook with useSheduler hook instead

--- a/packages/core/src/lib/hooks/useTask.ts
+++ b/packages/core/src/lib/hooks/useTask.ts
@@ -2,7 +2,6 @@ import { onDestroy } from 'svelte'
 import { readable, writable, type Readable } from 'svelte/store'
 import { DAG, type Key, type Stage, type Task } from '../frame-scheduling'
 import { browser } from '../utilities'
-import { useThrelte } from '../context/compounds/useThrelte'
 import { useScheduler } from '../context/fragments/scheduler.svelte'
 
 export type ThrelteUseTask = {
@@ -88,16 +87,16 @@ export function useTask(
     opts = fnOrOptions as ThrelteUseTaskOptions | undefined
   }
 
-  const ctx = useThrelte()
+	const schedulerCtx = useScheduler()
 
-  let stage: Stage = ctx.mainStage
+  let stage: Stage = schedulerCtx.mainStage
 
   if (opts) {
     if (opts.stage) {
       if (DAG.isValue(opts.stage)) {
         stage = opts.stage
       } else {
-        const maybeStage = ctx.scheduler.getStage(opts.stage)
+        const maybeStage = schedulerCtx.scheduler.getStage(opts.stage)
         if (!maybeStage) {
           throw new Error(`No stage found with key ${opts.stage.toString()}`)
         }
@@ -130,7 +129,7 @@ export function useTask(
     }
   }
 
-  const schedulerCtx = useScheduler()
+
 
   const started = writable(false)
 


### PR DESCRIPTION
This PR fixes: #1164 

### Description
Removes dependency on `useThrelte` hook in `useTask` hook, and replaces it with `useScheduler` hook.