### PR TITLE
[next] provide way to start/stop html render task and a way to render on demand

### DIFF
--- a/.changeset/fair-pandas-drum.md
+++ b/.changeset/fair-pandas-drum.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": minor
+---
+
+adds ability to start and stop HTML's render task. exposes the render task for rendering a single frame

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -51,7 +51,7 @@ componentSignature:
         { name: 'as', type: 'keyof HTMLElementTagNameMap', default: "'div'", required: false },
         { name: 'portal', type: 'HTMLElement', default: 'undefined', required: false },
         { name: 'castShadow', type: 'boolean', default: 'undefined', required: false },
-        { name: 'recieveShadow', type: 'boolean', default: 'undefined', required: false },
+        { name: 'receiveShadow', type: 'boolean', default: 'undefined', required: false },
         { name: 'material', type: 'THREE.Material', default: 'undefined', required: false },
         { name: 'geometry', type: 'THREE.BufferGeoemtry', default: 'undefined', required: false },
         {
@@ -77,9 +77,68 @@ The container of your `<Canvas>` component needs to be set to `position: relativ
 
 <Example path="extras/html/basic" />
 
-`<HTML> also exports it's internal render task and the `start`and`stop` functions so you can either render on demand or start and stop the internal task at your will.
+\<HTML> also exports it's internal render task and the `startRendering`, `stopRendering`, and `render` functions so you can either render on demand or start and stop the internal task at your will.
 
-TODO: add "on-demand" example below
+```svelte title="Render-On-Demand"
+<script>
+  let html = $state()
+
+  $effect(() => {
+    // if (shouldRender) {
+    html?.render()
+    // }
+  })
+</script>
+
+<HTML
+  autoRender={false}
+  bind:this={html}
+>
+  <h1>Hello World</h1>
+</HTML>
+```
+
+```svelte title="Start-And-Stop-Rendering"
+<script>
+  let html = $state()
+
+  // turn this on and off in accordance with your application
+  let renderWhileTrue = $state(false)
+
+  $effect(() => {
+    if (html !== undefined) {
+      if (renderWhileTrue) {
+        html.startRendering()
+        // always stop rendering if it was started
+        return () => {
+          html.stopRendering()
+        }
+      }
+    }
+  })
+</script>
+
+<HTML
+  autoRender={false}
+  bind:this={html}
+>
+  <h1>Hello World</h1>
+</HTML>
+```
+
+In both cases you should set `autonRender` to false so that the render task doesn't automatically begin.
+
+Lastly, you can access these functions from the `<HTML>`'s children snippet.
+
+```svelte
+<HTML>
+  {#snippet children({ render, startRendering, stopRendering })}
+		<button onclick={startRendering}>start rendering</button>
+		<button onclick={stopRendering}>stop rendering</button>
+		<button onclick={render}>render a single frame</button>
+	{/render}
+</HTML>
+```
 
 ### Examples
 

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -130,7 +130,7 @@ The container of your `<Canvas>` component needs to be set to `position: relativ
 </HTML>
 ```
 
-In both cases you should set `autonRender` to false so that the render task doesn't automatically begin.
+In both cases you should set `autoRender` to `false` so that the render task doesn't automatically begin.
 
 Lastly, you can access these functions from the `<HTML>`'s children snippet.
 
@@ -144,9 +144,9 @@ Lastly, you can access these functions from the `<HTML>`'s children snippet.
 </HTML>
 ```
 
-### Examples
+## Examples
 
-#### Basic Example
+### Basic Example
 
 ```svelte
 <script lang="ts">
@@ -158,7 +158,7 @@ Lastly, you can access these functions from the `<HTML>`'s children snippet.
 </HTML>
 ```
 
-#### Transform
+### Transform
 
 `transform` applies matrix3d transformations.
 
@@ -172,7 +172,7 @@ Lastly, you can access these functions from the `<HTML>`'s children snippet.
 </HTML>
 ```
 
-#### Occlude
+### Occlude
 
 `<Html>` can be occluded behind geometry using the occlude `occlude` property.
 
@@ -199,7 +199,7 @@ like `<OrbitControls>` do this automatically.
 
 <Example path="extras/html/phone" />
 
-#### Visibility Change Event
+### Visibility Change Event
 
 Use the property `occlude` and bind to the event `visibilitychange` to implement a custom hide/show behaviour.
 
@@ -225,7 +225,7 @@ Use the property `occlude` and bind to the event `visibilitychange` to implement
 When binding to the event `visibilitychange` the contents of `<HTML>` is _not_ automatically hidden when it's occluded.
 </Tip>
 
-#### Sprite Rendering
+### Sprite Rendering
 
 Use the property `sprite` in `transform` mode to render the contents of `<HTML>` as a sprite.
 
@@ -242,7 +242,7 @@ Use the property `sprite` in `transform` mode to render the contents of `<HTML>`
 </HTML>
 ```
 
-#### Center
+### Center
 
 Add a -50%/-50% css transform with `center` when _not_ in `transform` mode.
 
@@ -256,7 +256,7 @@ Add a -50%/-50% css transform with `center` when _not_ in `transform` mode.
 </HTML>
 ```
 
-#### Portal
+### Portal
 
 Use the property `portal` to mount the contents of the `<HTML>` component on another `HTMLElement`.
 By default the contents are mounted as a sibling to the rendering `<canvas>`.

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -9,8 +9,12 @@ componentSignature:
     extends: { type: 'Group', url: 'https://threejs.org/docs/index.html#api/en/objects/Group' },
     exports:
       [
-        { name: 'start', type: '() => void', description: 'Manually start the render task' },
-        { name: 'stop', type: '() => void', description: 'Manually stop the render task' },
+        {
+          name: 'startRendering',
+          type: '() => void',
+          description: 'Manually start the render task'
+        },
+        { name: 'stopRendering', type: '() => void', description: 'Manually stop the render task' },
         {
           description: 'renders a single frame of the provided html',
           name: 'render',
@@ -77,9 +81,9 @@ The container of your `<Canvas>` component needs to be set to `position: relativ
 
 <HTML> has an `autoRender` prop that you can use to turn off and on its render task. If at some point in your application, you no longer need to update the hmtl, you can set `autoRender` to `false`. If you need to resume the task, set `autoRender` back to `true`.
 
-\<HTML> also exports it's internal render task and the `startRendering`, `stopRendering`, and `render` functions so you can either render on demand or start and stop the internal task at your will.
+\<HTML> also exports it's internal render task and the `startRendering`, `stopRendering`, and `render` functions so you can either manually render the html or start and stop the internal task at your will.
 
-```svelte title="Render-On-Demand"
+```svelte title="Manually-Rendering"
 <script>
   let html = $state()
 

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -7,6 +7,16 @@ type: 'component'
 componentSignature:
   {
     extends: { type: 'Group', url: 'https://threejs.org/docs/index.html#api/en/objects/Group' },
+    exports:
+      [
+        { name: 'start', type: '() => void', description: 'Manually start the render task' },
+        { name: 'stop', type: '() => void', description: 'Manually stop the render task' },
+        {
+          description: 'renders a single frame of the provided html',
+          name: 'render',
+          type: '() => void'
+        }
+      ],
     props:
       [
         { name: 'transform', type: 'boolean', default: 'false', required: false },

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -71,11 +71,11 @@ This component is a port of [drei's `<Html>` component](https://github.com/pmndr
 The container of your `<Canvas>` component needs to be set to `position: relative | absolute | sticky | fixed`. This is because the DOM element will be mounted as a sibling to the `<canvas>` element.
 </Tip>
 
+<Example path="extras/html/basic" />
+
 ## Stopping and Starting the Task
 
-\<HTML> has an `autoRender` prop that you can use to turn off and on its render task. If at some point in your application, you no longer need to update the hmtl, you can set `autoRender` to `false`. If you need to resume the task, set `autoRender` back to `true`.
-
-<Example path="extras/html/basic" />
+<HTML> has an `autoRender` prop that you can use to turn off and on its render task. If at some point in your application, you no longer need to update the hmtl, you can set `autoRender` to `false`. If you need to resume the task, set `autoRender` back to `true`.
 
 \<HTML> also exports it's internal render task and the `startRendering`, `stopRendering`, and `render` functions so you can either render on demand or start and stop the internal task at your will.
 

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -131,12 +131,12 @@ In both cases you should set `autonRender` to false so that the render task does
 Lastly, you can access these functions from the `<HTML>`'s children snippet.
 
 ```svelte
-<HTML>
+<HTML autoRender={false}>
   {#snippet children({ render, startRendering, stopRendering })}
-		<button onclick={startRendering}>start rendering</button>
-		<button onclick={stopRendering}>stop rendering</button>
-		<button onclick={render}>render a single frame</button>
-	{/render}
+    <button onclick={startRendering}>start rendering</button>
+    <button onclick={stopRendering}>stop rendering</button>
+    <button onclick={render}>render a single frame</button>
+  {/snippet}
 </HTML>
 ```
 

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -43,7 +43,14 @@ componentSignature:
         { name: 'castShadow', type: 'boolean', default: 'undefined', required: false },
         { name: 'recieveShadow', type: 'boolean', default: 'undefined', required: false },
         { name: 'material', type: 'THREE.Material', default: 'undefined', required: false },
-        { name: 'geometry', type: 'THREE.BufferGeoemtry', default: 'undefined', required: false }
+        { name: 'geometry', type: 'THREE.BufferGeoemtry', default: 'undefined', required: false },
+        {
+          name: 'autoRender',
+          type: 'boolean',
+          default: 'true',
+          required: false,
+          description: 'whether the render task should be ran every frame'
+        }
       ]
   }
 ---
@@ -54,7 +61,15 @@ This component is a port of [drei's `<Html>` component](https://github.com/pmndr
 The container of your `<Canvas>` component needs to be set to `position: relative | absolute | sticky | fixed`. This is because the DOM element will be mounted as a sibling to the `<canvas>` element.
 </Tip>
 
+## Stopping and Starting the Task
+
+\<HTML> has an `autoRender` prop that you can use to turn off and on its render task. If at some point in your application, you no longer need to update the hmtl, you can set `autoRender` to `false`. If you need to resume the task, set `autoRender` back to `true`.
+
 <Example path="extras/html/basic" />
+
+`<HTML> also exports it's internal render task and the `start`and`stop` functions so you can either render on demand or start and stop the internal task at your will.
+
+TODO: add "on-demand" example below
 
 ### Examples
 
@@ -66,7 +81,7 @@ The container of your `<Canvas>` component needs to be set to `position: relativ
 </script>
 
 <HTML>
-  <h1>Hello World</h1>
+  <h1>Hello, World!</h1>
 </HTML>
 ```
 
@@ -104,7 +119,7 @@ The container of your `<Canvas>` component needs to be set to `position: relativ
 Setting `occlude` to `"blending"` will allow objects to partially occlude the `<HTML>` component.
 
 <Tip type="warning">
-This occlusion mode requires the `<canvas>` element to have `pointer-events` set to `none`. 
+This occlusion mode requires the `<canvas>` element to have `pointer-events` set to `none`.
 Therefore, any events like those in `OrbitControls` must be set on the canvas parent. Extras components
 like `<OrbitControls>` do this automatically.
 </Tip>

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -79,9 +79,9 @@ The container of your `<Canvas>` component needs to be set to `position: relativ
 
 ## Stopping and Starting the Task
 
-<HTML> has an `autoRender` prop that you can use to turn off and on its render task. If at some point in your application, you no longer need to update the hmtl, you can set `autoRender` to `false`. If you need to resume the task, set `autoRender` back to `true`.
+`<HTML>` has an `autoRender` prop that you can use to turn off and on its render task. If at some point in your application, you no longer need to update the hmtl, you can set `autoRender` to `false`. If you need to resume the task, set `autoRender` back to `true`.
 
-\<HTML> also exports it's internal render task and the `startRendering`, `stopRendering`, and `render` functions so you can either manually render the html or start and stop the internal task at your will.
+`<HTML>` also exports it's internal render task and the `startRendering`, `stopRendering`, and `render` functions so you can either manually render the html or start and stop the internal task at your will.
 
 ```svelte title="Manually-Rendering"
 <script>

--- a/apps/docs/src/examples/extras/html/basic/App.svelte
+++ b/apps/docs/src/examples/extras/html/basic/App.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
-  import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
+  import { Canvas } from '@threlte/core'
+  import { Checkbox, Pane } from 'svelte-tweakpane-ui'
+
+  let autoRender = $state(true)
 </script>
+
+<Pane position="fixed">
+  <Checkbox
+    label="auto render"
+    bind:value={autoRender}
+  />
+</Pane>
 
 <div>
   <Canvas>
-    <Scene />
+    <Scene {autoRender} />
   </Canvas>
 </div>
 

--- a/apps/docs/src/examples/extras/html/basic/Scene.svelte
+++ b/apps/docs/src/examples/extras/html/basic/Scene.svelte
@@ -4,6 +4,12 @@
   import { spring } from 'svelte/motion'
   import { DEG2RAD } from 'three/src/math/MathUtils.js'
 
+  type Props = {
+    autoRender?: boolean
+  }
+
+  let { autoRender = true }: Props = $props()
+
   const getRandomColor = () =>
     `#${Math.floor(Math.random() * 16777215)
       .toString(16)
@@ -50,6 +56,7 @@
     position.y={1.25}
     position.z={$htmlPosZ}
     transform
+    {autoRender}
   >
     <button
       onpointerenter={() => (isHovering = true)}
@@ -76,6 +83,7 @@
     position.x={0.75}
     transform
     pointerEvents="none"
+    {autoRender}
   >
     <p
       class="w-auto translate-x-1/2 text-xs drop-shadow-lg"

--- a/apps/docs/src/examples/extras/html/phone/RoundedPlaneGeometry.ts
+++ b/apps/docs/src/examples/extras/html/phone/RoundedPlaneGeometry.ts
@@ -17,8 +17,6 @@ export class RoundedPlaneGeometry extends BufferGeometry {
       segments
     }
 
-    console.log(width, height)
-
     // helper consts
     const wi = width / 2 - radius // inner width
     const hi = height / 2 - radius // inner height

--- a/packages/extras/src/lib/components/AsciiRenderer/AsciiRenderer.svelte
+++ b/packages/extras/src/lib/components/AsciiRenderer/AsciiRenderer.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { AsciiRendererProps } from './types'
   import { AsciiEffect } from 'three/examples/jsm/Addons.js'
-  import { observe, useTask, useThrelte } from '@threlte/core'
   import { fromStore } from 'svelte/store'
+  import { useTask, useThrelte } from '@threlte/core'
 
   const defaultCharacters = ' .:-+*=%@#'
 
@@ -88,6 +88,7 @@
     if (autoRender) {
       start()
       return () => {
+        // this should stop the task on unmount as well
         stop()
       }
     }
@@ -98,8 +99,6 @@
     threlteAutoRender.set(!autoRender)
     return () => {
       threlteAutoRender.set(lastAutoRender)
-      // be sure to turn off the task if the component is destroyed
-      stop()
     }
   })
 </script>

--- a/packages/extras/src/lib/components/AsciiRenderer/AsciiRenderer.svelte
+++ b/packages/extras/src/lib/components/AsciiRenderer/AsciiRenderer.svelte
@@ -84,19 +84,17 @@
     onstop?.()
   }
 
-  observe.pre(
-    () => [autoRender],
-    ([autoRender]) => {
-      if (autoRender) {
-        start()
-      } else {
+  $effect(() => {
+    if (autoRender) {
+      start()
+      return () => {
         stop()
       }
     }
-  )
+  })
 
   $effect(() => {
-    let lastAutoRender = threlteAutoRender.current
+    const lastAutoRender = threlteAutoRender.current
     threlteAutoRender.set(!autoRender)
     return () => {
       threlteAutoRender.set(lastAutoRender)

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -256,7 +256,17 @@
     }
   }
 
-  export const { start, stop } = useTask(render, { autoStart: false })
+  export const { start: startRendering, stop: stopRendering } = useTask(render, {
+    autoStart: false
+  })
+  $effect(() => {
+    if (autoRender) {
+      startRendering()
+      return () => {
+        stopRendering()
+      }
+    }
+  })
 
   let pos = $derived.by(() => {
     scene.updateMatrixWorld()
@@ -274,15 +284,6 @@
       destroy: () => el.remove()
     }
   }
-
-  $effect(() => {
-    if (autoRender) {
-      start()
-      return () => {
-        stop()
-      }
-    }
-  })
 </script>
 
 <T
@@ -353,7 +354,7 @@
           class={props.class}
           style={props.style}
         >
-          {@render children?.()}
+          {@render children?.({ render, startRendering, stopRendering })}
         </div>
       </div>
     </div>
@@ -368,7 +369,7 @@
       style={props.style}
       class={props.class}
     >
-      {@render children?.()}
+      {@render children?.({ render, startRendering, stopRendering })}
     </div>
   {/if}
 </svelte:element>

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -56,6 +56,7 @@
   import type { HTMLProps } from './types'
 
   let {
+    autoRender = true,
     eps = 0.001,
     center = false,
     fullscreen = false,
@@ -124,7 +125,7 @@
     }
   })
 
-  useTask(() => {
+  export const render = () => {
     camera.current.updateMatrixWorld()
     group.updateWorldMatrix(true, false)
     const vec = transform ? oldPosition : calculatePosition(group, camera.current, $size)
@@ -253,7 +254,9 @@
         occlusionMesh.lookAt(camera.current.position)
       }
     }
-  })
+  }
+
+  export const { start, stop } = useTask(render, { autoStart: false })
 
   let pos = $derived.by(() => {
     scene.updateMatrixWorld()
@@ -271,6 +274,15 @@
       destroy: () => el.remove()
     }
   }
