### PR TITLE
fix(docs): screenquad postprocessing example

### DIFF
--- a/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
+++ b/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
@@ -9,7 +9,7 @@ The basic idea of postprocessing is to draw the scene to a frame-buffer that can
 1. a webgl render target
 2. a separate scene from the one that threlte provides
 
-The [`useFBO`](/docs/reference/extras/use-fbo) hook returns a render target. This will be what we render the main scene to every frame and pass into the fragment shader as a texture.
+A [WebGLRenderTarget](https://threejs.org/docs/index.html?q=webgl#api/en/renderers/WebGLRenderTarget) is created and its size is set up to follow the size of the canvas.
 
 A separate scene is needed so that we can add the screen-quad mesh to it and render it. The idea is that the only thing in this scene will be the screen-quad mesh that has the post-processed scene as its material. This mesh can't be added to the main scene because it would cause a circular dependency.
 

--- a/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
+++ b/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
@@ -1,4 +1,4 @@
-This example demonstrates a well-known technique for doing simple postprocessing utilizing a "screen-quad". Mouse around the canvas to see the effect.
+This example demonstrates a well-known technique for doing simple postprocessing utilizing a "screen-quad".
 
 <Example path="postprocessing/screen-quad" />
 

--- a/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/App.svelte
@@ -1,24 +1,8 @@
 <script lang="ts">
-  import { Pane, Slider } from 'svelte-tweakpane-ui'
   import Scene from './Scene.svelte'
   import { Canvas } from '@threlte/core'
-
-  let radius = $state(0.05)
 </script>
 
-<Pane
-  position="fixed"
-  title="simple post-processing"
->
-  <Slider
-    label="radius"
-    bind:value={radius}
-    min={0.01}
-    max={0.1}
-    step={0.01}
-  />
-</Pane>
-
 <Canvas autoRender={false}>
-  <Scene {radius} />
+  <Scene />
 </Canvas>

--- a/apps/docs/src/examples/postprocessing/screen-quad/ScreenQuadGeometry.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/ScreenQuadGeometry.svelte
@@ -17,10 +17,14 @@
 
   export const vertexShader = `
 		precision highp float;
+
 		attribute vec2 position;
 
+		varying vec2 vUv;
+
 		void main() {
-			gl_Position = vec4(position, 1.0, 1.0);
+			vUv = 0.5 * (position + 1.0);
+			gl_Position = vec4(position, 0.0, 1.0);
 		}
 	`
 
@@ -32,13 +36,21 @@
   import { BufferAttribute, BufferGeometry, Sphere, Vector3 } from 'three'
   import { T } from '@threlte/core'
 
-  const geometry = new BufferGeometry()
-  geometry.setAttribute('position', new BufferAttribute(vertices, 2))
-  geometry.boundingSphere = new Sphere().set(center, Infinity)
+  let {
+    ref = $bindable(new BufferGeometry()),
+    children,
+    ...restProps
+  }: Props<BufferGeometry> = $props()
 
-  let { children }: Props<typeof BufferGeometry> = $props()
+  ref.setAttribute('position', new BufferAttribute(vertices, 2))
+  ref.boundingSphere = new Sphere().set(center, Infinity)
 </script>
 
-<T is={geometry}>
-  {@render children?.({ ref: geometry })}
+<T
+  is={ref}
+  {...restProps}
+>
+  {@render children?.({
+    ref
+  })}
 </T>


### PR DESCRIPTION
the shader for [this example](https://threlte.xyz/docs/examples/postprocessing/screenquad) broke somewhere along the line.

this pr fixes the shader and makes the example simpler. mobile users didn't have a way to move the spotlight around in the old example. now the effect is just a circle that grows and shrinks. this means that no matter what device you're using, the experience is the same.