### PR TITLE
feat(core): export `createRootParentObject3DContext` fragment

### DIFF
--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -36,7 +36,11 @@ export { createCameraContext, useCamera } from './context/fragments/camera'
 export { createCanvasContext, useCanvas } from './context/fragments/canvas'
 export { createDisposalContext, useDisposal } from './context/fragments/disposal'
 export { createParentContext, useParent } from './context/fragments/parent'
-export { createParentObject3DContext, useParentObject3D } from './context/fragments/parentObject3D'
+export {
+  createRootParentObject3DContext,
+  createParentObject3DContext,
+  useParentObject3D
+} from './context/fragments/parentObject3D'
 export { createRendererContext, useRenderer } from './context/fragments/renderer.svelte'
 export { createSceneContext, useScene } from './context/fragments/scene'
 export { createSchedulerContext, useScheduler } from './context/fragments/scheduler.svelte'


### PR DESCRIPTION
Fixes: https://github.com/threlte/threlte/issues/1165

This PR ensures creating custom threlte context is possible with currently exported fragment contexts, as Threlte's `useAttach` depends on `createParentObject3DContext` which depends on `createRootParentObject3DContext` to be available.