### PR TITLE
[next] cleanup types of lava lamp example

### DIFF
--- a/.changeset/quick-crabs-tickle.md
+++ b/.changeset/quick-crabs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@threlte/docs": patch
+---
+
+fixes types in the MarchingCubes example and makes it a little less libraryish

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
-  import type { Props } from '@threlte/core'
   import { MarchingCube } from './MarchingCube'
   import { T } from '@threlte/core'
 
-  type MarchingCubeProps = Props<MarchingCube>
+  import type { MarchingCubeProps } from './types'
 
   let { ref = $bindable(), children, ...props }: MarchingCubeProps = $props()
+
+  const cube = new MarchingCube()
 </script>
 
 <T
-  is={MarchingCube}
+  is={cube}
   bind:ref
   {...props}
 >
-  {@render children?.({ ref })}
+  {@render children?.({ ref: cube })}
 </T>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.svelte
@@ -4,14 +4,13 @@
 
   import type { MarchingCubeProps } from './types'
 
-  let { ref = $bindable(), children, ...props }: MarchingCubeProps = $props()
+  let { children, ...props }: MarchingCubeProps = $props()
 
   const cube = new MarchingCube()
 </script>
 
 <T
   is={cube}
-  bind:ref
   {...props}
 >
   {@render children?.({ ref: cube })}

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.ts
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCube.ts
@@ -1,11 +1,11 @@
-import type { Color } from 'three'
+import { Color } from 'three'
 import { Group } from 'three'
 
 export class MarchingCube extends Group {
   constructor(
     public strength = 0.5,
     public subtract = 12,
-    public color?: Color
+    public color = new Color()
   ) {
     super()
   }

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCubes.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingCubes.svelte
@@ -1,19 +1,15 @@
 <script
   lang="ts"
-  context="module"
+  module
 >
-  import type { MarchingPlaneAxis } from './MarchingPlane'
+  import type { AddAxisMap } from './types'
   import { Vector3 } from 'three'
 
-  type addAxisMap = {
-    [Key in MarchingPlaneAxis]: `addPlane${Uppercase<Key>}`
-  }
-
-  const map: addAxisMap = {
+  const map: AddAxisMap = {
     x: 'addPlaneX',
     y: 'addPlaneY',
     z: 'addPlaneZ'
-  }
+  } as const
 
   // reusable for calculating world position of `<MarchingCube>`s
   const position = new Vector3()

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
@@ -6,12 +6,14 @@
   type MarchingPlaneProps = Props<MarchingPlane>
 
   let { ref = $bindable(), children, ...props }: MarchingPlaneProps = $props()
+
+  const plane = new MarchingPlane()
 </script>
 
 <T
-  is={MarchingPlane}
+  is={plane}
   bind:ref
   {...props}
 >
-  {@render children?.({ ref })}
+  {@render children?.({ ref: plane })}
 </T>

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.svelte
@@ -5,14 +5,13 @@
 
   type MarchingPlaneProps = Props<MarchingPlane>
 
-  let { ref = $bindable(), children, ...props }: MarchingPlaneProps = $props()
+  let { children, ...props }: MarchingPlaneProps = $props()
 
   const plane = new MarchingPlane()
 </script>
 
 <T
   is={plane}
-  bind:ref
   {...props}
 >
   {@render children?.({ ref: plane })}

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.ts
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/MarchingPlane.ts
@@ -1,6 +1,5 @@
 import { Group } from 'three'
-
-export type MarchingPlaneAxis = 'x' | 'y' | 'z'
+import type { MarchingPlaneAxis } from './types'
 
 export class MarchingPlane extends Group {
   constructor(

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/Scene.svelte
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/Scene.svelte
@@ -2,7 +2,7 @@
   import MarchingCube from './MarchingCube.svelte'
   import MarchingCubes from './MarchingCubes.svelte'
   import MarchingPlane from './MarchingPlane.svelte'
-  import type { MarchingPlaneAxis } from './MarchingPlane'
+  import type { MarchingPlaneAxis } from './types'
   import { Color, Vector2 } from 'three'
   import { OrbitControls } from '@threlte/extras'
   import { T, useTask } from '@threlte/core'

--- a/apps/docs/src/examples/marching-cubes/lava-lamp/types.ts
+++ b/apps/docs/src/examples/marching-cubes/lava-lamp/types.ts
@@ -1,0 +1,13 @@
+import type { MarchingCube } from './MarchingCube'
+import type { MarchingCubes } from 'three/examples/jsm/Addons.js'
+import type { MarchingPlane } from './MarchingPlane'
+import type { Props } from '@threlte/core'
+
+export type AddAxisMap = {
+  [K in keyof MarchingCubes as K extends `addPlane${infer Axis}` ? Lowercase<Axis> : never]: K
+}
+
+export type MarchingPlaneAxis = keyof AddAxisMap
+
+export type MarchingPlaneProps = Props<MarchingPlane>
+export type MarchingCubeProps = Props<MarchingCube>


### PR DESCRIPTION
fixes #1194

it's complete but I can't figure out why the type errors still say `undefined is not assignable to ${refType}`. i thought it had to do with putting things into a `types.ts` file but that didn't work.

other than that, everything is typed ok. @grischaerbe I may need your help on that.