### PR TITLE
[next] fix: Include auto-generated d.ts file

### DIFF
--- a/packages/core/src/lib/components/T/T.svelte.d.ts
+++ b/packages/core/src/lib/components/T/T.svelte.d.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+/**
+ * This file is a copy of the compiled d.ts file. It needs to be updated
+ * manually to export the $$IsomorphicComponent interface for Typescript to be
+ * able to do `typeof T`.
+ *
+ * TODO: At some point we need to get rid of this!
+ */
+
+/// <reference types="svelte" />
+import type { TProps } from './types'
+declare class __sveltets_Render<Type> {
+  props(): TProps<Type>
+  events(): {}
+  slots(): {}
+  bindings(): 'ref'
+  exports(): {}
+}
+export interface $$IsomorphicComponent {
+  new <Type>(
+    options: import('svelte').ComponentConstructorOptions<
+      ReturnType<__sveltets_Render<Type>['props']>
+    >
+  ): import('svelte').SvelteComponent<
+    ReturnType<__sveltets_Render<Type>['props']>,
+    ReturnType<__sveltets_Render<Type>['events']>,
+    ReturnType<__sveltets_Render<Type>['slots']>
+  > & {
+    $$bindings?: ReturnType<__sveltets_Render<Type>['bindings']>
+  } & ReturnType<__sveltets_Render<Type>['exports']>
+  <Type>(
+    internal: unknown,
+    props: ReturnType<__sveltets_Render<Type>['props']> & {}
+  ): ReturnType<__sveltets_Render<Type>['exports']>
+  z_$$bindings?: ReturnType<__sveltets_Render<any>['bindings']>
+}
+declare const T: $$IsomorphicComponent
+type T<Type> = InstanceType<typeof T<Type>>
+export default T


### PR DESCRIPTION
Working around a svelte language tools bug when packaging core:

```txt
d.ts type declaration files for the following files were likely not generated due to the following errors:
/Users/grischaerbe/Projects/threlte/packages/core/src/lib/components/T/T.ts
  - Exported variable 'T' has or is using name '$$IsomorphicComponent' from external module "/Users/grischaerbe/Projects/threlte/packages/core/src/lib/components/T/T.svelte" but cannot be named.
```

This essentially means "I'm trying to reference `$$IsomorphicComponent` from this module but it's not exported, so I don't know what to do here". By compiling it once, adding the `export` and copying it over to the source we're temporarily fixing the issue.