### PR TITLE
[next] Cursor lines example refactor

### DIFF
--- a/apps/docs/src/content/examples/meshline/Cursor Lines.mdx
+++ b/apps/docs/src/content/examples/meshline/Cursor Lines.mdx
@@ -9,37 +9,33 @@ This example was inspired by [OGL's Polyline example](https://oframe.github.io/o
 
 ## How Does it Work?
 
-First we create a scene with an orthographic camera and a mesh. The mesh's only purpose is to capture pointer move events so it needs to be big enough to fill the entire screen. The camera is placed above the mesh and is rotated to look down upon the mesh using the `lookAt` property.
+First we create a scene with an orthographic camera and a mesh. The mesh's only purpose is to capture pointer move events so it needs to be big enough to fill the entire screen. The mesh is placed in front of the camera. It doesn't really matter the exact position of the mesh because an orthographic camera has no perspective. All that really matters it is in fron of the camera and there is space inbetween the camera and the mesh - this is where the mesh lines will be drawn.
 
 ```svelte
 <T.OrthographicCamera
   zoom={50}
   makeDefault
-  position.y={10}
-  oncreate={(ref) => {
-    ref.lookAt(0, 0, 0)
-  }}
 />
 
 <T.Mesh
-  rotation.x={-1 * 0.5 * Math.PI}
   scale={100}
   visible={false}
+  position.z={-10}
 >
   <T.PlaneGeometry />
 </T.Mesh>
 ```
 
-The mesh is rotated so that it lies flat on the xz-plane and is made invisible.
+The camera is positioned at the origin and the mesh is positioned down the z-axis.
 
 ### Getting the Cursor Position
 
-To get the cursor position we use Threlte's [interactivity](/docs/reference/extras/interactivity) plugin. The event object that is passed to the `onpointermove` callback has a point property which tells you where the cursor position was when the event was triggered. The cursor positions is updated and sent into the `<CursorLine>` component as a prop.
+To get the cursor position we use Threlte's [interactivity](/docs/reference/extras/interactivity) plugin. The event object that is passed to the `onpointermove` callback has a point property which tells you where the cursor position was when the event was triggered. The cursor position is updated and sent into the `<CursorLine>` component as a prop.
 
 ```svelte
 <script lang="ts">
+  const cursorPosition = new Spring<Vector3Tuple>([0, 0, 0])
   interactivity()
-  let cursorPosition: Vector3Tuple = $state.raw([0, 0, 0])
 </script>
 
 <T.Mesh
@@ -51,14 +47,9 @@ To get the cursor position we use Threlte's [interactivity](/docs/reference/extr
 </T.Mesh>
 ```
 
-<Tip type="info">
-  `$state.raw` is used over `$state` to store the position because we don't care about making each
-  entry in the tuple reactive. More on this in the next section.
-</Tip>
-
 ### Inside the CursorLine Component
 
-The `<CursorLine>` component receives the current pointer position and uses a [Spring](https://svelte.dev/docs/svelte/svelte-motion#Spring) to interpolate between updates. To create the "trailing" effect two lists of `Vector3` points are created - a back and a front. Each frame, the back set of points is updated then swapped with the front set of points. This swap causes anything that reads from the front set of points to get updated.
+The `<CursorLine>` component receives the current pointer position. To create the "trailing" effect two lists of `Vector3` points are created - a back and a front. Each frame, the back set of points is updated then swapped with the front set of points. This swap causes anything that reads from the front set of points to get updated.
 
 #### Making Use of $state.raw
 
@@ -106,3 +97,17 @@ useTask((delta) => {
 ```
 
 In summary, we update the "back" set of points and swap it with the "front" once all points have been updated. This is very similar to a the double-buffering strategy used by many graphics software.
+
+A "getter" for the points is available in the `children` snippet so that its current value can be used.
+
+```svelte
+<CursorLine>
+  {#snippet children({ getPoints })}
+    <MeshLineGeometry
+      points={getPoints()}
+      shape="taper"
+    />
+    <MeshLineMaterial attenuate={false} />
+  {/snippet}
+</CursorLine>
+```

--- a/apps/docs/src/examples/meshline/cursor-lines/CursorLine.svelte
+++ b/apps/docs/src/examples/meshline/cursor-lines/CursorLine.svelte
@@ -18,7 +18,7 @@
     cursorPosition: Vector3Tuple
   }
 
-  let { cursorPosition, color, width, children, ...props }: CursorLineProps = $props()
+  let { cursorPosition, children, ...props }: CursorLineProps = $props()
 
   const count = 50
   let front = $state.raw(createPoints(count))

--- a/apps/docs/src/examples/meshline/cursor-lines/Scene.svelte
+++ b/apps/docs/src/examples/meshline/cursor-lines/Scene.svelte
@@ -1,42 +1,53 @@
 <script lang="ts">
   import CursorLine from './CursorLine.svelte'
-  import { T } from '@threlte/core'
   import type { Vector3Tuple } from 'three'
+  import { MeshLineGeometry, MeshLineMaterial } from '@threlte/extras'
+  import { Spring } from 'svelte/motion'
+  import { T } from '@threlte/core'
   import { interactivity } from '@threlte/extras'
 
   interactivity()
 
-  let cursorPosition: Vector3Tuple = $state.raw([0, 0, 0])
-  const colors = ['#fc6435', '#ff541f', '#f53c02', '#261f9a', '#1e168d']
+  const cursorPosition = new Spring<Vector3Tuple>([0, 0, 0])
+
+  const colors = ['#0000ff', '#00ff00', '#00ffff', '#ff0000', '#ff00ff', '#ffff00']
+  const m = (2 * Math.PI) / colors.length
 </script>
 
 {#each colors as color, i}
+  {@const a = m * i}
   <CursorLine
     {color}
-    {cursorPosition}
-    position.y={5 - i}
-    stiffness={0.02 * i + 0.02}
-    damping={0.25 - 0.04 * i}
-    width={15 + i * 10}
-  />
+    cursorPosition={cursorPosition.current}
+    position.x={0.5 * Math.cos(a)}
+    position.y={0.5 * Math.sin(a)}
+  >
+    {#snippet children({ getPoints })}
+      <MeshLineGeometry
+        points={getPoints()}
+        shape="taper"
+      />
+      <MeshLineMaterial
+        width={10}
+        {color}
+        attenuate={false}
+      />
+    {/snippet}
+  </CursorLine>
 {/each}
 
 <T.OrthographicCamera
   zoom={50}
   makeDefault
-  position.y={10}
-  oncreate={(ref) => {
-    ref.lookAt(0, 0, 0)
-  }}
 />
 
 <T.Mesh
   visible={false}
   onpointermove={(event) => {
-    cursorPosition = event.point.toArray()
+    cursorPosition.set(event.point.toArray())
   }}
+  position.z={-10}
   scale={100}
-  rotation.x={-1 * 0.5 * Math.PI}
 >
   <T.PlaneGeometry />
 </T.Mesh>


### PR DESCRIPTION
simplifies and improves quite a lot.

- one Spring instance instead of one per `<CursorLine>`
- simplify positioning of the camera and mesh that captures mouse movement.
- slots the children snippet into the underlying mesh
  - provides a `getPoints` getter function for the `children` snippet so that you can do different things with it. you don't have to only use it with `MeshLineGeometry`.
- updates the colors and their positions to be a little more visually appealing but that's of course subjective

due to how `<MeshLineGeometry />` handles its `points` prop (it expects a new points array when the points inside it have updated) we have to do the `useTask` like before. there's an issue open for addressing the unreactive props in `<MeshLineGeometry>` and `<MeshLineMaterial>` https://github.com/threlte/threlte/issues/1315