### PR TITLE
[next] categories organization

### DIFF
--- a/apps/docs/src/content/reference/extras/align.mdx
+++ b/apps/docs/src/content/reference/extras/align.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.11
+order: 4.11
 category: '@threlte/extras'
 name: '<Align>'
 sourcePath: 'packages/extras/src/lib/components/Align/Align.svelte'

--- a/apps/docs/src/content/reference/extras/animated-sprite-material.mdx
+++ b/apps/docs/src/content/reference/extras/animated-sprite-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.1
+order: 5.1
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/AnimatedSpriteMaterial/AnimatedSpriteMaterial.svelte'
 name: <AnimatedSpriteMaterial>

--- a/apps/docs/src/content/reference/extras/ascii-renderer.mdx
+++ b/apps/docs/src/content/reference/extras/ascii-renderer.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.10
+order: 5.10
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/AsciiRenderer/AsciiRenderer.svelte'
 name: <AsciiRenderer>

--- a/apps/docs/src/content/reference/extras/audio-listener.mdx
+++ b/apps/docs/src/content/reference/extras/audio-listener.mdx
@@ -1,5 +1,5 @@
 ---
-order: 1.2
+order: 6.2
 category: '@threlte/extras'
 name: '<AudioListener>'
 type: 'component'

--- a/apps/docs/src/content/reference/extras/audio.mdx
+++ b/apps/docs/src/content/reference/extras/audio.mdx
@@ -1,5 +1,5 @@
 ---
-order: 1.1
+order: 6.1
 category: '@threlte/extras'
 name: <Audio>
 sourcePath: 'packages/extras/src/lib/audio/Audio/Audio.svelte'

--- a/apps/docs/src/content/reference/extras/audioCategory.mdx
+++ b/apps/docs/src/content/reference/extras/audioCategory.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Audio
-order: 1
+order: 6
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/bake-shadows.mdx
+++ b/apps/docs/src/content/reference/extras/bake-shadows.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.7
+order: 7.7
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/BakeShadows/BakeShadows.svelte'
 name: '<BakeShadows>'

--- a/apps/docs/src/content/reference/extras/billboard.mdx
+++ b/apps/docs/src/content/reference/extras/billboard.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.12
+order: 4.12
 category: '@threlte/extras'
 name: '<Billboard>'
 sourcePath: 'packages/extras/src/lib/components/Billboard/Billboard.svelte'

--- a/apps/docs/src/content/reference/extras/contact-shadows.mdx
+++ b/apps/docs/src/content/reference/extras/contact-shadows.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.13
+order: 4.13
 category: '@threlte/extras'
 name: <ContactShadows>
 sourcePath: 'packages/extras/src/lib/components/ContactShadows/ContactShadows.svelte'

--- a/apps/docs/src/content/reference/extras/content.mdx
+++ b/apps/docs/src/content/reference/extras/content.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Content
-order: 2
+order: 1
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/csm.mdx
+++ b/apps/docs/src/content/reference/extras/csm.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.14
+order: 4.14
 category: '@threlte/extras'
 name: <CSM>
 sourcePath: 'packages/extras/src/lib/components/CSM/CSM.svelte'

--- a/apps/docs/src/content/reference/extras/cube-camera.mdx
+++ b/apps/docs/src/content/reference/extras/cube-camera.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.10
+order: 5.10
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/CubeCamera/CubeCamera.svelte'
 name: '<CubeCamera>'

--- a/apps/docs/src/content/reference/extras/cube-environment.mdx
+++ b/apps/docs/src/content/reference/extras/cube-environment.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.142
+order: 4.142
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/environment/CubeEnvironment/CubeEnvironment.svelte'
 name: <CubeEnvironment>

--- a/apps/docs/src/content/reference/extras/detailed.mdx
+++ b/apps/docs/src/content/reference/extras/detailed.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.6
+order: 7.6
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/Detailed/Detailed.svelte'
 name: '<Detailed>'

