### PR TITLE
(docs) move `Migration-Guides` page to "More" section

### DIFF
--- a/apps/docs/src/content/learn/advanced/migration-guides.mdx
+++ b/apps/docs/src/content/learn/advanced/migration-guides.mdx
@@ -1,5 +1,5 @@
 ---
-category: Advanced
+category: More
 title: Migration Guides
 order: 2
 ---


### PR DESCRIPTION
i think it makes more sense to put it into the "More" section. "advanced" is for advanced topics in threlte or threejs. migration guide fits more with external slightly unrelated things. not sure if that's a good sell but it feels "off-topic" in a way... if that makes sense.