### PR TITLE
[next] restore ability to disable automatic attaching for gradient textures

### DIFF
--- a/.changeset/wet-badgers-end.md
+++ b/.changeset/wet-badgers-end.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": attach
+---
+
+[next] Restore ability to disable *attaching* for gradient textures

--- a/apps/docs/src/content/reference/extras/linear-gradient-texture.mdx
+++ b/apps/docs/src/content/reference/extras/linear-gradient-texture.mdx
@@ -66,9 +66,26 @@ componentSignature:
   }
 ---
 
-A reactive linear gradient texture that attaches to the "map" property of its parent. The underlying texture uses an [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) and a [CanvasTexture](https://threejs.org/docs/index.html#api/en/textures/CanvasTexture) and is assigned the same [colorspace](https://threejs.org/docs/index.html#api/en/textures/Texture.colorSpace) as the renderer.
+A reactive linear gradient texture. The underlying texture uses an [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) and a [CanvasTexture](https://threejs.org/docs/index.html#api/en/textures/CanvasTexture) and is assigned the same [colorspace](https://threejs.org/docs/index.html#api/en/textures/Texture.colorSpace) as the renderer.
 
 <Example path="extras/gradient-texture/linear" />
+
+## Attaching the Texture
+
+The texture is automatically attached to the `map` property of its parent. You can disable this behaviour by setting the `attach` prop to `false`. This may be useful if you want to create the texture but use it somewhere else.
+
+```svelte
+<script>
+  let texture = null
+</script>
+
+<LinearGradientTexture
+  attach={false}
+  bind:ref={texture}
+/>
+
+<SomeComponent {texture} />
+```
 
 ## Gradient Stops
 
@@ -97,7 +114,7 @@ You can even mix and match color representations
 <LinearGradientTexture
   stops={[
     { color: 'red', offset: 0 },
-    { color: 0xff0000, offset: 0.25 },
+    { color: 0xff_00_00, offset: 0.25 },
     { color: 'rgb(255, 0, 0)', offset: 0.5 },
     { color: '#ff0000', offset: 0.75 },
     { color: new Color(new Color(new Color())).set(1, 0, 0), offset: 1 }

--- a/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
+++ b/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
@@ -108,7 +108,7 @@ You can even mix and match color representations
 <RadialGradientTexture
   stops={[
     { color: 'red', offset: 0 },
-    { color: 0xff0000, offset: 0.25 },
+    { color: 0xff_00_00, offset: 0.25 },
     { color: 'rgb(255, 0, 0)', offset: 0.5 },
     { color: '#ff0000', offset: 0.75 },
     { color: new Color(new Color(new Color())).set(1, 0, 0), offset: 1 }

--- a/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
+++ b/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
@@ -56,6 +56,23 @@ A reactive radial gradient texture that attaches to the "map" property of its pa
 
 <Example path="extras/gradient-texture/radial" />
 
+## Attaching the Texture
+
+The texture is automatically attached to the `map` property of its parent. You can disable this behaviour by setting the `attach` prop to `false`. This may be useful if you want to create the texture but use it somewhere else.
+
+```svelte
+<script>
+  let texture = null
+</script>
+
+<RadialGradientTexture
+  attach={false}
+  bind:ref={texture}
+/>
+
+<SomeComponent {texture} />
+```
+
 ## Radius Props
 
 The `innerRadius` and `outerRadius` props control the size of the gradient. The `innerRadius` prop should be less than the `outerRadius` prop but it is not enforced. If `outerRadius` is set to `'auto'` the `outerRadius` is effectively set to the radius of the circle that circumscribes the canvas. For example, if the canvas's width and height are **1024**, and `outerRadius` is set to `'auto'`, the radius that will be used is **sqrt(1024\*\*2 + 1024\*\*2)** or roughly **724**.

--- a/packages/extras/src/lib/components/GradientTexture/linear/LinearGradientTexture.svelte
+++ b/packages/extras/src/lib/components/GradientTexture/linear/LinearGradientTexture.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import type { LinearGradientTextureProps } from './types'
   import { CanvasTexture } from 'three'
-  import { T, useThrelte } from '@threlte/core'
+  import { T, observe, useThrelte } from '@threlte/core'
   import { applyGradient, addStops } from '../common'
-
-  const { colorSpace, invalidate } = useThrelte()
 
   let {
     width = 1024,
@@ -17,6 +15,7 @@
       { offset: 0, color: 'black' },
       { offset: 1, color: 'white' }
     ],
+    attach = 'map',
     children,
     ref = $bindable(),
     ...props
@@ -34,12 +33,13 @@
     canvas.height = height
   })
 
-  $effect(() => {
-    props.wrapS
-    props.wrapT
-    texture.needsUpdate = true
-    invalidate()
-  })
+  observe(
+    () => [props.wrapS, props.wrapT],
+    () => {
+      texture.needsUpdate = true
+      invalidate()
+    }
+  )
 
   const gradient = $derived.by(() => {
     const gradient = context?.createLinearGradient(startX, startY, endX, endY)
@@ -49,6 +49,7 @@
     return gradient
   })
 
+  const { invalidate } = useThrelte()
   $effect(() => {
     if (gradient !== undefined && context !== null) {
       applyGradient(context, gradient)
@@ -61,8 +62,7 @@
 <T
   is={texture}
   bind:ref
-  attach="map"
-  colorSpace={$colorSpace}
+  {attach}
   {...props}
 >
   {@render children?.({ ref: texture })}

--- a/packages/extras/src/lib/components/GradientTexture/radial/RadialGradientTexture.svelte
+++ b/packages/extras/src/lib/components/GradientTexture/radial/RadialGradientTexture.svelte
@@ -66,8 +66,6 @@
       invalidate()
     }
   })
-
-  $inspect(attach)
 </script>
 
 <T

--- a/packages/extras/src/lib/components/GradientTexture/radial/RadialGradientTexture.svelte
+++ b/packages/extras/src/lib/components/GradientTexture/radial/RadialGradientTexture.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
   import type { RadialGradientTextureProps } from './types'
   import { CanvasTexture } from 'three'
-  import { T, useThrelte } from '@threlte/core'
+  import { T, observe, useThrelte } from '@threlte/core'
   import { applyGradient, addStops } from '../common'
 
-  const { colorSpace, invalidate } = useThrelte()
-
   let {
+    width = 1024,
+    height = 1024,
     innerRadius = 0,
     outerRadius = 'auto',
     stops = [
       { offset: 0, color: 'black' },
       { offset: 1, color: 'white' }
     ],
-    width = 1024,
-    height = 1024,
+    attach = 'map',
     children,
     ref = $bindable(),
     ...props
@@ -32,12 +31,13 @@
     canvas.height = height
   })
 
-  $effect(() => {
-    props.wrapS
-    props.wrapT
-    texture.needsUpdate = true
-    invalidate()
-  })
+  observe(
+    () => [props.wrapS, props.wrapT],
+    () => {
+      texture.needsUpdate = true
+      invalidate()
+    }
+  )
 
   let canvasCenterX = $derived(0.5 * width)
   let canvasCenterY = $derived(0.5 * height)
@@ -58,6 +58,7 @@
     return gradient
   })
 
+  const { invalidate } = useThrelte()
   $effect(() => {
     if (gradient !== undefined && context !== null) {
       applyGradient(context, gradient)
@@ -65,13 +66,14 @@
       invalidate()
     }
   })
+
+  $inspect(attach)
 </script>
 
 <T
   is={texture}
-  attach="map"
-  colorSpace={$colorSpace}
   {...props}
+  {attach}
   bind:ref
 >
   {@render children?.({ ref: texture })}


### PR DESCRIPTION
Restores the ability to disable automatic attaching of these textures to parents. They will automatically attach to the `map` property of their parent but you can now override that with `attach={false}` or any of the other attaches that <T> accepts.

other things

- adds docs for disabling auto-attachment.
- uses `observe` instead of the weird looking

```typescript
$effect(() => {
  /* dependencies */
  depends
  on
  this
  and
  that
  /* effect code that doesn't reference any dependencies */
})
```
- no longer sets the colorspace to the colorspace of the renderer. you can still do that but now you must do it yourself.