### PR TITLE
Update three-perf dependency version

### DIFF
--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -92,7 +92,7 @@
     "@threejs-kit/instanced-sprite-mesh": "^2.5.0",
     "camera-controls": "^2.9.0",
     "three-mesh-bvh": "^0.7.4",
-    "three-perf": "github:jerzakm/three-perf#three-kit-threlte-fork",
+    "three-perf": "^1.0.10",
     "three-viewport-gizmo": "^2.0.2",
     "troika-three-text": "^0.50.3"
   }


### PR DESCRIPTION
StackBlitz cannot run with a package pointing to a github repo like `github:jerzakm/three-perf#three-kit-threlte-fork`, so this change resolves that issue, and latest @threlte/extras versions can be used on StackBlitz.

@jerzakm's PR to the `three-perf` repo was [merged last month](https://github.com/TheoTheDev/three-perf/commit/e153e36fa154a455f9b16bd147d95535f673b3dd).

Now we can point to the main package!