### PR TITLE
[next] Use fbo simplifications

### DIFF
--- a/.changeset/wise-dryers-shop.md
+++ b/.changeset/wise-dryers-shop.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": minor
+"@threlte/docs": patch
+---
+
+updates useFBO to use default options of `WebGLRenderTarget`

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -14,7 +14,7 @@ Framebuffer objects are useful when you want to render a scene but not display i
 
 ## Options
 
-```ts
+```typescript
 type UseFBOOptions = THREE.WebGLRenderTargetOptions & {
   /**
    * If set, the scene depth will be rendered into buffer.depthTexture.
@@ -31,4 +31,46 @@ export function useFBO(
   /**Options */
   options?: UseFBOOptions
 ): THREE.WebGLRenderTarget
+```
+
+`useFBO` can either be called with an options object or a width and height and options object.
+
+In the first case it will set its render target size to be equal to the width and height of the `size` store from `useThrelte`.
+
+In the second case, `useFBO` will set the target's width and height to the width and height that are passed in. Note that height is optional. If width is passed in but not height, height will default to `1`.
+
+In both cases the `size` store is subscribed to but the size of the render target is only updated to match when width is an options object. `size` is unsubscribed from when the component unmounts.
+
+```typescript
+// use width and height from `useThrelte's` size store and the default options for WebGLRenderTarget, update render target size to match when `size` updates
+useFBO()
+
+// use width and height from `useThrelte's` size store. update render target size to match when `size` updates. use options provided.
+useFBO({ samples: 4 })
+
+// use provided width andh height. do not update size at all
+useFBO(512, 512)
+
+// use provided width and a default height of 1
+useFBO(512)
+```
+
+If you want to provide options but you don't care about the width or height, you can pass in `1`.
+
+```typescript
+useFBO(512, 1, { samples: 4 })
+useFBO(1, 512, { samples: 4 })
+useFBO(1, 1, { samples: 4 })
+```
+
+`useFBO`'s options object accepts a `depth` property. If `depth` is set to `true`, a depth texture is created and the scene's depth is rendered into it.
+
+```svelte
+<script>
+  const fbo = useFBO({ depth: true })
+</script>
+
+{#if fbo.depthTexture !== null}
+  <SomethingThatUsesADepthTexture texture={fbo.depthTexture} />
+{/if}
 ```

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -6,25 +6,26 @@ name: useFBO
 type: 'hook'
 ---
 
-useFBO (Framebuffer Object) is a hook that creates a `THREE.WebGLRenderTarget`. This is a port of [drei's useFBO hook](https://github.com/pmndrs/drei#usefbo).
+useFBO (Framebuffer Object) is a port of [drei's useFBO](https://github.com/pmndrs/drei#usefbo) that creates a [THREE.WebGLRenderTarget](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderTarget).
 
-Framebuffer objects are useful for cases where you want to render a scene but not display it. For example, rendering a scene to a framebuffer then passing that to a fragment shader as a uniform. You can read more about `WebGLRenderTarget`'s [here](https://threejs.org/docs/index.html?q=render%20target#api/en/renderers/WebGLRenderTarget).
+Framebuffer objects are useful when you want to render a scene but not display it. For example, rendering a scene to a framebuffer then passing that to a fragment shader as a texture.
 
 <Example path="extras/use-fbo" />
 
 ## Options
 
 ```ts
-type UseFBOOptions = {
-  /** Defines the count of MSAA samples. Can only be used with WebGL 2. Default: 0 */
-  samples?: number
-  /** If set, the scene depth will be rendered into buffer.depthTexture. Default: false */
+type UseFBOOptions = THREE.WebGLRenderTargetOptions & {
+  /**
+   * If set, the scene depth will be rendered into buffer.depthTexture.
+   * @default false
+   */
   depth?: boolean
-} & THREE.WebGLRenderTargetOptions
+}
 
 export function useFBO(
   /** Width in pixels, or options (will render fullscreen by default) */
-  width?: number | UseFBOOptions,
+  width?: number | UseFBOOptions = {},
   /** Height in pixels */
   height?: number,
   /**Options */

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -6,7 +6,6 @@
   const { camera, renderer, scene } = useThrelte()
 
   const renderTarget = useFBO({
-    depth: true,
     samples: 4
   })
 

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -5,8 +5,8 @@
 
   const { camera, renderer, scene } = useThrelte()
 
-  // render scene at a lower resolution
   const renderTarget = useFBO({
+    depth: true,
     samples: 4
   })
 
@@ -56,7 +56,7 @@
   scale={5}
 >
   <T.PlaneGeometry />
-  <T.MeshBasicMaterial
+  <T.MeshStandardMaterial
     map={renderTarget.texture}
     color="#CCFFCC"
   />

--- a/packages/extras/src/lib/hooks/useFBO.ts
+++ b/packages/extras/src/lib/hooks/useFBO.ts
@@ -1,15 +1,9 @@
 /* Based on https://github.com/pmndrs/drei/blob/master/src/core/useFBO.tsx under the MIT License */
 
-import { useThrelte, watch } from '@threlte/core'
+import type { RenderTargetOptions } from 'three'
+import { HalfFloatType, DepthTexture, FloatType, WebGLRenderTarget } from 'three'
 import { onMount } from 'svelte'
-import {
-  type RenderTargetOptions,
-  WebGLRenderTarget,
-  LinearFilter,
-  HalfFloatType,
-  DepthTexture,
-  FloatType
-} from 'three'
+import { useThrelte, watch } from '@threlte/core'
 
 type UseFBOOptions = RenderTargetOptions & {
   /**
@@ -24,25 +18,22 @@ export function useFBO(
   width: number | UseFBOOptions = {},
   /** Height in pixels */
   height?: number,
-  /** Options */
+  /** Options that are passed to the  */
   options?: UseFBOOptions
 ): WebGLRenderTarget {
   const { dpr, size } = useThrelte()
 
   const _width = typeof width === 'number' ? width : Math.max(dpr.current, 1)
   const _height = typeof height === 'number' ? height : Math.max(dpr.current, 1)
+
   const {
     samples = 0,
     depth = false,
-    minFilter = LinearFilter,
-    magFilter = LinearFilter,
     type = HalfFloatType,
     ...targetOptions
   } = typeof width === 'number' ? options ?? {} : width
 
   const target = new WebGLRenderTarget(_width, _height, {
-    minFilter,
-    magFilter,
     type,
     ...targetOptions
   })
@@ -54,7 +45,7 @@ export function useFBO(
   target.samples = samples
 
   onMount(() => {
-    if (samples) target.samples = samples
+    if (samples > 0) target.samples = samples
     return () => target.dispose()
   })
 


### PR DESCRIPTION
i was working with trying to make a `RenderTexture` component or an example of an example of a screen quad / mini postprocessing example. Similar to what's described in this [article](https://luruke.medium.com/simple-postprocessing-in-three-js-91936ecadfb7).

i noticed that fbo would be really nice to use here but while reading the docs, i decided that it could use a little spruce up.

The original port was almost a 1:1 with drei's. Most of the changes are to simplify the example and to get rid of things like `as Type` casts and to let the threejs defaults pass through.

More docs about the different ways to call `useFBO` and a small code snippet about how to use the optional depth texture have been added.

because the WebGLRenderTarget defaults are now used and we were using nondefaults in `useFBO`, this is a breaking change. i'm not sure if there should be a minor or major changeset for this. probably minor right because at the time of writing this, the next branch has not been officially released.