### PR TITLE
Screen-quad post-processing example

### DIFF
--- a/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
+++ b/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
@@ -34,6 +34,6 @@ Firstly, The screen-quad mesh is not frustrum culled. This is because the geomet
 
 This `<T.Mesh>` uses threlte's `attach` prop to add it to the secondary scene instead of the default scene created by threlte.
 
-Secondly, the render task that threlte automatically uses is disabled and a custom render task is used instead. This is explained on the [`useTask page`](/docs/reference/core/use-task).
+Secondly, the render task that threlte automatically uses is disabled and a custom render task is used instead. This is explained on the [`useTask`](/docs/reference/core/use-task) page.
 
 Lastly, the uvs are used in the fragment shader to use as an index into the scene texture. For this reason, the resolution of the canvas is sent into the shader as a uniform. An effect is ran to keep the uniform in sync with the current size of the canvas.

--- a/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
+++ b/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
@@ -1,0 +1,39 @@
+This example demonstrates a well-known technique for doing simple postprocessing utilizing a "screen-quad".
+
+<Example path="postprocessing/screen-quad" />
+
+## Overview
+
+The basic idea of postprocessing is to draw the scene to a frame-buffer that can then be sent into another shader. The output of this shader is used as the texture or material for a mesh that covers the screen. To do this we need two things:
+
+1. a webgl render target
+2. a separate scene from the one that threlte provides
+
+The [`useFBO`](/docs/reference/extras/use-fbo) hook returns a render target. This will be what we render the main scene to every frame and pass into the fragment shader as a texture.
+
+A separate scene is needed so that we can add the screen-quad mesh to it and render it. The idea is that the only thing in this scene will be the screen-quad mesh that has the post-processed scene as its material. This mesh can't be added to the main scene because it would cause a circular dependency.
+
+So the steps are as follows:
+
+1. render the "main" scene to the render target.
+2. render the separate scene.
+
+There are some sub-steps inbetween but these are the two important bits that happen in the `useTask` callback in the `<Scene>` component.
+
+## ScreenQuadGeometry
+
+This component creates a right triangle such that its right angle is positioned in the lower-left of the canvas. The size of the triangle is such that the hypotenuse only touches the top-right corner of the canvas. The triangle is in clip-space so we need a special vertex shader to use it.
+
+The vertex shader string is exported from the `<ScreenQuadGeometry>` component to be used with either a `Three.RawShaderMaterial` or `Three.ShaderMaterial`.
+
+## Scene
+
+There are a few notable techniques in the `<Scene>` component.
+
+Firstly, The screen-quad mesh is not frustrum culled. This is because the geometry is so simple that culling it would actually requare more work. If you culled its geometry, you'd actually be creating more vertices.
+
+This `<T.Mesh>` uses threlte's `attach` prop to add it to the secondary scene instead of the default scene created by threlte.
+
+Secondly, the render task that threlte automatically uses is disabled and a custom render task is used instead. This is explained on the [`useTask page`](/docs/reference/core/use-task).
+
+Lastly, the uvs are used in the fragment shader to use as an index into the scene texture. For this reason, the resolution of the canvas is sent into the shader as a uniform. An effect is ran to keep the uniform in sync with the current size of the canvas.

--- a/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
+++ b/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
@@ -1,4 +1,4 @@
-This example demonstrates a well-known technique for doing simple postprocessing utilizing a "screen-quad".
+This example demonstrates a well-known technique for doing simple postprocessing utilizing a "screen-quad". Mouse around the canvas to see the effect.
 
 <Example path="postprocessing/screen-quad" />
 

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -15,7 +15,10 @@
   let amplitude = $state(1)
 </script>
 
-<Pane position="fixed">
+<Pane
+  position="fixed"
+  title="simple post-processing"
+>
   <Slider
     label="amplitude"
     bind:value={amplitude}

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -19,6 +19,6 @@
   />
 </Pane>
 
-<Canvas>
+<Canvas autoRender={false}>
   <Scene {radius} />
 </Canvas>

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { Pane, Slider } from 'svelte-tweakpane-ui'
+  import Scene from './Scene.svelte'
+  import { Canvas } from '@threlte/core'
+
+  /**
+   * how fast to cycle
+   */
+  let frequency = $state(2)
+
+  /**
+   * how much the effect will come through
+   * 0 -> 1 since gl colors are in this range
+   */
+  let amplitude = $state(0.2)
+</script>
+
+<Pane position="fixed">
+  <Slider
+    label="amplitude"
+    bind:value={amplitude}
+    min={0}
+    max={1}
+    step={0.1}
+  />
+  <Slider
+    label="frequency"
+    bind:value={frequency}
+    min={1}
+    max={10}
+    step={1}
+  />
+</Pane>
+
+<Canvas autoRender={false}>
+  <Scene
+    {amplitude}
+    {frequency}
+  />
+</Canvas>

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -6,13 +6,13 @@
   /**
    * how fast to cycle
    */