+
+  $effect(() => {
+    if (autoRender) {
+      start()
+      return () => {
+        stop()
+      }
+    }
+  })
 </script>
 
 <T

--- a/packages/extras/src/lib/components/HTML/types.ts
+++ b/packages/extras/src/lib/components/HTML/types.ts
@@ -1,7 +1,10 @@
 import type { Props } from '@threlte/core'
 import type { Camera, Group, Object3D } from 'three'
 
-export type HTMLProps = Props<Group, []> & {
+export type HTMLProps = Props<
+  Group,
+  [{ render(): void; startRendering(): void; stopRendering(): void }]
+> & {
   /**
    * @default true
    */

--- a/packages/extras/src/lib/components/HTML/types.ts
+++ b/packages/extras/src/lib/components/HTML/types.ts
@@ -3,6 +3,11 @@ import type { Camera, Group, Object3D } from 'three'
 
 export type HTMLProps = Props<Group, []> & {
   /**
+   * @default true
+   */
+  autoRender?: boolean
+
+  /**
    * @default false
    */
   transform?: boolean

--- a/packages/extras/src/lib/hooks/useGamepad.ts
+++ b/packages/extras/src/lib/hooks/useGamepad.ts
@@ -444,7 +444,7 @@ export function useGamepad(options: UseGamepadOptions = {}) {
     const processSnapshot = () => {
       /**
        * getGamepads() will return a snapshot of a gamepad that will never change,
-       * so it must be polled continuously to recieve new values.
+       * so it must be polled continuously to receive new values.
        */
       const pad = navigator.getGamepads()[gamepadIndex]
       gamepad.raw = pad


### PR DESCRIPTION
closes #1262 

~~i want to add an example for rendering on demand so i will undraft when i have that working.~~

i couldn't think of a good example

---

includes minor changes to `<AsciiRenderer>` - just using an $effect instead of an observe.