### PR TITLE
[threlte studio] fix extension example

### DIFF
--- a/apps/docs/src/content/reference/studio/authoring-extensions.mdx
+++ b/apps/docs/src/content/reference/studio/authoring-extensions.mdx
@@ -70,7 +70,7 @@ This file implements the extension. Furthermore, it has full access to the Threl
 
   const { createExtension } = useStudio()
 
-  createExtension<ExtensionState, ExtensionActions>({
+  const extension = createExtension<ExtensionState, ExtensionActions>({
     scope: extensionScope,
     state({ persist }) {
       return {


### PR DESCRIPTION
Just a small change to fix the example for creating your own extensions to threlte studio, as it currently throws `Uncaught ReferenceError: extension is not defined` when the decrement or increment button is pressed.