### PR TITLE
Fix `<Text>` published types

### DIFF
--- a/.changeset/wise-comics-wonder.md
+++ b/.changeset/wise-comics-wonder.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fix `<Text>` published types

--- a/packages/extras/src/lib/components/Text/Text.svelte
+++ b/packages/extras/src/lib/components/Text/Text.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { observe, T, useThrelte } from '@threlte/core'
   import { tick } from 'svelte'
-  import { preloadFont, Text } from 'troika-three-text'
+  import { preloadFont, Text as TroikaText } from 'troika-three-text'
   import { useSuspense } from '../../suspense/useSuspense'
   import type { TextProps } from './types'
 
@@ -15,7 +15,7 @@
     ...props
   }: TextProps = $props()
 
-  const text = new Text()
+  const text = new TroikaText()
 
   const { invalidate } = useThrelte()
 


### PR DESCRIPTION
Fixes error reported by TS 5.7: `Cannot access ambient const enums when 'verbatimModuleSyntax' is enabled.` which is caused by wrong import in published `Text.svelte.d.ts` file.

It is enough to rename the troika import to `TroikaText`. I suspect this is some edge case for the Svelte package builder which gets confused when the imported symbol has the same name as the component itself. I could also create an issue in Svelte repo, but I'm not sure if Svelte is even the right place to report it as it might come from some thirparty tool used to build the package. Would be great to get some advice here.

```ts
// Published Text.svelte.d.ts
import { Text } from 'troika-three-text'; // <- This is the wrong import
import type { TextProps } from './types';
declare const Text: import("svelte").Component<TextProps, {}, "ref">;
export default Text;
```