### PR TITLE
Fix TriMesh & ConvexHull auto colliders

### DIFF
--- a/.changeset/sweet-ducks-sort.md
+++ b/.changeset/sweet-ducks-sort.md
@@ -1,0 +1,5 @@
+---
+"@threlte/rapier": minor
+---
+
+Fix TriMesh & ConvexHull auto colliders

--- a/packages/rapier/src/lib/lib/createCollidersFromChildren.ts
+++ b/packages/rapier/src/lib/lib/createCollidersFromChildren.ts
@@ -121,12 +121,16 @@ export const createCollidersFromChildren = (
 
         case 'convexHull':
           {
-            const scaleX = scale.x
+            const scaleX = scale.x;
+						const scaleY = scale.y;
+						const scaleZ = scale.z;
             const vertices = new Float32Array(geometry.attributes.position.array)
             if (scaleX !== 1) {
-              for (let i = 0; i < vertices.length; i++) {
-                vertices[i] *= scaleX
-              }
+              for (let i = 0; i < vertices.length; i += 3) {
+								vertices[i] *= scaleX;
+								vertices[i + 1] *= scaleY;
+								vertices[i + 2] *= scaleZ;
+						}
             }
             description = ColliderDesc.convexHull(vertices) as ColliderDesc
           }

--- a/packages/rapier/src/lib/lib/createCollidersFromChildren.ts
+++ b/packages/rapier/src/lib/lib/createCollidersFromChildren.ts
@@ -91,16 +91,20 @@ export const createCollidersFromChildren = (
 
         case 'trimesh':
           {
-            const scaleX = scale.x
+            const { x: scaleX, y: scaleY, z: scaleZ } = scale
             const vertices = new Float32Array(geometry.attributes.position.array)
-            if (scaleX !== 1) {
-              for (let i = 0; i < vertices.length; i++) {
+            if (scaleX !== 1 || scaleY !== 1 || scaleZ !== 1) {
+              for (let i = 0; i < vertices.length; i += 3) {
                 vertices[i] *= scaleX
+                vertices[i + 1] *= scaleY
+                vertices[i + 2] *= scaleZ
               }
             }
             description = ColliderDesc.trimesh(
               vertices,
-              new Uint32Array(geometry.index?.array ?? [])
+              new Uint32Array(
+                geometry.index?.array ?? Uint32Array.from(Array(vertices.length / 3).keys())
+              )
             )
           }
           break
@@ -121,16 +125,14 @@ export const createCollidersFromChildren = (
 
         case 'convexHull':
           {
-            const scaleX = scale.x;
-						const scaleY = scale.y;
-						const scaleZ = scale.z;
+            const { x: scaleX, y: scaleY, z: scaleZ } = scale
             const vertices = new Float32Array(geometry.attributes.position.array)
-            if (scaleX !== 1) {
+            if (scaleX !== 1 || scaleY !== 1 || scaleZ !== 1) {
               for (let i = 0; i < vertices.length; i += 3) {
-								vertices[i] *= scaleX;
-								vertices[i + 1] *= scaleY;
-								vertices[i + 2] *= scaleZ;
-						}
+                vertices[i] *= scaleX
+                vertices[i + 1] *= scaleY
+                vertices[i + 2] *= scaleZ
+              }
             }
             description = ColliderDesc.convexHull(vertices) as ColliderDesc
           }


### PR DESCRIPTION
Hi, here's a small PR that fix two auto colliders types, the TriMesh and ConvexHull.
Indeed, there was an issue where these two were not using the Y and Z axis scaling, resulting in an inaccurate collider generation.

Also, there is a possibility that a geometry doesn't have its index, and in the TriMesh setup if there were none it would pass an empty index array. This was causing an exception down in rapier stack along the line of https://github.com/dimforge/rapier.js/issues/234 (seems like the shape could not be created with empty index and was undefined). So now we are generating a default index.

I did test these autocolliders against complex gltf models and they successfully generated accurate colliders.