### PR TITLE
fix: remove .d.ts import from dist/index.js

### DIFF
--- a/.changeset/cool-masks-own.md
+++ b/.changeset/cool-masks-own.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+fix: remove .d.ts import from dist/index.js

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,13 +68,23 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
-      "svelte": "./dist/index.js"
+      "types": "./src/lib/index.ts",
+      "svelte": "./src/lib/index.ts"
     }
   },
-  "types": "./dist/types.d.ts",
-  "svelte": "./dist/index.js",
-  "files": [
-    "dist"
-  ]
+  "types": "./src/lib/index.ts",
+  "svelte": "./src/lib/index.ts",
+  "publishOverrides": {
+    "files": [
+      "dist"
+    ],
+    "svelte": "./dist/index.js",
+    "exports": {
+      ".": {
+        "types": "./dist/types.d.ts",
+        "svelte": "./dist/index.js"
+      }
+    },
+    "types": "./dist/types.d.ts"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,23 +68,13 @@
   },
   "exports": {
     ".": {
-      "types": "./src/lib/index.ts",
-      "svelte": "./src/lib/index.ts"
+      "types": "./dist/types.d.ts",
+      "svelte": "./dist/index.js"
     }
   },
-  "types": "./src/lib/index.ts",
-  "svelte": "./src/lib/index.ts",
-  "publishOverrides": {
-    "files": [
-      "dist"
-    ],
-    "svelte": "./dist/index.js",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "svelte": "./dist/index.js"
-      }
-    },
-    "types": "./dist/index.d.ts"
-  }
+  "types": "./dist/types.d.ts",
+  "svelte": "./dist/index.js",
+  "files": [
+    "dist"
+  ]
 }

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,5 +1,3 @@
-import './types.d.ts'
-
 export const VERSION = 8
 
 // canvas component

--- a/packages/core/src/lib/types.d.ts
+++ b/packages/core/src/lib/types.d.ts
@@ -1,10 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-declare namespace Threlte {
-  interface UserProps {
-    // User can extend with custom props here
-  }
-  interface UserCatalogue {
-    // User can the <T> catalogue here
+declare global {
+  namespace Threlte {
+    interface UserProps {
+      // User can extend with custom props here
+    }
+    interface UserCatalogue {
+      // User can the <T> catalogue here
+    }
   }
 }
+
+export * from './index'


### PR DESCRIPTION
Implements the suggestion in #1242 (albeit only for `@threlte/core` — not sure if it would also need to happen in other places?)