--- a/apps/docs/src/content/reference/extras/discard-material.mdx
+++ b/apps/docs/src/content/reference/extras/discard-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.10
+order: 5.10
 category: '@threlte/extras'
 name: '<MeshDiscardMaterial>'
 sourcePath: 'packages/extras/src/lib/components/MeshDiscardMaterial/MeshDiscardMaterial.svelte'

--- a/apps/docs/src/content/reference/extras/edges.mdx
+++ b/apps/docs/src/content/reference/extras/edges.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.2
+order: 5.2
 category: '@threlte/extras'
 name: <Edges>
 sourcePath: 'packages/extras/src/lib/components/Edges/Edges.svelte'

--- a/apps/docs/src/content/reference/extras/environment.mdx
+++ b/apps/docs/src/content/reference/extras/environment.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.141
+order: 4.141
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/environment/Environment/Environment.svelte'
 name: <Environment>

--- a/apps/docs/src/content/reference/extras/fake-glow-material.mdx
+++ b/apps/docs/src/content/reference/extras/fake-glow-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.3
+order: 5.3
 category: '@threlte/extras'
 name: '<FakeGlowMaterial>'
 sourcePath: 'packages/extras/src/lib/components/FakeGlowMaterial/FakeGlowMaterial.svelte'

--- a/apps/docs/src/content/reference/extras/float.mdx
+++ b/apps/docs/src/content/reference/extras/float.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.16
+order: 4.16
 category: '@threlte/extras'
 name: '<Float>'
 sourcePath: 'packages/extras/src/lib/components/Float/Float.svelte'

--- a/apps/docs/src/content/reference/extras/gizmo.mdx
+++ b/apps/docs/src/content/reference/extras/gizmo.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.1
+order: 2.1
 category: '@threlte/extras'
 name: <Gizmo>
 sourcePath: 'packages/extras/src/lib/components/Gizmo/Gizmo.svelte'

--- a/apps/docs/src/content/reference/extras/gltf.mdx
+++ b/apps/docs/src/content/reference/extras/gltf.mdx
@@ -1,5 +1,5 @@
 ---
-order: 2.1
+order: 1.1
 category: '@threlte/extras'
 name: <GLTF>
 sourcePath: 'packages/extras/src/lib/components/GLTF/GLTF.svelte'

--- a/apps/docs/src/content/reference/extras/grid.mdx
+++ b/apps/docs/src/content/reference/extras/grid.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.17
+order: 4.17
 category: '@threlte/extras'
 name: <Grid>
 sourcePath: 'packages/extras/src/lib/components/Grid/Grid.svelte'

--- a/apps/docs/src/content/reference/extras/html.mdx
+++ b/apps/docs/src/content/reference/extras/html.mdx
@@ -1,5 +1,5 @@
 ---
-order: 2.2
+order: 1.2
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/HTML/HTML.svelte'
 name: <HTML>

--- a/apps/docs/src/content/reference/extras/hud.mdx
+++ b/apps/docs/src/content/reference/extras/hud.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.15
+order: 4.15
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/HUD/HUD.svelte'
 name: <HUD>

--- a/apps/docs/src/content/reference/extras/image-material.mdx
+++ b/apps/docs/src/content/reference/extras/image-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 11.4
+order: 5.4
 category: '@threlte/extras'
 name: <ImageMaterial>
 sourcePath: 'packages/extras/src/lib/components/ImageMaterial/ImageMaterial.svelte'

--- a/apps/docs/src/content/reference/extras/instance.mdx
+++ b/apps/docs/src/content/reference/extras/instance.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.1
+order: 7.1
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/Instancing/Instance.svelte'
 name: '<Instance>'

--- a/apps/docs/src/content/reference/extras/instanced-mesh.mdx
+++ b/apps/docs/src/content/reference/extras/instanced-mesh.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.2
+order: 7.2
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/Instancing/InstancedMesh.svelte'
 name: '<InstancedMesh>'

