### PR TITLE
[next] <Backdrop> component

### DIFF
--- a/apps/docs/src/content/reference/extras/backdrop.mdx
+++ b/apps/docs/src/content/reference/extras/backdrop.mdx
@@ -1,0 +1,60 @@
+---
+order: 7.32
+category: '@threlte/extras'
+name: '<Backdrop>'
+sourcePath: 'packages/extras/src/lib/components/Backdrop/Backdrop.svelte'
+type: 'component'
+componentSignature:
+  {
+    extends: { type: 'Group', url: 'https://threejs.org/docs/index.html#api/en/objects/Group' },
+    props:
+      [
+        {
+          name: 'floor',
+          type: 'number',
+          default: '0.25',
+          description: 'length of the floor segment',
+          required: false
+        },
+        {
+          name: 'receiveShadow',
+          type: 'boolean',
+          default: 'false',
+          description: 'whether the backdrop is to receive shadows',
+          required: false
+        },
+        {
+          name: 'segments',
+          type: 'number',
+          default: '20',
+          description: "resolution of the backdrop's geometry",
+          required: false
+        }
+      ]
+  }
+---
+
+A mesh of a curved plane designed to look like a studio backdrop. Its intent is to break up light and shadows in more interesting ways.
+
+<Example path="extras/backdrop" />
+
+Children are "slotted" into the underlying mesh so you can set the material of the backdrop like so:
+
+```svelte
+<Backdrop>
+  <T.MeshStandardMaterial color="#ffffdd" />
+</Backdrop>
+```
+
+## Props
+
+`floor` controls the length of the "floor" segment of the geometry. The higher the value, the longer the segment.
+
+`receiveShadow` controls whether the mesh receives shadows or not.
+
+`segments` controls the resolution of the mesh.
+
+<Tip type="warning">
+  Be aware that updating the `segments` prop causes the geometry to be rebuilt. It's advised not to
+  update `segments` in hot-code paths such as [`useTask()`](/docs/reference/core/use-task).
+</Tip>

