### PR TITLE
[docs] Fix link to Three.js Draco library example

### DIFF
--- a/apps/docs/src/content/reference/gltf/getting-started.mdx
+++ b/apps/docs/src/content/reference/gltf/getting-started.mdx
@@ -178,7 +178,7 @@ Make contents conditional:
 
 ## DRACO Compression
 
-You don't need to do anything if your models are draco compressed, since `useGltf` defaults to a [draco CDN](https://www.gstatic.com/draco/v1/decoders/). By adding the `--draco` flag you can refer to [local binaries](https://github.com/mrdoob/three.js/tree/dev/examples/js/libs/draco/gltf) which must reside in your /public folder.
+You don't need to do anything if your models are draco compressed, since `useGltf` defaults to a [draco CDN](https://www.gstatic.com/draco/v1/decoders/). By adding the `--draco` flag you can refer to [local binaries](https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco/gltf) which must reside in your /public folder.
 
 ## Auto-Transform
 


### PR DESCRIPTION
Path is now `jsm` instead of `js`. Current link 404s.