--- a/apps/docs/src/content/reference/extras/instanced-meshes.mdx
+++ b/apps/docs/src/content/reference/extras/instanced-meshes.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.3
+order: 7.3
 category: '@threlte/extras'
 name: '<InstancedMeshes>'
 sourcePath: 'packages/extras/src/lib/components/Instancing/InstancedMeshes'

--- a/apps/docs/src/content/reference/extras/instanced-sprite.mdx
+++ b/apps/docs/src/content/reference/extras/instanced-sprite.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.4
+order: 7.4
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/InstancedSprite/InstancedSprite.svelte'
 name: <InstancedSprite>

--- a/apps/docs/src/content/reference/extras/interaction.mdx
+++ b/apps/docs/src/content/reference/extras/interaction.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Interaction
-order: 3
+order: 2
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/interactivity.mdx
+++ b/apps/docs/src/content/reference/extras/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.5
+order: 2.5
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/interactivity'
 name: 'interactivity'

--- a/apps/docs/src/content/reference/extras/layers.mdx
+++ b/apps/docs/src/content/reference/extras/layers.mdx
@@ -1,5 +1,5 @@
 ---
-order: 5.3
+order: 8.3
 category: '@threlte/extras'
 name: 'layers'
 sourcePath: 'packages/extras/src/lib/layers'

--- a/apps/docs/src/content/reference/extras/linear-gradient-texture.mdx
+++ b/apps/docs/src/content/reference/extras/linear-gradient-texture.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.9
+order: 5.9
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/GradientTexture/LinearGradientTexture.svelte'
 name: '<LinearGradientTexture>'

--- a/apps/docs/src/content/reference/extras/loading.mdx
+++ b/apps/docs/src/content/reference/extras/loading.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Loading
-order: 4
+order: 3
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/mask.mdx
+++ b/apps/docs/src/content/reference/extras/mask.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.4
+order: 5.4
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/Mask/Mask.svelte'
 name: <Mask>

--- a/apps/docs/src/content/reference/extras/mesh-bounds.mdx
+++ b/apps/docs/src/content/reference/extras/mesh-bounds.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.8
+order: 7.8
 category: '@threlte/extras'
 name: 'meshBounds'
 sourcePath: 'packages/extras/src/lib/utilities/meshBounds.ts'

--- a/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
+++ b/apps/docs/src/content/reference/extras/mesh-refraction-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.7
+order: 5.7
 category: '@threlte/extras'
 name: '<MeshRefractionMaterial>'
 sourcePath: 'packages/extras/src/lib/components/MeshRefractionMaterial/MeshRefractionMaterial.svelte'

--- a/apps/docs/src/content/reference/extras/meshline-geometry.mdx
+++ b/apps/docs/src/content/reference/extras/meshline-geometry.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.5
+order: 5.5
 category: '@threlte/extras'
 name: <MeshLineGeometry>
 sourcePath: 'packages/extras/src/lib/components/MeshLine/MeshLineMaterial.svelte'

--- a/apps/docs/src/content/reference/extras/meshline-material.mdx
+++ b/apps/docs/src/content/reference/extras/meshline-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.6
+order: 5.6
 category: '@threlte/extras'
 name: <MeshLineMaterial>
 sourcePath: 'packages/extras/src/lib/components/MeshLine/MeshLineMaterial.svelte'

--- a/apps/docs/src/content/reference/extras/misc.mdx
+++ b/apps/docs/src/content/reference/extras/misc.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Misc
-order: 5
+order: 8
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/onReveal.mdx
+++ b/apps/docs/src/content/reference/extras/onReveal.mdx
@@ -1,5 +1,5 @@
 ---
-order: 8.2
+order: 3.4
 category: '@threlte/extras'
 name: 'onReveal'
 type: 'hook'

