### PR TITLE
[next]Xr teleport example svelte 5

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -76,7 +76,6 @@
     "runed": "^0.15.3",
     "sharp": "^0.31.3",
     "shiki": "^0.14.3",
-    "simplex-noise": "^4.0.1",
     "svelte": "^5.14.4",
     "svelte-portal": "^2.2.1",
     "svelte-preprocess": "^5.1.3",

--- a/apps/docs/src/components/Example/stackblitz-files/stackblitz-package.json
+++ b/apps/docs/src/components/Example/stackblitz-files/stackblitz-package.json
@@ -29,7 +29,6 @@
     "three": "*",
     "tslib": "*",
     "typescript": "*",
-    "vite": "*",
-    "simplex-noise": "^4.0.1"
+    "vite": "*"
   }
 }

--- a/apps/docs/src/examples/xr/teleport-controls/App.svelte
+++ b/apps/docs/src/examples/xr/teleport-controls/App.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { Canvas } from '@threlte/core'
-  import { VRButton } from '@threlte/xr'
   import Scene from './Scene.svelte'
+  import { Canvas } from '@threlte/core'
   import { Pane, Checkbox } from 'svelte-tweakpane-ui'
+  import { VRButton } from '@threlte/xr'
 
-  let showSurfaces = false
-  let showBlockers = false
+  let showSurfaces = $state(false)
+  let showBlockers = $state(false)
 </script>
 
 <Pane

--- a/apps/docs/src/examples/xr/teleport-controls/Surfaces.svelte
+++ b/apps/docs/src/examples/xr/teleport-controls/Surfaces.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte'
   import { T } from '@threlte/core'
   import { teleportControls } from '@threlte/xr'
   import { useDraco, useGltf } from '@threlte/extras'
 
-  export let showSurfaces: boolean
-  export let showBlockers: boolean
+  type Props = {
+    children?: Snippet
+    showBlockers: boolean
+    showSurfaces: boolean
+  }
+
+  let { children, showBlockers, showSurfaces }: Props = $props()
 
   teleportControls('left')
   teleportControls('right')
@@ -15,12 +21,12 @@
   })
 </script>
 
-<slot />
+{@render children?.()}
 
-{#if $gltf}
+{#await gltf then { nodes }}
   {#each [1, 2, 3, 4, 5, 6, 7, 8, 9] as n}
     <T
-      is={$gltf.nodes[`teleportBlocker${n}`]}
+      is={nodes[`teleportBlocker${n}`]}
       visible={showBlockers}
       teleportBlocker
     />
@@ -28,9 +34,9 @@
 
   {#each [1, 2, 3] as n}
     <T
-      is={$gltf.nodes[`teleportSurface${n}`]}
+      is={nodes[`teleportSurface${n}`]}
       visible={showSurfaces}
       teleportSurface
     />
   {/each}
-{/if}
+{/await}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,9 +207,6 @@ importers:
       shiki:
         specifier: ^0.14.3
         version: 0.14.3
-      simplex-noise:
-        specifier: ^4.0.1
-        version: 4.0.1
       svelte:
         specifier: ^5.14.4
         version: 5.14.4
@@ -7157,9 +7154,6 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  simplex-noise@4.0.1:
-    resolution: {integrity: sha512-zl/+bdSqW7HJOQ0oDbxrNYaF4F5ik0i7M6YOYmEoIJNtg16NpvWaTTM1Y7oV/7T0jFljawLgYPS81Uu2rsfo1A==}
-
   sirv@3.0.0:
     resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
     engines: {node: '>=18'}
@@ -12101,7 +12095,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.45.0(eslint@9.0.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@9.0.0)):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.45.0(eslint@9.0.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1):
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
@@ -12120,7 +12114,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.0.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.45.0(eslint@9.0.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@9.0.0))
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.45.0(eslint@9.0.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -15846,8 +15840,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-
-  simplex-noise@4.0.1: {}
 
   sirv@3.0.0:
     dependencies:


### PR DESCRIPTION
- convert to svelte 5
- uses more `$derived`s and effects to keep the use task callback very minimal

this is the last example that used the simplex-noise package so i've removed that from `package.json`.