### PR TITLE
Fixed width property of HTML component when using fullscreen property

### DIFF
--- a/.changeset/stupid-dingos-sip.md
+++ b/.changeset/stupid-dingos-sip.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fixed width property of HTML component when using fullscreen property

--- a/packages/extras/src/lib/components/HTML/HTML.svelte
+++ b/packages/extras/src/lib/components/HTML/HTML.svelte
@@ -364,7 +364,7 @@
       style:transform={center ? 'translate3d(-50%,-50%,0)' : 'none'}
       style:top={fullscreen ? `${-height / 2}px` : undefined}
       style:left={fullscreen ? `${-width / 2}px` : undefined}
-      style:width={fullscreen ? `${width / 2}px` : undefined}
+      style:width={fullscreen ? `${width}px` : undefined}
       style:height={fullscreen ? `${height}px` : undefined}
       style={props.style}
       class={props.class}


### PR DESCRIPTION
#1352

The `style:width` property was being erroneously divided by 2.