--- a/apps/docs/src/content/reference/extras/onSuspend.mdx
+++ b/apps/docs/src/content/reference/extras/onSuspend.mdx
@@ -1,5 +1,5 @@
 ---
-order: 8.3
+order: 3.4
 category: '@threlte/extras'
 name: 'onSuspend'
 type: 'hook'

--- a/apps/docs/src/content/reference/extras/orbit-controls.mdx
+++ b/apps/docs/src/content/reference/extras/orbit-controls.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.2
+order: 2.2
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/controls/OrbitControls/OrbitControls.svelte'
 name: '<OrbitControls>'

--- a/apps/docs/src/content/reference/extras/outlines.mdx
+++ b/apps/docs/src/content/reference/extras/outlines.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.8
+order: 5.8
 category: '@threlte/extras'
 name: <Outlines>
 sourcePath: 'packages/extras/src/lib/components/Outlines/Outlines.svelte'

--- a/apps/docs/src/content/reference/extras/peformance.mdx
+++ b/apps/docs/src/content/reference/extras/peformance.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Peformance
-order: 6
+order: 7
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/perf-monitor.mdx
+++ b/apps/docs/src/content/reference/extras/perf-monitor.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6.5
+order: 7.5
 category: '@threlte/extras'
 name: '<PerfMonitor>'
 sourcePath: 'packages/extras/src/lib/components/PerfMonitor/PerfMonitor.svelte'

--- a/apps/docs/src/content/reference/extras/portal-target.mdx
+++ b/apps/docs/src/content/reference/extras/portal-target.mdx
@@ -1,5 +1,5 @@
 ---
-order: 5.2
+order: 8.2
 category: '@threlte/extras'
 name: '<PortalTarget>'
 sourcePath: 'packages/extras/src/lib/components/portals/PortalTarget/PortalTarget.svelte'

--- a/apps/docs/src/content/reference/extras/portal.mdx
+++ b/apps/docs/src/content/reference/extras/portal.mdx
@@ -1,5 +1,5 @@
 ---
-order: 5.1
+order: 8.1
 category: '@threlte/extras'
 name: '<Portal>'
 sourcePath: 'packages/extras/src/lib/components/portals/Portal/Portal.svelte'

--- a/apps/docs/src/content/reference/extras/positional-audio.mdx
+++ b/apps/docs/src/content/reference/extras/positional-audio.mdx
@@ -1,5 +1,5 @@
 ---
-order: 1.3
+order: 6.3
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/audio/PositionalAudio/PositionalAudio.svelte'
 name: <PositionalAudio>

--- a/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
+++ b/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9.10
+order: 5.10
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/GradientTexture/RadialGradientTexture.svelte'
 name: '<RadialGradientTexture>'

--- a/apps/docs/src/content/reference/extras/resize.mdx
+++ b/apps/docs/src/content/reference/extras/resize.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.12
+order: 4.12
 category: '@threlte/extras'
 name: '<Resize>'
 sourcePath: 'packages/extras/src/lib/components/Resize/Resize.svelte'

--- a/apps/docs/src/content/reference/extras/rounded-box-geometry.mdx
+++ b/apps/docs/src/content/reference/extras/rounded-box-geometry.mdx
@@ -1,5 +1,5 @@
 ---
-order: 2.3
+order: 1.3
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/RoundedBoxGeometry/RoundedBoxGeometry.svelte'
 name: <RoundedBoxGeometry>

--- a/apps/docs/src/content/reference/extras/sky.mdx
+++ b/apps/docs/src/content/reference/extras/sky.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.18
+order: 4.18
 category: '@threlte/extras'
 name: '<Sky>'
 sourcePath: 'packages/extras/src/lib/components/Sky/Sky.svelte'

--- a/apps/docs/src/content/reference/extras/soft-shadows.mdx
+++ b/apps/docs/src/content/reference/extras/soft-shadows.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.19
+order: 4.19
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/SoftShadows/SoftShadows.svelte'
 name: '<SoftShadows>'

