### PR TITLE
[next](docs-useTexture) change examples around and simplify usage section

### DIFF
--- a/.changeset/breezy-tomatoes-smile.md
+++ b/.changeset/breezy-tomatoes-smile.md
@@ -1,0 +1,5 @@
+---
+"@threlte/docs": patch
+---
+
+modify useTexture docs. examples use svelte 5 effects, simplify `usage` section and modify headings

--- a/apps/docs/src/content/reference/extras/use-texture.mdx
+++ b/apps/docs/src/content/reference/extras/use-texture.mdx
@@ -8,47 +8,49 @@ type: 'hook'
 
 `useTexture` is a convenience hook wrapping
 [`useLoader`](/docs/reference/core/hooks#useloader) that returns an
-[`AsyncWritable`](/docs/reference/core/utilities#asyncwritable) store populated
+[`AsyncWritable`](/docs/reference/core/utilities#asyncwritable) store that is eventually populated
 with a `THREE.Texture`. The texture is automatically assigned the
 [`colorSpace`](https://threejs.org/docs/#api/en/textures/Texture.colorSpace)
 that the renderer uses.
 
 ## Usage
 
-The [`AsyncWritable`](/docs/reference/core/utilities#asyncwritable) returned
-from `useTexture` can be used as a store and a promise at the same time. You can
-`await` it or use it as any other store.
+### Basic Example
 
 ```svelte
 <script>
   import { T } from '@threlte/core'
   import { useTexture } from '@threlte/extras'
 
-  const map = useTexture('texture.png')
+  const texture = useTexture('texture.png')
 
-  $: console.log($map) // eventually THREE.Texture
+  texture.then(() => {
+    console.log('texture has loaded')
+  })
+
+  $inspect($texture) // eventually a Three.Texture
 </script>
 
-{#await map then value}
+{#await texture then map}
   <T.Mesh>
     <T.SphereGeometry />
-    <T.MeshBasicMaterial map={value} />
+    <T.MeshBasicMaterial {map} />
   </T.Mesh>
 {/await}
 ```
 
-## Transforming the Texture
+### Transforming the Texture
 
 You can pass a `transform` function to transform the texture **once** its
 loaded.
 
 ```svelte
 <script>
+  import { RepeatWrapping } from 'three'
   import { T } from '@threlte/core'
   import { useTexture } from '@threlte/extras'
-  import { RepeatWrapping } from 'three'
 
-  const map = useTexture('texture.png', {
+  const texture = useTexture('texture.png', {
     transform: (texture) => {
       texture.wrapS = RepeatWrapping
       texture.wrapT = RepeatWrapping
@@ -58,10 +60,10 @@ loaded.
   })
 </script>
 
-{#await map then value}
+{#await texture then map}
   <T.Mesh>
     <T.SphereGeometry />
-    <T.MeshBasicMaterial map={value} />
+    <T.MeshBasicMaterial {map} />
   </T.Mesh>
 {/await}
 ```


### PR DESCRIPTION
- remove a `$: `
- remove redundant "returns an AsyncWritable"
- change heading levels for more navigation
- add  `.then` to example for further demonstrate
- change name of variable to `texture` so that we can call it `map` in the template