### PR TITLE
[next] useFBO rewrite

### DIFF
--- a/.changeset/weak-mayflies-give.md
+++ b/.changeset/weak-mayflies-give.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": major
+"@threlte/docs": patch
+---
+
+rewrite of `useFBO` which adds more functionality and is easier to follow in its implementation

--- a/.changeset/wise-dryers-shop.md
+++ b/.changeset/wise-dryers-shop.md
@@ -1,0 +1,6 @@
+---
+"@threlte/extras": minor
+"@threlte/docs": patch
+---
+
+updates useFBO to use default options of `WebGLRenderTarget`

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -14,7 +14,7 @@ Framebuffer objects are useful when you want to render a scene but not display i
 
 ## Options
 
-```ts
+```typescript
 type UseFBOOptions = THREE.WebGLRenderTargetOptions & {
   /**
    * If set, the scene depth will be rendered into buffer.depthTexture.
@@ -31,4 +31,46 @@ export function useFBO(
   /**Options */
   options?: UseFBOOptions
 ): THREE.WebGLRenderTarget
+```
+
+`useFBO` can either be called with an options object or a width and height and options object.
+
+In the first case it will set its render target size to be equal to the width and height of the `size` store from `useThrelte`.
+
+In the second case, `useFBO` will set the target's width and height to the width and height that are passed in. Note that height is optional. If width is passed in but not height, height will default to `1`.
+
+In both cases the `size` store is subscribed to but the size of the render target is only updated to match when width is an options object. `size` is unsubscribed from when the component unmounts.
+
+```typescript
+// use width and height from `useThrelte's` size store and the default options for WebGLRenderTarget, update render target size to match when `size` updates
+useFBO()
+
+// use width and height from `useThrelte's` size store. update render target size to match when `size` updates. use options provided.
+useFBO({ samples: 4 })
+
+// use provided width andh height. do not update size at all
+useFBO(512, 512)
+
+// use provided width and a default height of 1
+useFBO(512)
+```
+
+If you want to provide options but you don't care about the width or height, you can pass in `1`.
+
+```typescript
+useFBO(512, 1, { samples: 4 })
+useFBO(1, 512, { samples: 4 })
+useFBO(1, 1, { samples: 4 })
+```
+
+`useFBO`'s options object accepts a `depth` property. If `depth` is set to `true`, a depth texture is created and the scene's depth is rendered into it.
+
+```svelte
+<script>
+  const fbo = useFBO({ depth: true })
+</script>
+
+{#if fbo.depthTexture !== null}
+  <SomethingThatUsesADepthTexture texture={fbo.depthTexture} />
+{/if}
 ```

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -6,25 +6,26 @@ name: useFBO
 type: 'hook'
 ---
 
-useFBO (Framebuffer Object) is a hook that creates a `THREE.WebGLRenderTarget`. This is a port of [drei's useFBO hook](https://github.com/pmndrs/drei#usefbo).
+useFBO (Framebuffer Object) is a port of [drei's useFBO](https://github.com/pmndrs/drei#usefbo) that creates a [THREE.WebGLRenderTarget](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderTarget).
 
-Framebuffer objects are useful for cases where you want to render a scene but not display it. For example, rendering a scene to a framebuffer then passing that to a fragment shader as a uniform. You can read more about `WebGLRenderTarget`'s [here](https://threejs.org/docs/index.html?q=render%20target#api/en/renderers/WebGLRenderTarget).
+Framebuffer objects are useful when you want to render a scene but not display it. For example, rendering a scene to a framebuffer then passing that to a fragment shader as a texture.
 
 <Example path="extras/use-fbo" />
 
 ## Options
 
 ```ts
-type UseFBOOptions = {
-  /** Defines the count of MSAA samples. Can only be used with WebGL 2. Default: 0 */
-  samples?: number
-  /** If set, the scene depth will be rendered into buffer.depthTexture. Default: false */
+type UseFBOOptions = THREE.WebGLRenderTargetOptions & {
+  /**
+   * If set, the scene depth will be rendered into buffer.depthTexture.
+   * @default false
+   */
   depth?: boolean
-} & THREE.WebGLRenderTargetOptions
+}
 
 export function useFBO(
   /** Width in pixels, or options (will render fullscreen by default) */
-  width?: number | UseFBOOptions,
+  width?: number | UseFBOOptions = {},
   /** Height in pixels */
   height?: number,
   /**Options */

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -70,7 +70,7 @@ assert(target.height === 1)
 
 ### `depth`
 
-`depth` is used to assign a [DepthTexture](https://threejs.org/docs/#api/en/textures/DepthTexture) to the `depthTexture` property of the render target. It can either be a boolean, "dimensions object", or DepthTexture instance. By default, `depth` is set to `false` and a `depth` texture is **not** created.
+`depth` is used to assign a [DepthTexture](https://threejs.org/docs/#api/en/textures/DepthTexture) to the `depthTexture` property of the render target. It can either be a boolean, "dimensions object", or DepthTexture instance. By default, `depth` is set to `false` and a `depth` texture is **not** created. When depth is used, the scene's depth is rendered to the `depthTexture` of the render target.
 
 If `depth` is set to `true`, a depth texture is created and sized to match the size of the render target, _after_ an appropriate size has been given to the render target.
 

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -6,7 +6,7 @@ name: useFBO
 type: 'hook'
 ---
 
-useFBO (Framebuffer Object) is a port of [drei's useFBO](https://github.com/pmndrs/drei#usefbo) that creates a [THREE.WebGLRenderTarget](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderTarget).
+`useFBO` (Framebuffer Object) is a port of [drei's useFBO](https://github.com/pmndrs/drei#usefbo) that creates a [THREE.WebGLRenderTarget](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderTarget).
 
 Framebuffer objects are useful when you want to render a scene but not display it. For example, rendering a scene to a framebuffer then passing that to a fragment shader as a texture.
 
@@ -14,63 +14,121 @@ Framebuffer objects are useful when you want to render a scene but not display i
 
 ## Options
 
-```typescript
-type UseFBOOptions = THREE.WebGLRenderTargetOptions & {
-  /**
-   * If set, the scene depth will be rendered into buffer.depthTexture.
-   * @default false
-   */
-  depth?: boolean
-}
+`useFBO`'s options object extends `Three.RenderTargetOptions`. The additional properties are listed below.
 
-export function useFBO(
-  /** Width in pixels, or options (will render fullscreen by default) */
-  width?: number | UseFBOOptions = {},
-  /** Height in pixels */
-  height?: number,
-  /**Options */
-  options?: UseFBOOptions
-): THREE.WebGLRenderTarget
-```
+### `dimensions`
 
-`useFBO` can either be called with an options object or a width and height and options object.
+`dimensions` is used to set the `width` and `height` of the render target.
 
-In the first case it will set its render target size to be equal to the width and height of the `size` store from `useThrelte`.
-
-In the second case, `useFBO` will set the target's width and height to the width and height that are passed in. Note that height is optional. If width is passed in but not height, height will default to `1`.
-
-In both cases the `size` store is subscribed to but the size of the render target is only updated to match when width is an options object. `size` is unsubscribed from when the component unmounts.
+If `dimensions` is not provided, the target's size is set to the size of the canvas and it will follow any updates to the size.
 
 ```typescript
-// use width and height from `useThrelte's` size store and the default options for WebGLRenderTarget, update render target size to match when `size` updates
-useFBO()
+const { size } = useThrelte()
 
-// use width and height from `useThrelte's` size store. update render target size to match when `size` updates. use options provided.
-useFBO({ samples: 4 })
+// use `size`'s width and height
+const target = useFBO()
 
-// use provided width andh height. do not update size at all
-useFBO(512, 512)
-
-// use provided width and a default height of 1
-useFBO(512)
+assert(target.width === size.current.width)
+assert(target.height === size.current.height)
 ```
 
-If you want to provide options but you don't care about the width or height, you can pass in `1`.
+If `dimensions` is provided, the `width` and `height` of the texture are taken from `dimensions`.
 
 ```typescript
-useFBO(512, 1, { samples: 4 })
-useFBO(1, 512, { samples: 4 })
-useFBO(1, 1, { samples: 4 })
+const dimensions = { width: 512, height: 512 }
+
+const target = useFBO({ dimensions })
+assert(target.width === dimensions.width)
+assert(target.height === dimensions.height)
 ```
 
-`useFBO`'s options object accepts a `depth` property. If `depth` is set to `true`, a depth texture is created and the scene's depth is rendered into it.
+`width` and `height` both default to `1` if they are not found on the `dimensions` object.
 
-```svelte
-<script>
-  const fbo = useFBO({ depth: true })
-</script>
+```typescript
+const dimensions = { width: 512 }
 
-{#if fbo.depthTexture !== null}
-  <SomethingThatUsesADepthTexture texture={fbo.depthTexture} />
-{/if}
+const target = useFBO({ dimensions })
+assert(target.width === dimensions.width)
+assert(target.height === 1)
+```
+
+```typescript
+const dimensions = { height: 512 }
+
+const target = useFBO({ dimensions })
+assert(target.width === 1)
+assert(target.height === dimensions.height)
+```
+
+```typescript
+const dimensions = {}
+
+const target = useFBO({ dimensions })
+assert(target.width === 1)
+assert(target.height === 1)
+```
+
+### `depth`
+
+`depth` is used to assign a [DepthTexture](https://threejs.org/docs/#api/en/textures/DepthTexture) to the `depthTexture` property of the render target. It can either be a boolean, "dimensions object", or DepthTexture instance. By default, `depth` is set to `false` and a `depth` texture is **not** created.
+
+If `depth` is set to `true`, a depth texture is created and sized to match the size of the render target, _after_ an appropriate size has been given to the render target.
+
+```typescript
+const { size } = useThrelte()
+
+const target = useFBO({ depth: true })
+
+assert(target.depthTexture.image.width === size.current.width)
+assert(target.depthTexture.image.height === size.current.height)
+```
+
+If `depth` is a depth texture instance, it is assigned to the `depthTexture` property of the returned render target.
+
+```typescript
+const depthTexture = new DepthTexture(512, 512)
+
+const target = useFBO({ depth: depthTexture })
+
+assert(target.depthTexture === depthTexture)
+```
+
+If `depth` is set to a dimensions object, the depth texture size is set the `width` and `height` of the object.
+
+```typescript
+const depth = { width: 512, height: 512 }
+
+const target = useFBO({ depth })
+
+assert(target.depthTexture.image.width === depth.width)
+assert(target.depthTexture.image.height === depth.height)
+```
+
+`width` and `height` default to `1` if they are not found on the `depth` object.
+
+```typescript
+const depth = { width: 512 }
+
+const target = useFBO({ depth })
+
+assert(target.depthTexture.image.width === depth.width)
+assert(target.depthTexture.image.height === 1)
+```
+
+```typescript
+const depth = { height: 512 }
+
+const target = useFBO({ depth })
+
+assert(target.depthTexture.image.width === 1)
+assert(target.depthTexture.image.height === depth.height)
+```
+
+```typescript
+const depth = {}
+
+const target = useFBO({ depth })
+
+assert(target.depthTexture.image.width === 1)
+assert(target.depthTexture.image.height === 1)
 ```

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -16,11 +16,11 @@ Framebuffer objects are useful when you want to render a scene but not display i
 
 `useFBO`'s options object extends `Three.RenderTargetOptions`. The additional properties are listed below.
 
-### `dimensions`
+### `size`
 
-`dimensions` is used to set the `width` and `height` of the render target.
+`size` is used to set the `width` and `height` of the render target.
 
-If `dimensions` is not provided, the target's size is set to the size of the canvas and it will follow any updates to the size.
+If `size` is not provided, the target's size is set to the size of the canvas and it will follow any updates to the size.
 
 ```typescript
 const { size } = useThrelte()
@@ -32,45 +32,45 @@ assert(target.width === size.current.width)
 assert(target.height === size.current.height)
 ```
 
-If `dimensions` is provided, the `width` and `height` of the texture are taken from `dimensions`.
+If `size` is provided, the `width` and `height` of the texture are taken from `size`.
 
 ```typescript
-const dimensions = { width: 512, height: 512 }
+const size = { width: 512, height: 512 }
 
-const target = useFBO({ dimensions })
-assert(target.width === dimensions.width)
-assert(target.height === dimensions.height)
+const target = useFBO({ size })
+assert(target.width === size.width)
+assert(target.height === size.height)
 ```
 
-`width` and `height` both default to `1` if they are not found on the `dimensions` object.
+`width` and `height` both default to `1` if they are not found on the `size` object.
 
 ```typescript
-const dimensions = { width: 512 }
+const size = { width: 512 }
 
-const target = useFBO({ dimensions })
-assert(target.width === dimensions.width)
+const target = useFBO({ size })
+assert(target.width === size.width)
 assert(target.height === 1)
 ```
 
 ```typescript
-const dimensions = { height: 512 }
+const size = { height: 512 }
 
-const target = useFBO({ dimensions })
+const target = useFBO({ size })
 assert(target.width === 1)
-assert(target.height === dimensions.height)
+assert(target.height === size.height)
 ```
 
 ```typescript
-const dimensions = {}
+const size = {}
 
-const target = useFBO({ dimensions })
+const target = useFBO({ size })
 assert(target.width === 1)
 assert(target.height === 1)
 ```
 
 ### `depth`
 
-`depth` is used to assign a [DepthTexture](https://threejs.org/docs/#api/en/textures/DepthTexture) to the `depthTexture` property of the render target. It can either be a boolean, "dimensions object", or DepthTexture instance. By default, `depth` is set to `false` and a `depth` texture is **not** created. When depth is used, the scene's depth is rendered to the `depthTexture` of the render target.
+`depth` is used to assign a [DepthTexture](https://threejs.org/docs/#api/en/textures/DepthTexture) to the `depthTexture` property of the render target. It can either be a boolean, "size" object, or `DepthTexture` instance. By default, `depth` is set to `false` and a depth texture is **not** created. When `depth` is used, the scene's depth is rendered to the `depthTexture` of the render target.
 
 If `depth` is set to `true`, a depth texture is created and sized to match the size of the render target, _after_ an appropriate size has been given to the render target.
 
@@ -93,7 +93,7 @@ const target = useFBO({ depth: depthTexture })
 assert(target.depthTexture === depthTexture)
 ```
 
-If `depth` is set to a dimensions object, the depth texture size is set the `width` and `height` of the object.
+If `depth` is set to a "size" object, the depth texture size is set the `width` and `height` of the object.
 
 ```typescript
 const depth = { width: 512, height: 512 }

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -8,7 +8,7 @@ type: 'hook'
 
 `useFBO` (Framebuffer Object) is a port of [drei's useFBO](https://github.com/pmndrs/drei#usefbo) that creates a [THREE.WebGLRenderTarget](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderTarget).
 
-Framebuffer objects are useful when you want to render a scene but not display it. For example, rendering a scene to a framebuffer then passing that to a fragment shader as a texture.
+Framebuffer objects are useful when you want to render a scene to something other than the canvas. In ThreeJS, you do this by rendering the scene to a RenderTarget. The render target has a texture property that can be used for various things such as postprocessing effects or applying the texture to something in the scene.
 
 <Example path="extras/use-fbo" />
 

--- a/apps/docs/src/examples/extras/use-fbo/App.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/App.svelte
@@ -1,20 +1,11 @@
 <script lang="ts">
   import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
-  import { Checkbox, Pane } from 'svelte-tweakpane-ui'
-
-  let useRotatingCamera = $state(false)
 </script>
 
-<Pane position="fixed">
-  <Checkbox
-    bind:value={useRotatingCamera}
-    label="use rotating camera"
-  />
-</Pane>
 <div>
   <Canvas>
-    <Scene {useRotatingCamera} />
+    <Scene />
   </Canvas>
 </div>
 

--- a/apps/docs/src/examples/extras/use-fbo/App.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/App.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
   import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
+  import { Checkbox, Pane } from 'svelte-tweakpane-ui'
+
+  let useRotatingCamera = $state(false)
 </script>
 
+<Pane position="fixed">
+  <Checkbox
+    bind:value={useRotatingCamera}
+    label="use rotating camera"
+  />
+</Pane>
 <div>
   <Canvas>
-    <Scene />
+    <Scene {useRotatingCamera} />
   </Canvas>
 </div>
 

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -54,7 +54,7 @@
   <OrbitControls enabled={useControlsCamera} />
 </T.PerspectiveCamera>
 
-<T.AmbientLight intensity={0.5} />
+<T.AmbientLight />
 
 <Sky />
 

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -6,7 +6,6 @@
   const { camera, renderer, scene } = useThrelte()
 
   const renderTarget = useFBO({
-    depth: true,
     samples: 4
   })
 

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -5,8 +5,8 @@
 
   const { camera, renderer, scene } = useThrelte()
 
-  // render scene at a lower resolution
   const renderTarget = useFBO({
+    depth: true,
     samples: 4
   })
 
@@ -56,7 +56,7 @@
   scale={5}
 >
   <T.PlaneGeometry />
-  <T.MeshBasicMaterial
+  <T.MeshStandardMaterial
     map={renderTarget.texture}
     color="#CCFFCC"
   />

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -1,57 +1,79 @@
 <script lang="ts">
-  import type { Mesh } from 'three'
-  import { OrbitControls, Sky, useFBO } from '@threlte/extras'
+  import { OrbitControls, Sky, useGltf } from '@threlte/extras'
+  import { Group, Mesh, MeshStandardMaterial, PerspectiveCamera, PlaneGeometry } from 'three'
   import { T, useTask, useThrelte } from '@threlte/core'
+  import { useFBO } from '@threlte/extras'
 
-  const { camera, renderer, scene } = useThrelte()
+  let { useRotatingCamera }: { useRotatingCamera: boolean } = $props()
 
-  const renderTarget = useFBO()
+  const useControlsCamera = $derived(!useRotatingCamera)
 
-  let fboPreviewMesh: Mesh
+  const gltf = useGltf('/models/Duck.glb')
 
-  let knotRotation = 0
+  const { renderer, scene } = useThrelte()
+  const fbo = useFBO()
 
+  const group = new Group()
+
+  const cameraMeshHeight = 1
+  const cameraRotationRadius = 5
+
+  // create the plane and other camera in the script tag so that we don't have to bind to the ref and worry about `undefined` cases
+  const rotatingCamera = new PerspectiveCamera()
+
+  const planeMesh = new Mesh(new PlaneGeometry(), new MeshStandardMaterial({ map: fbo.texture }))
+  planeMesh.position.setZ(-1 * (cameraMeshHeight + cameraRotationRadius))
+  planeMesh.scale.setScalar(10)
+
+  let time = 0
   useTask((delta) => {
-    knotRotation += delta
+    time += delta
+    const c = Math.cos(time)
+    const s = Math.sin(time)
+    rotatingCamera.position.set(cameraRotationRadius * c, 2 * c * s, cameraRotationRadius * s)
+    rotatingCamera.lookAt(group.position)
 
-    // save state before updating
-    const previewMeshVisible = fboPreviewMesh.visible
+    const lastVisible = planeMesh.visible
+    planeMesh.visible = false
     const lastRenderTarget = renderer.getRenderTarget()
 
-    // update state
-    renderer.setRenderTarget(renderTarget)
-    fboPreviewMesh.visible = false
+    renderer.setRenderTarget(fbo)
+    renderer.render(scene, rotatingCamera)
 
-    renderer.render(scene, camera.current)
-
-    // restore previous state
-    fboPreviewMesh.visible = previewMeshVisible
+    planeMesh.visible = lastVisible
     renderer.setRenderTarget(lastRenderTarget)
   })
 </script>
 
 <T.PerspectiveCamera
-  makeDefault
-  position={[5, 1, 5]}
+  position.x={5}
+  position.y={5}
+  position.z={10}
+  makeDefault={useControlsCamera}
 >
-  <OrbitControls />
+  <OrbitControls enabled={useControlsCamera} />
 </T.PerspectiveCamera>
+
+<T.AmbientLight intensity={0.5} />
 
 <Sky />
 
-<T.Mesh
-  rotation.x={knotRotation}
-  rotation.z={knotRotation}
+<T
+  is={rotatingCamera}
+  makeDefault={useRotatingCamera}
 >
-  <T.TorusKnotGeometry />
-  <T.MeshStandardMaterial color="orangered" />
-</T.Mesh>
+  <T.Mesh rotation.x={0.5 * Math.PI}>
+    <T.CylinderGeometry
+      args={[0.25 * cameraMeshHeight, 0.5 * cameraMeshHeight, cameraMeshHeight]}
+    />
+    <T.MeshStandardMaterial color="orangered" />
+  </T.Mesh>
+</T>
 
-<T.Mesh
-  position.z={-5}
-  bind:ref={fboPreviewMesh}
-  scale={5}
->
-  <T.PlaneGeometry />
-  <T.MeshStandardMaterial map={renderTarget.texture} />
-</T.Mesh>
+<T is={planeMesh} />
+
+<T is={group}>
+  {#await gltf then { scene }}
+    <T is={scene} />
+  {/await}
+</T>

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
-  import { OrbitControls, Sky, useGltf } from '@threlte/extras'
-  import { Group, Mesh, MeshStandardMaterial, PerspectiveCamera, PlaneGeometry } from 'three'
   import { T, useTask, useThrelte } from '@threlte/core'
-  import { useFBO } from '@threlte/extras'
-
-  let { useRotatingCamera }: { useRotatingCamera: boolean } = $props()
-
-  const useControlsCamera = $derived(!useRotatingCamera)
+  import { OrbitControls, Sky, useFBO, useGltf } from '@threlte/extras'
+  import {
+    CameraHelper,
+    Group,
+    Mesh,
+    MeshStandardMaterial,
+    PerspectiveCamera,
+    PlaneGeometry
+  } from 'three'
 
   const gltf = useGltf('/models/Duck.glb')
 
   const { renderer, scene } = useThrelte()
-  const fbo = useFBO()
+  const fbo = useFBO({
+    size: {
+      width: 1024,
+      height: 2048
+    }
+  })
 
   const group = new Group()
 
@@ -19,7 +26,8 @@
   const cameraRotationRadius = 5
 
   // create the plane and other camera in the script tag so that we don't have to bind to the ref and worry about `undefined` cases
-  const rotatingCamera = new PerspectiveCamera()
+  const rotatingCamera = new PerspectiveCamera(40, 1, 2, 8)
+  const helper = new CameraHelper(rotatingCamera)
 
   const planeMesh = new Mesh(new PlaneGeometry(), new MeshStandardMaterial({ map: fbo.texture }))
   planeMesh.position.setZ(-1 * (cameraMeshHeight + cameraRotationRadius))
@@ -27,20 +35,21 @@
 
   let time = 0
   useTask((delta) => {
-    time += delta
+    time += delta * 0.2
     const c = Math.cos(time)
     const s = Math.sin(time)
     rotatingCamera.position.set(cameraRotationRadius * c, 2 * c * s, cameraRotationRadius * s)
     rotatingCamera.lookAt(group.position)
 
-    const lastVisible = planeMesh.visible
     planeMesh.visible = false
+    helper.visible = false
     const lastRenderTarget = renderer.getRenderTarget()
 
     renderer.setRenderTarget(fbo)
     renderer.render(scene, rotatingCamera)
 
-    planeMesh.visible = lastVisible
+    helper.visible = true
+    planeMesh.visible = true
     renderer.setRenderTarget(lastRenderTarget)
   })
 </script>
@@ -49,9 +58,9 @@
   position.x={5}
   position.y={5}
   position.z={10}
-  makeDefault={useControlsCamera}
+  makeDefault
 >
-  <OrbitControls enabled={useControlsCamera} />
+  <OrbitControls />
 </T.PerspectiveCamera>
 
 <T.AmbientLight />
@@ -60,20 +69,19 @@
 
 <T
   is={rotatingCamera}
-  makeDefault={useRotatingCamera}
->
-  <T.Mesh rotation.x={0.5 * Math.PI}>
-    <T.CylinderGeometry
-      args={[0.25 * cameraMeshHeight, 0.5 * cameraMeshHeight, cameraMeshHeight]}
-    />
-    <T.MeshStandardMaterial color="orangered" />
-  </T.Mesh>
-</T>
+  manual
+/>
+<T
+  is={helper}
+  attach={scene}
+/>
 
 <T is={planeMesh} />
 
 <T is={group}>
-  {#await gltf then { scene }}
-    <T is={scene} />
-  {/await}
+  <T.Group position.y={-1}>
+    {#await gltf then { scene }}
+      <T is={scene} />
+    {/await}
+  </T.Group>
 </T>

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Mesh } from 'three'
+  import type { AmbientLight, Mesh } from 'three'
   import { OrbitControls, Sky, useFBO } from '@threlte/extras'
   import { T, useTask, useThrelte } from '@threlte/core'
 
@@ -44,7 +44,7 @@
   rotation.z={knotRotation}
 >
   <T.TorusKnotGeometry />
-  <T.MeshStandardMaterial />
+  <T.MeshStandardMaterial color="orangered" />
 </T.Mesh>
 
 <T.Mesh

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AmbientLight, Mesh } from 'three'
+  import type { Mesh } from 'three'
   import { OrbitControls, Sky, useFBO } from '@threlte/extras'
   import { T, useTask, useThrelte } from '@threlte/core'
 

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -5,7 +5,7 @@
 
   const { camera, renderer, scene } = useThrelte()
 
-  const renderTarget = useFBO({})
+  const renderTarget = useFBO()
 
   let fboPreviewMesh: Mesh
 
@@ -53,8 +53,5 @@
   scale={5}
 >
   <T.PlaneGeometry />
-  <T.MeshStandardMaterial
-    map={renderTarget.texture}
-    color="#CCFFCC"
-  />
+  <T.MeshStandardMaterial map={renderTarget.texture} />
 </T.Mesh>

--- a/apps/docs/src/examples/extras/use-fbo/Scene.svelte
+++ b/apps/docs/src/examples/extras/use-fbo/Scene.svelte
@@ -5,9 +5,7 @@
 
   const { camera, renderer, scene } = useThrelte()
 
-  const renderTarget = useFBO({
-    samples: 4
-  })
+  const renderTarget = useFBO({})
 
   let fboPreviewMesh: Mesh
 

--- a/packages/extras/src/lib/hooks/useFBO.ts
+++ b/packages/extras/src/lib/hooks/useFBO.ts
@@ -11,12 +11,11 @@ export type UseFBOOptions = RenderTargetOptions & {
    */
   depth?: { width?: number; height?: number } | DepthTexture | boolean
   /**
-   * if set, the render target size will be set to the width and height and not use the size of the canvas
-   * width defaults to 1
-   * height defaults to 1
+   * if set, the render target size will be set to the corresponding width and height and not use or follow the size of the canvas
    */
   dimensions?: { width?: number; height?: number }
 }
+
 export function useFBO({
   depth = false,
   dimensions,

--- a/packages/extras/src/lib/hooks/useFBO.ts
+++ b/packages/extras/src/lib/hooks/useFBO.ts
@@ -7,7 +7,7 @@ import { isInstanceOf, useThrelte, watch } from '@threlte/core'
 
 export type UseFBOOptions = RenderTargetOptions & {
   /**
-   * if set, the scene depth will be rendered into buffer.depthTexture.
+   * if set, the scene depth will be rendered into buffer.depthTexture
    */
   depth?: { width?: number; height?: number } | DepthTexture | boolean
   /**
@@ -16,11 +16,11 @@ export type UseFBOOptions = RenderTargetOptions & {
   dimensions?: { width?: number; height?: number }
 }
 
-export function useFBO({
+export const useFBO = ({
   depth = false,
   dimensions,
   ...targetOptions
-}: UseFBOOptions = {}): WebGLRenderTarget {
+}: UseFBOOptions = {}): WebGLRenderTarget => {
   const target = new WebGLRenderTarget(1, 1, targetOptions)
 
   // first set the width and height because if a depth texture has to be created, it can only have its width and height set in its constructor
@@ -41,8 +41,9 @@ export function useFBO({
   } else if (isInstanceOf(depth, 'DepthTexture')) {
     target.depthTexture = depth
   } else if (depth !== false) {
-    let { width, height } = depth
-    target.depthTexture = new DepthTexture(Math.max(width ?? 1, 1), Math.max(height ?? 1, 1))
+    const width = Math.max(depth.width ?? 1, 1)
+    const height = Math.max(depth.height ?? 1, 1)
+    target.depthTexture = new DepthTexture(width, height)
   }
 
   onDestroy(() => {

--- a/packages/extras/src/lib/hooks/useFBO.ts
+++ b/packages/extras/src/lib/hooks/useFBO.ts
@@ -1,15 +1,9 @@
 /* Based on https://github.com/pmndrs/drei/blob/master/src/core/useFBO.tsx under the MIT License */
 
-import { useThrelte, watch } from '@threlte/core'
+import type { RenderTargetOptions } from 'three'
+import { HalfFloatType, DepthTexture, FloatType, WebGLRenderTarget } from 'three'
 import { onMount } from 'svelte'
-import {
-  type RenderTargetOptions,
-  WebGLRenderTarget,
-  LinearFilter,
-  HalfFloatType,
-  DepthTexture,
-  FloatType
-} from 'three'
+import { useThrelte, watch } from '@threlte/core'
 
 type UseFBOOptions = RenderTargetOptions & {
   /**
@@ -24,25 +18,22 @@ export function useFBO(
   width: number | UseFBOOptions = {},
   /** Height in pixels */
   height?: number,
-  /** Options */
+  /** Options that are passed to the  */
   options?: UseFBOOptions
 ): WebGLRenderTarget {
   const { dpr, size } = useThrelte()
 
   const _width = typeof width === 'number' ? width : Math.max(dpr.current, 1)
   const _height = typeof height === 'number' ? height : Math.max(dpr.current, 1)
+
   const {
     samples = 0,
     depth = false,
-    minFilter = LinearFilter,
-    magFilter = LinearFilter,
     type = HalfFloatType,
     ...targetOptions
   } = typeof width === 'number' ? options ?? {} : width
 
   const target = new WebGLRenderTarget(_width, _height, {
-    minFilter,
-    magFilter,
     type,
     ...targetOptions
   })
@@ -54,7 +45,7 @@ export function useFBO(
   target.samples = samples
 
   onMount(() => {
-    if (samples) target.samples = samples
+    if (samples > 0) target.samples = samples
     return () => target.dispose()
   })
 

--- a/packages/extras/src/lib/hooks/useFBO.ts
+++ b/packages/extras/src/lib/hooks/useFBO.ts
@@ -1,5 +1,3 @@
-/* Based on https://github.com/pmndrs/drei/blob/master/src/core/useFBO.tsx under the MIT License */
-
 import type { RenderTargetOptions } from 'three'
 import { DepthTexture, WebGLRenderTarget } from 'three'
 import { onDestroy } from 'svelte'
@@ -13,26 +11,26 @@ export type UseFBOOptions = RenderTargetOptions & {
   /**
    * if set, the render target size will be set to the corresponding width and height and not use or follow the size of the canvas
    */
-  dimensions?: { width?: number; height?: number }
+  size?: { width?: number; height?: number }
 }
 
 export const useFBO = ({
   depth = false,
-  dimensions,
+  size,
   ...targetOptions
 }: UseFBOOptions = {}): WebGLRenderTarget => {
   const target = new WebGLRenderTarget(1, 1, targetOptions)
 
   // first set the width and height because if a depth texture has to be created, it can only have its width and height set in its constructor
-  if (dimensions === undefined) {
+  if (size === undefined) {
     const { dpr, size } = useThrelte()
     watch([dpr, size], ([dpr, { width, height }]) => {
       target.setSize(dpr * width, dpr * height)
     })
   } else {
     // handle when width and height are undefined or the user set them to negative numbers
-    const width = Math.max(dimensions.width ?? 1, target.width)
-    const height = Math.max(dimensions.height ?? 1, target.height)
+    const width = Math.max(size.width ?? 1, target.width)
+    const height = Math.max(size.height ?? 1, target.height)
     target.setSize(width, height)
   }
 


### PR DESCRIPTION
This is a rewrite of `useFBO` that adds functionality, improves readability of the implementation, and adds to the docs to be more comprehensive.

`useFBO`'s signature is now

```typescript
export type UseFBOOptions = RenderTargetOptions & {
  /**
   * if set, the scene depth will be rendered into buffer.depthTexture.
   */
  depth?: { width?: number; height?: number } | DepthTexture | boolean
  /**
   * if set, the render target size will be set to the corresponding width and height and not use or follow the size of the canvas
   */
  dimensions?: { width?: number; height?: number }
}

export function useFBO({
  depth = false,
  dimensions,
  ...targetOptions
}: UseFBOOptions = {}): WebGLRenderTarget {
```

depth is now allowed to be either a boolean, depth texture, or dimensions object and `useFBO` handles each case according to what's described in the .mdx file.

the implementation of useFBO has been modified to be more readable and traceable. The old implementation was a very close 1:1 with drei's useFBO and i think deviating from there yields a more interesting and useful hook.

The corresponding mdx file has been modified to account for all the various uses of `useFBO`. It now contains many code snippets as examples are usually more explicit than docs.

The example has been rewritten to be more simple while retaining its original intent and goal.