--- a/apps/docs/src/content/reference/extras/staging.mdx
+++ b/apps/docs/src/content/reference/extras/staging.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Staging
-order: 7
+order: 4
 isDivider: true
 ---

--- a/apps/docs/src/content/reference/extras/stars.mdx
+++ b/apps/docs/src/content/reference/extras/stars.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.2
+order: 4.2
 category: '@threlte/extras'
 name: '<Stars>'
 sourcePath: 'packages/extras/src/lib/components/Stars/Stars.svelte'

--- a/apps/docs/src/content/reference/extras/suspense-category.mdx
+++ b/apps/docs/src/content/reference/extras/suspense-category.mdx
@@ -1,6 +1,0 @@
----
-category: '@threlte/extras'
-name: Suspense
-order: 8
-isDivider: true
----

--- a/apps/docs/src/content/reference/extras/suspense.mdx
+++ b/apps/docs/src/content/reference/extras/suspense.mdx
@@ -1,5 +1,5 @@
 ---
-order: 8.1
+order: 3.3
 category: '@threlte/extras'
 name: '<Suspense>'
 sourcePath: 'packages/extras/src/lib/suspense/Suspense.svelte'

--- a/apps/docs/src/content/reference/extras/text-3d-geometry.mdx
+++ b/apps/docs/src/content/reference/extras/text-3d-geometry.mdx
@@ -1,5 +1,5 @@
 ---
-order: 2.5
+order: 1.5
 category: '@threlte/extras'
 name: '<Text3DGeometry>'
 sourcePath: 'packages/extras/src/lib/components/Text3DGeometry/Text3DGeometry.svelte'

--- a/apps/docs/src/content/reference/extras/text.mdx
+++ b/apps/docs/src/content/reference/extras/text.mdx
@@ -1,5 +1,5 @@
 ---
-order: 2.4
+order: 1.4
 category: '@threlte/extras'
 name: '<Text>'
 sourcePath: 'packages/extras/src/lib/components/Text/Text.svelte'

--- a/apps/docs/src/content/reference/extras/trackball-controls.mdx
+++ b/apps/docs/src/content/reference/extras/trackball-controls.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.3
+order: 2.3
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/controls/TrackballControls/TrackballControls.svelte'
 name: '<TrackballControls>'

--- a/apps/docs/src/content/reference/extras/transform-controls.mdx
+++ b/apps/docs/src/content/reference/extras/transform-controls.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.4
+order: 2.4
 category: '@threlte/extras'
 name: '<TransformControls>'
 sourcePath: 'packages/extras/src/lib/components/controls/TransformControls/TransformControls.svelte'

--- a/apps/docs/src/content/reference/extras/transitions.mdx
+++ b/apps/docs/src/content/reference/extras/transitions.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.31
+order: 3.5
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/transitions'
 name: transitions

--- a/apps/docs/src/content/reference/extras/transitions.mdx
+++ b/apps/docs/src/content/reference/extras/transitions.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.5
+order: 4.4
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/transitions'
 name: transitions

--- a/apps/docs/src/content/reference/extras/use-audio-listener.mdx
+++ b/apps/docs/src/content/reference/extras/use-audio-listener.mdx
@@ -1,5 +1,5 @@
 ---
-order: 1.4
+order: 6.4
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/audio/useAudioListener.ts'
 name: useAudioListener

--- a/apps/docs/src/content/reference/extras/use-cursor.mdx
+++ b/apps/docs/src/content/reference/extras/use-cursor.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.6
+order: 2.6
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/hooks/useCursor.ts'
 name: useCursor

--- a/apps/docs/src/content/reference/extras/use-fbo.mdx
+++ b/apps/docs/src/content/reference/extras/use-fbo.mdx
@@ -1,5 +1,5 @@
 ---
