### PR TITLE
[next] fix problem with  text update 

### DIFF
--- a/.changeset/clean-badgers-occur.md
+++ b/.changeset/clean-badgers-occur.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fix problem with update in <Text>

--- a/packages/extras/src/lib/components/Text/Text.svelte
+++ b/packages/extras/src/lib/components/Text/Text.svelte
@@ -15,13 +15,13 @@
     ...props
   }: TextProps = $props()
 
-  const text = new Text()
+  const text3d = new Text()
 
   const { invalidate } = useThrelte()
 
   const onUpdate = async () => {
     await tick()
-    text.sync(() => {
+    text3d.sync(() => {
       invalidate()
       onsync?.()
     })
@@ -40,12 +40,12 @@
 </script>
 
 <T
-  is={text}
+  is={text3d}
   bind:ref
   {...props}
   {font}
   {characters}
   {sdfGlyphSize}
 >
-  {@render children?.({ ref: text })}
+  {@render children?.({ ref: text3d })}
 </T>


### PR DESCRIPTION
#1371 

Name for text change when the text was migrated to Svelte5. But it seems there is a collision in T props values, which causes the problem mentioned at issue. 

Changing troika text name should fix the bug. 