### PR TITLE
[next] Cube camera ref assignment tweaks

### DIFF
--- a/.changeset/cyan-lemons-walk.md
+++ b/.changeset/cyan-lemons-walk.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+CubeCamera follows what other components do and binds to the ref at the component instead of assigning in the script tag

--- a/packages/extras/src/lib/components/CubeCamera/CubeCamera.svelte
+++ b/packages/extras/src/lib/components/CubeCamera/CubeCamera.svelte
@@ -18,8 +18,6 @@
     ...props
   }: CubeCameraProps = $props()
 
-  ref = new Group()
-
   export const renderTarget = new WebGLCubeRenderTarget(resolution)
   observe.pre(
     () => [resolution],
@@ -33,6 +31,7 @@
   })
 
   export const camera = new CubeCamera(near, far, renderTarget)
+
   observe.pre(
     () => [near, far],
     () => {
@@ -48,6 +47,7 @@
 
   const { renderer, scene } = useThrelte()
 
+  const group = new Group()
   const inner = new Group()
 
   let count = 0
@@ -88,11 +88,12 @@
 </script>
 
 <T
-  is={ref}
+  is={group}
+  bind:ref
   {...props}
 >
   <T is={camera} />
   <T is={inner}>
-    {@render children?.({ camera, ref, renderTarget, restart })}
+    {@render children?.({ camera, ref: group, renderTarget, restart })}
   </T>
 </T>


### PR DESCRIPTION
Other components create the binding ref in the script tag and then do

```svelte
<T is={someThreeObjectInstance} bind:ref />
```

so cube camera should do the same.