-  let frequency = $state(2)
+  let frequency = $state(1)
 
   /**
    * how much the effect will come through
    * 0 -> 1 since gl colors are in this range
    */
-  let amplitude = $state(0.5)
+  let amplitude = $state(1)
 </script>
 
 <Pane position="fixed">
@@ -27,7 +27,7 @@
     label="frequency"
     bind:value={frequency}
     min={1}
-    max={10}
+    max={5}
     step={1}
   />
 </Pane>

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -12,7 +12,7 @@
    * how much the effect will come through
    * 0 -> 1 since gl colors are in this range
    */
-  let amplitude = $state(0.2)
+  let amplitude = $state(0.5)
 </script>
 
 <Pane position="fixed">

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -3,16 +3,7 @@
   import Scene from './Scene.svelte'
   import { Canvas } from '@threlte/core'
 
-  /**
-   * how fast to cycle
-   */
-  let frequency = $state(1)
-
-  /**
-   * how much the effect will come through
-   * 0 -> 1 since gl colors are in this range
-   */
-  let amplitude = $state(1)
+  let radius = $state(0.05)
 </script>
 
 <Pane
@@ -20,24 +11,14 @@
   title="simple post-processing"
 >
   <Slider
-    label="amplitude"
-    bind:value={amplitude}
-    min={0}
-    max={1}
-    step={0.1}
-  />
-  <Slider
-    label="frequency"
-    bind:value={frequency}
-    min={1}
-    max={5}
-    step={1}
+    label="radius"
+    bind:value={radius}
+    min={0.01}
+    max={0.1}
+    step={0.01}
   />
 </Pane>
 
-<Canvas autoRender={false}>
-  <Scene
-    {amplitude}
-    {frequency}
-  />
+<Canvas>
+  <Scene {radius} />
 </Canvas>

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -46,7 +46,7 @@
     uResolution.value.set($size.width, $size.height)
   })
 
-  const gltf = useGltf('/public/models/spaceships/Bob.gltf')
+  const gltf = useGltf('/models/spaceships/Bob.gltf')
 </script>
 
 <T.PerspectiveCamera

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -24,6 +24,10 @@
     { stage: renderStage }
   )
 