--- a/apps/docs/src/examples/extras/backdrop/App.svelte
+++ b/apps/docs/src/examples/extras/backdrop/App.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import Scene from './Scene.svelte'
+  import { Canvas } from '@threlte/core'
+  import { Checkbox, Color, Folder, Slider, Pane } from 'svelte-tweakpane-ui'
+
+  let floor = $state(0.25)
+  let receiveShadow = $state(true)
+  let segments = $state(20)
+
+  let materialColor = $state('#ffffff')
+  let materialWireframe = $state(false)
+
+  let lightHelperVisible = $state(true)
+</script>
+
+<Pane
+  position="fixed"
+  title="backdrop"
+>
+  <Folder title="backdrop props">
+    <Slider
+      bind:value={floor}
+      min={0}
+      max={1}
+      step={0.25}
+      label="floor"
+    />
+    <Checkbox
+      bind:value={receiveShadow}
+      label="receive shadow"
+    />
+    <Slider
+      min={10}
+      max={50}
+      step={10}
+      bind:value={segments}
+      label="segments"
+    />
+  </Folder>
+  <Folder title="material props">
+    <Color
+      bind:value={materialColor}
+      label="color"
+    />
+    <Checkbox
+      label="wireframe"
+      bind:value={materialWireframe}
+    />
+  </Folder>
+  <Folder title="light helper">
+    <Checkbox
+      label="visible"
+      bind:value={lightHelperVisible}
+    />
+  </Folder>
+</Pane>
+
+<div>
+  <Canvas>
+    <Scene
+      {floor}
+      {materialColor}
+      {materialWireframe}
+      {receiveShadow}
+      {segments}
+      {lightHelperVisible}
+    />
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/extras/backdrop/Scene.svelte
+++ b/apps/docs/src/examples/extras/backdrop/Scene.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import type { BackdropProps } from '@threlte/extras'
+  import type { TransformControls as ThreeTransformControls } from 'three/examples/jsm/Addons.js'
+  import type {
+    ColorRepresentation,
+    DirectionalLight,
+    DirectionalLightHelper,
+    Mesh,
+    MeshStandardMaterial
+  } from 'three'
+  import { Backdrop, OrbitControls } from '@threlte/extras'
+  import { Resize, TransformControls, useGltf } from '@threlte/extras'
+  import { T, useThrelte } from '@threlte/core'
+
+  let {
+    lightHelperVisible = true,
+    materialColor = 'white',
+    materialWireframe = false,
+    ...backdropProps
+  }: BackdropProps & {
+    lightHelperVisible: boolean
+    materialColor: ColorRepresentation
+    materialWireframe: boolean
+  } = $props()
+
+  const gltf = useGltf<{
+    nodes: { LOD3spShape: Mesh }
+    materials: { 'blinn3-fx': MeshStandardMaterial }
+  }>('/models/Duck.glb').then((gltf) => {
+    gltf.nodes.LOD3spShape.castShadow = true
+    return gltf
+  })
+
+  const { scene } = useThrelte()
+
+  let helper = $state.raw<DirectionalLightHelper>()
+  let controls = $state.raw<ThreeTransformControls>()
+  let light = $state.raw<DirectionalLight>()
+
+  $effect(() => {
+    if (lightHelperVisible && light !== undefined) {
+      controls?.attach(light)
+    }
+    return () => {
+      controls?.detach()
+    }
+  })
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position.x={10}
+  position.y={5}
+  position.z={10}
+>
+  <OrbitControls
+    enableDamping
+    maxPolarAngle={0.5 * Math.PI}
+    minAzimuthAngle={-1 * 0.25 * Math.PI}
+    maxAzimuthAngle={0.25 * Math.PI}
+    maxDistance={20}
+  />
+</T.PerspectiveCamera>
+
+<T.DirectionalLight
+  position.x={-1 * 3}
+  position.y={2}
+  position.z={4}
+  castShadow
+  bind:ref={light}
+>
+  {#snippet children({ ref })}
+    <TransformControls
+      bind:controls
+      onobjectChange={() => {
+        helper?.update()
+      }}
+    />
+    <T.DirectionalLightHelper
+      bind:ref={helper}
+      args={[ref]}
+      attach={scene}
+      visible={lightHelperVisible}
+    />
+  {/snippet}
+</T.DirectionalLight>
+
+<Backdrop
+  {...backdropProps}
+  scale={[50, 10, 10]}
+>
+  <T.MeshStandardMaterial
+    color={materialColor}
+    wireframe={materialWireframe}
+  />
+</Backdrop>
+
+{#await gltf then { scene }}
+  <Resize
+    scale={3}
+    position.z={1}
+    rotation.y={Math.PI}
+  >
+    <T is={scene} />
+  </Resize>
+{/await}

--- a/apps/docs/src/examples/extras/mesh-discard-material/App.svelte
+++ b/apps/docs/src/examples/extras/mesh-discard-material/App.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Scene from './Scene.svelte'
   import { Canvas } from '@threlte/core'
-  import { Checkbox, Pane } from 'svelte-tweakpane-ui'
 </script>
 
 <div>

--- a/packages/extras/src/lib/components/Backdrop/Backdrop.svelte
+++ b/packages/extras/src/lib/components/Backdrop/Backdrop.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { BackdropProps } from './types'
+  import type { Group, PlaneGeometry } from 'three'
+  import type { Props } from '@threlte/core'
+  import { T, useThrelte } from '@threlte/core'
+  import { easeInExpo } from './easeInExpo'
+
+  let {
+    floor = 0.25,
+    receiveShadow = false,
+    segments = 20,
+    children,
+    ...props
+  }: Omit<Props<typeof Group>, 'receiveShadow'> & BackdropProps = $props()
+
+  let geometry = $state<PlaneGeometry>()
+  const position = $derived(geometry?.getAttribute('position'))
+  const s = $derived(segments + 1)
+
+  const offset = 0.5
+
+  const { invalidate } = useThrelte()
+
+  $effect(() => {
+    if (position !== undefined) {
+      let i = 0
+
+      for (let x = 0; x < s; x += 1) {
+        for (let y = 0; y < s; y += 1) {
+          const xOverSegments = x / segments
+          position.setXYZ(
+            i,
+            xOverSegments - offset + +(x === 0) * -1 * floor,
+            y / segments - offset,
+            easeInExpo(xOverSegments)
+          )
+          i += 1
+        }
+      }
+      position.needsUpdate = true
+      geometry?.computeVertexNormals()
+      invalidate()
+    }
+  })
+</script>
+
+<T.Group {...props}>
+  {#snippet children({ ref })}
+    <T.Mesh
+      {receiveShadow}
+      rotation.x={-1 * 0.5 * Math.PI}
+      rotation.z={0.5 * Math.PI}
+    >
+      <T.PlaneGeometry
+        args={[1, 1, segments, segments]}
+        bind:ref={geometry}
+      />
+      {@render children?.({ ref })}
+    </T.Mesh>
+  {/snippet}
+</T.Group>

--- a/packages/extras/src/lib/components/Backdrop/easeInExpo.ts
+++ b/packages/extras/src/lib/components/Backdrop/easeInExpo.ts
@@ -1,0 +1,3 @@
+export const easeInExpo = (x: number): number => {
+  return +(x !== 0) * 2 ** (10 * x - 10)
+}

--- a/packages/extras/src/lib/components/Backdrop/index.ts
+++ b/packages/extras/src/lib/components/Backdrop/index.ts
@@ -1,0 +1,2 @@
+export type { BackdropProps } from './types'
+export { default as Backdrop } from './Backdrop.svelte'

--- a/packages/extras/src/lib/components/Backdrop/types.ts
+++ b/packages/extras/src/lib/components/Backdrop/types.ts
@@ -1,0 +1,15 @@
+export type BackdropProps = {
+  /**
+   * @default 0.25
+   * length of the floor segment
+   */
+  floor?: number
+  /**
+   * @default false
+   */
+  receiveShadow?: boolean
+  /**
+   * @default 20
+   */
+  segments?: number
+}

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -58,6 +58,7 @@ export { default as RadialGradientTexture } from './components/GradientTexture/r
 export type { GradientStop, RadialGradientOuterRadius } from './components/GradientTexture/types'
 export { default as View } from './components/View/View.svelte'
 export { default as AsciiRenderer } from './components/AsciiRenderer/AsciiRenderer.svelte'
+export { Backdrop, type BackdropProps } from './components/Backdrop'
 
 // Transitions
 export { transitions } from './transitions/transltions.svelte'


### PR DESCRIPTION
a port of drei's backdrop component https://drei.docs.pmnd.rs/staging/backdrop

Two new approches

## Export Component Prop Types

i export the Backdrop component props type so that they would be available to the user. this is something that i think we should do for new components and probably go back and do for existing components. my reasoning is that if i want to forward props to a component it's very easy to do the following:

(Backdrop is used in the examples below but it could be any component from @threlte/extras)

```svelte
<Backdrop {...backdropProps} />
```

but what type should `backdropProps` have? exporting the type from extras makes it very easy to give it the correct type.

```svelte
<!-- Scene.svelte -->
<script lang="ts">
import type { BackdropProps } from '@threlte/extras'

type SceneProps = BackdropProps & {
// ... additional scene Props
}

let {sceneProp1, sceneProp2, ...backdropProps}: SceneProps = $props() 
</script>

<Backdrop {...backdropProps} />
```

or if i just want to create an object this is spreadable onto `<Backdrop>`

```svelte
<script lang="ts">
import type { BackdropProps } from '@threlte/extras'

const props: BackdropProps = {
// ...
}
</script>

<Backdrop {...props} />
```

I don't think there's any downside to exporting the component props type like this, it just makes it easier to provide the correct types in some cases. i usually advocate for following in the footsteps of svelte and they make most of their types available to the user - for example `TweenedOptions` for Tween classes and stores from the `svelte/motion` library.

## index.ts file for the component

`/Backdrop/index.ts` re-exports the component and the prop types to make it easier to export from the main `lib/index.ts` file

doing so makes the export from the `lib/index.ts` file become

```typescript
export { default as Backdrop, type BackdropProps } from './components/Backdrop';
```

instead of

```typescript
export { default as Backdrop } from './components/Backdrop/Backdrop.svelte'
export type { BackdropProps } from './components/Backdrop/types'
```

i think this is a more suitable approach if we plan to export component prop types.

## other things about this pr

- there's some unused imports in `MeshDiscardMaterial` that were removed
- feel free to tweak the docs or the example to look or feel better or to show off the component in a better way.