### PR TITLE
[next] AsciiRenderer docs update

### DIFF
--- a/.changeset/brown-dryers-exist.md
+++ b/.changeset/brown-dryers-exist.md
@@ -1,0 +1,5 @@
+---
+"@threlte/docs": patch
+---
+
+[next] AsciiRenderer docs update

--- a/apps/docs/src/content/reference/extras/ascii-renderer.mdx
+++ b/apps/docs/src/content/reference/extras/ascii-renderer.mdx
@@ -83,7 +83,7 @@ componentSignature:
   }
 ---
 
-A wrapper around Three's AsciiRenderer addon. It replaces the main render function with a function that renders the scene to an HTML table and overlays it on top of the canvas. Areas with a higher "brightness" are mapped to characters that appear "fuller".
+A wrapper around Three's [AsciiEffect](https://github.com/timoxley/threejs/blob/master/examples/js/effects/AsciiEffect.js) addon. It replaces the main render function with a function that renders the scene to an HTML table and overlays it on top of the canvas. Areas with a higher "brightness" are mapped to characters that appear "fuller".
 
 <Example path="extras/ascii-renderer/basic" />
 


### PR DESCRIPTION
clarify that it is a wrapper for Ascii**Effect**. threejs has no Ascii**Renderer**