### PR TITLE
Update three-perf dependency in extras

### DIFF
--- a/.changeset/calm-rockets-search.md
+++ b/.changeset/calm-rockets-search.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Point three-perf dependency to latest version

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -92,7 +92,7 @@
     "@threejs-kit/instanced-sprite-mesh": "^2.5.0",
     "camera-controls": "^2.9.0",
     "three-mesh-bvh": "^0.7.4",
-    "three-perf": "github:jerzakm/three-perf#three-kit-threlte-fork",
+    "three-perf": "^1.0.10",
     "three-viewport-gizmo": "^2.0.2",
     "troika-three-text": "^0.50.3"
   }


### PR DESCRIPTION
Updating the `three-perf` dependency to point at the latest version instead of @jerzakm forked repo because his PR into the main package was [merged last month](https://github.com/TheoTheDev/three-perf/pull/3).

Edit: I forgot to mention, StackBlitz cannot install a package that points to a `git` repo, so @threlte/extras will always fail to install in StackBlitz projects while three-perf is pointed at a github repo (so any version after `9.0.0-next.31`)