-order: 5.5
+order: 8.5
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/hooks/useFBO.ts'
 name: useFBO

--- a/apps/docs/src/content/reference/extras/use-gamepad.mdx
+++ b/apps/docs/src/content/reference/extras/use-gamepad.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3.7
+order: 2.7
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/hooks/useGamepad.ts'
 name: useGamepad

--- a/apps/docs/src/content/reference/extras/use-gltf-animations.mdx
+++ b/apps/docs/src/content/reference/extras/use-gltf-animations.mdx
@@ -1,5 +1,5 @@
 ---
-order: 4.2
+order: 3.2
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/hooks/useGltfAnimations.ts'
 name: useGltfAnimations

--- a/apps/docs/src/content/reference/extras/use-gltf.mdx
+++ b/apps/docs/src/content/reference/extras/use-gltf.mdx
@@ -1,5 +1,5 @@
 ---
-order: 4.1
+order: 3.1
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/hooks/useGltf.ts'
 name: useGltf

--- a/apps/docs/src/content/reference/extras/use-progress.mdx
+++ b/apps/docs/src/content/reference/extras/use-progress.mdx
@@ -1,5 +1,5 @@
 ---
-order: 4.3
+order: 3.2
 category: '@threlte/extras'
 name: useProgress
 sourcePath: 'packages/extras/src/lib/hooks/useProgress.ts'

--- a/apps/docs/src/content/reference/extras/use-suspense.mdx
+++ b/apps/docs/src/content/reference/extras/use-suspense.mdx
@@ -1,5 +1,5 @@
 ---
-order: 8.4
+order: 3.4
 category: '@threlte/extras'
 name: 'useSuspense'
 type: 'hook'

--- a/apps/docs/src/content/reference/extras/use-texture.mdx
+++ b/apps/docs/src/content/reference/extras/use-texture.mdx
@@ -1,5 +1,5 @@
 ---
-order: 4.4
+order: 3.2
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/hooks/useTexture.ts'
 name: useTexture

--- a/apps/docs/src/content/reference/extras/use-threlte-audio.mdx
+++ b/apps/docs/src/content/reference/extras/use-threlte-audio.mdx
@@ -1,5 +1,5 @@
 ---
-order: 1.5
+order: 6.5
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/audio/useThrelteAudio.ts'
 name: useThrelteAudio

--- a/apps/docs/src/content/reference/extras/use-viewport.mdx
+++ b/apps/docs/src/content/reference/extras/use-viewport.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.3
+order: 4.3
 category: '@threlte/extras'
 name: useViewport
 sourcePath: 'packages/extras/src/lib/hooks/useViewport.ts'

--- a/apps/docs/src/content/reference/extras/view.mdx
+++ b/apps/docs/src/content/reference/extras/view.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.31
+order: 4.31
 category: '@threlte/extras'
 name: '<View>'
 sourcePath: 'packages/extras/src/lib/components/View/View.svelte'

--- a/apps/docs/src/content/reference/extras/virtual-environment.mdx
+++ b/apps/docs/src/content/reference/extras/virtual-environment.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7.143
+order: 4.143
 category: '@threlte/extras'
 sourcePath: 'packages/extras/src/lib/components/environment/VirtualEnvironment/VirtualEnvironment.svelte'
 name: <VirtualEnvironment>

--- a/apps/docs/src/content/reference/extras/visual-effects.mdx
+++ b/apps/docs/src/content/reference/extras/visual-effects.mdx
@@ -1,6 +1,6 @@
 ---
 category: '@threlte/extras'
 name: Visual Effects
-order: 9
+order: 5
 isDivider: true
 ---


### PR DESCRIPTION
- Audio section moved further down
- Misc moved to bottom
- Performance moved further down
- suspense pages merged with loading category
- `transitions` page moved to bottom of staging category, hoping its easier to pickup on when scrolling the list.