+  /**
+   * put your interesting effects in this shader.
+   * this one oscillates the blue channel of the scene by a sine wave
+   */
   const fragmentShader = `
 		precision highp float;
 		uniform sampler2D uScene;

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -38,7 +38,7 @@
 		void main() {
 			vec2 uv = gl_FragCoord.xy / uResolution.xy;
 			vec3 color = texture2D(uScene, uv).rgb;
-			color.b = uAmplitude * (1.0 + sin(uFrequency * uTime));
+			color.b = uAmplitude * 0.5 * (1.0 + sin(uFrequency * uTime));
 			gl_FragColor = vec4(color, 1.0);
 		}
 	`

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -26,7 +26,7 @@
 
   /**
    * put your interesting effects in this shader.
-   * this one oscillates the blue channel of the scene by a sine wave
+   * this one oscillates the blue channel of the scene
    */
   const fragmentShader = `
 		precision highp float;
@@ -39,7 +39,10 @@
 		void main() {
 			vec2 uv = gl_FragCoord.xy / uResolution.xy;
 			vec4 color = texture2D(uScene, uv);
-			color.b = uAmplitude * 0.5 * (1.0 + sin(uFrequency * uTime));
+			// remap sine's output from -1 -> 1 to 0 -> 1
+			float v = 0.5 * (1.0 + sin(uFrequency * uTime));
+			// uAmplitude scales v but must also be in the range 0 -> 1
+			color.b = uAmplitude * v;
 			gl_FragColor = color;
 		}
 	`

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import ScreenQuadGeometry, { vertexShader } from './ScreenQuadGeometry.svelte'
+  import { Scene, Uniform, Vector2 } from 'three'
+  import { T, useTask, useThrelte } from '@threlte/core'
+  import { Environment, OrbitControls, useFBO, useGltf } from '@threlte/extras'
+
+  let { amplitude = 1, frequency = 1 }: { amplitude?: number; frequency?: number } = $props()
+
+  const { camera, renderStage, renderer, scene, size } = useThrelte()
+
+  const fbo = useFBO()
+  const _scene = new Scene()
+
+  const uTime = new Uniform(0)
+  useTask(
+    (delta) => {
+      uTime.value += delta
+      const last = renderer.getRenderTarget()
+      renderer.setRenderTarget(fbo)
+      renderer.render(scene, camera.current)
+      renderer.setRenderTarget(last)
+      renderer.render(_scene, camera.current)
+    },
+    { stage: renderStage }
+  )
+
+  const fragmentShader = `
+		precision highp float;
+		uniform sampler2D uScene;
+		uniform vec2 uResolution;
+		uniform float uTime;
+		uniform float uAmplitude;
+		uniform float uFrequency;
+		void main() {
+			vec2 uv = gl_FragCoord.xy / uResolution.xy;
+			vec3 color = texture2D(uScene, uv).rgb;
+			color.b = uAmplitude * (1.0 + sin(uFrequency * uTime));
+			gl_FragColor = vec4(color, 1.0);
+		}
+	`
+
+  const uScene = new Uniform(fbo.texture)
+  const uResolution = new Uniform(new Vector2())
+
+  $effect(() => {
+    uResolution.value.set($size.width, $size.height)
+  })
+
+  const gltf = useGltf('/public/models/spaceships/Bob.gltf')
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={5}
+>
+  <OrbitControls />
+</T.PerspectiveCamera>
+
+<!-- this geometry is so simple that frustrum culling it would actually be more work -->
+<T.Mesh
+  frustrumCulled={false}
+  attach={_scene}
+>
+  <T.RawShaderMaterial
+    {vertexShader}
+    {fragmentShader}
+    uniforms={{
+      uAmplitude: {
+        value: 1
+      },
+      uTime: {
+        value: 0
+      },
+      uFrequency: {
+        value: 1
+      }
+    }}
+    uniforms.uScene={uScene}
+    uniforms.uResolution={uResolution}
+    uniforms.uTime={uTime}
+    uniforms.uAmplitude.value={amplitude}
+    uniforms.uFrequency.value={frequency}
+  />
+  <ScreenQuadGeometry />
+</T.Mesh>
+
+{#await gltf then { scene }}
+  <T is={scene} />
+{/await}
+
+<Environment
+  url="/textures/equirectangular/hdr/shanghai_riverside_1k.hdr"
+  isBackground
+/>

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -35,11 +35,12 @@
 		uniform float uTime;
 		uniform float uAmplitude;
 		uniform float uFrequency;
+
 		void main() {
 			vec2 uv = gl_FragCoord.xy / uResolution.xy;
-			vec3 color = texture2D(uScene, uv).rgb;
+			vec4 color = texture2D(uScene, uv);
 			color.b = uAmplitude * 0.5 * (1.0 + sin(uFrequency * uTime));
-			gl_FragColor = vec4(color, 1.0);
+			gl_FragColor = color;
 		}
 	`
 

--- a/apps/docs/src/examples/postprocessing/screen-quad/ScreenQuadGeometry.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/ScreenQuadGeometry.svelte
@@ -1,0 +1,44 @@
+<script
+  lang="ts"
+  module
+>
+  // (-1, 3)
+  //    |\
+  //    | \
+  //    |  \
+  //    |   \
+  //    |    \
+  //    |     \
+  //    |      \
+  //    |       \
+  //    |________\
+  // (-1, -1)   (3, -1)
+  const vertices = new Float32Array([-1, -1, 3, -1, -1, 3])
+
+  export const vertexShader = `
+		precision highp float;
+		attribute vec2 position;
+
+		void main() {
+			gl_Position = vec4(position, 1.0, 1.0);
+		}
+	`
+
+  const center = new Vector3()
+</script>
+
+<script lang="ts">
+  import type { Props } from '@threlte/core'
+  import { BufferAttribute, BufferGeometry, Sphere, Vector3 } from 'three'
+  import { T } from '@threlte/core'
+
+  const geometry = new BufferGeometry()
+  geometry.setAttribute('position', new BufferAttribute(vertices, 2))
+  geometry.boundingSphere = new Sphere().set(center, Infinity)
+
+  let { children }: Props<typeof BufferGeometry> = $props()
+</script>
+
+<T is={geometry}>
+  {@render children?.({ ref: geometry })}
+</T>


### PR DESCRIPTION
an example that demonstrates how to do very basic post-processing

showcases a bunch of cool techniques in a short example

## considerations

drei actually has a [ScreenQuad](https://drei.docs.pmnd.rs/shapes/screen-quad) component but it doesn't tell you that you also need to do more with the shaders and materials in order to use it.

i didn't want to go too deep into explanation. i think that should be left to the viewer to go down that path.