### PR TITLE
Update secure context check getXRSupportState.ts

### DIFF
--- a/packages/xr/src/lib/lib/getXRSupportState.ts
+++ b/packages/xr/src/lib/lib/getXRSupportState.ts
@@ -10,7 +10,7 @@ export const getXRSupportState = async (
     return 'unsupported'
   }
 
-  if (location.protocol !== 'https:') {
+  if (!window.isSecureContext) {
     return 'insecure'
   }
 


### PR DESCRIPTION
Solely checking for `https` causes an address like `http://localhost:5173` to be treated as 'insecure', despite the fact that localhost is indeed a sufficient secure context for WebXR to run in.