### PR TITLE
feat: Add fadeOrigin parameter to Grid

### DIFF
--- a/.changeset/rotten-forks-refuse.md
+++ b/.changeset/rotten-forks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": minor
+---
+
+Add fadeOrigin parameter to Grid

--- a/apps/docs/src/content/reference/extras/grid.mdx
+++ b/apps/docs/src/content/reference/extras/grid.mdx
@@ -32,6 +32,13 @@ componentSignature:
         { name: 'fadeDistance', type: 'number', default: '100', required: false },
         { name: 'fadeStrength', type: 'number', default: '1', required: false },
         {
+          name: 'fadeOrigin',
+          type: 'Vector3',
+          default: 'undefined',
+          required: false,
+          description: 'Set a custom fading point of origin. The current camera position will be used if unset.'
+        },
+        {
           name: type,
           type: "'grid' | 'lines' | 'circular' | 'polar'",
           default: "'grid'",
@@ -106,7 +113,7 @@ You can adjust the color and thickness of cell and section lines with `cellColor
 
 The `<Grid>` component is a `THREE.Mesh` with a `PlaneGeometry` attached to it. The `gridSize` parameter defines the size of the `PlaneGeometry`.
 You can extend the grid into infinity if you set the `infiniteGrid` parameter to `true`.
-Changing `fadeDistance` sets how far from the camera position the grid begins to fade by having its alpha reduced. `fadeStrength` determines how fast it happens (exponent). `fadeStrength = 0` means that there is no fading (not recommended for large grids).
+Changing `fadeDistance` sets how far from the camera position the grid begins to fade by having its alpha reduced. `fadeStrength` determines how fast it happens (exponent). `fadeStrength = 0` means that there is no fading (not recommended for large grids). You can change the fading point of origin to not be the camera position but a custom point by setting `fadeOrigin`.
 
 ### Custom geometry
 

--- a/apps/docs/src/examples/extras/grid/App.svelte
+++ b/apps/docs/src/examples/extras/grid/App.svelte
@@ -2,8 +2,8 @@
   import Scene from './Scene.svelte'
   import { Canvas, T } from '@threlte/core'
   import { Checkbox, Color, Folder, Pane, List, Slider } from 'svelte-tweakpane-ui'
-  import { Grid } from '@threlte/extras'
-  import { PlaneGeometry } from 'three'
+  import { Grid, TransformControls } from '@threlte/extras'
+  import { PlaneGeometry, Vector3 } from 'three'
   import { SimplexNoise } from 'three/examples/jsm/Addons.js'
 
   let cellSize = $state(1)
@@ -23,6 +23,8 @@
 
   let followCamera = $state(false)
   let infiniteGrid = $state(false)
+  let useFadeOrigin = $state(false)
+  let fadeOrigin = $state(new Vector3())
   let fadeDistance = $state(100)
   let backgroundColor = $state('#003eff')
   let backgroundOpacity = $state(0)
@@ -142,6 +144,10 @@
       bind:value={infiniteGrid}
       label="infinite Grid"
     />
+    <Checkbox
+      bind:value={useFadeOrigin}
+      label="use fade origin"
+    />
     <Slider
       bind:value={fadeDistance}
       label="fade distance"
@@ -216,6 +222,14 @@
 
 <div>
   <Canvas>
+    <TransformControls
+      showX={useFadeOrigin}
+      showY={useFadeOrigin}
+      showZ={useFadeOrigin}
+      onobjectChange={(e) => {
+        fadeOrigin = e.target.object.position.clone()
+      }}
+    />
     {#if gridGeometryIsTerrain}
       <Grid
         position.y={-2}
@@ -230,6 +244,7 @@
         {infiniteGrid}
         {fadeDistance}
         {fadeStrength}
+        fadeOrigin={useFadeOrigin ? fadeOrigin : undefined}
         {gridSize}
         {backgroundColor}
         {backgroundOpacity}
@@ -254,6 +269,7 @@
         {infiniteGrid}
         {fadeDistance}
         {fadeStrength}
+        fadeOrigin={useFadeOrigin ? fadeOrigin : undefined}
         {gridSize}
         {backgroundColor}
         {backgroundOpacity}

--- a/packages/extras/src/lib/components/Grid/Grid.svelte
+++ b/packages/extras/src/lib/components/Grid/Grid.svelte
@@ -18,6 +18,7 @@
     infiniteGrid = false,
     fadeDistance = 100,
     fadeStrength = 1,
+    fadeOrigin = undefined,
     cellThickness = 1,
     sectionThickness = 2,
     side = DoubleSide,
@@ -82,6 +83,9 @@
     },
     fadeStrength: {
       value: fadeStrength
+    },
+    fadeOrigin: {
+      value: new Vector3()
     },
     cellThickness: {
       value: cellThickness
@@ -172,6 +176,12 @@
     invalidate()
   })
   $effect.pre(() => {
+    if (fadeOrigin) {
+      uniforms.fadeOrigin.value = fadeOrigin
+      invalidate()
+    }
+  })
+  $effect.pre(() => {
     uniforms.cellThickness.value = cellThickness
     invalidate()
   })
@@ -222,8 +232,15 @@
       const material = mesh.material as ShaderMaterial
       const worldCamProjPosition = material.uniforms.worldCamProjPosition as Uniform<Vector3>
       const worldPlanePosition = material.uniforms.worldPlanePosition as Uniform<Vector3>
+      const uFadeOrigin = material.uniforms.fadeOrigin as Uniform<Vector3>
 
-      gridPlane.projectPoint(camera.current.position, worldCamProjPosition.value)
+      const projectedPoint = gridPlane.projectPoint(
+        camera.current.position,
+        worldCamProjPosition.value
+      )
+      if (!fadeOrigin) {
+        uFadeOrigin.value = projectedPoint
+      }
       worldPlanePosition.value.set(0, 0, 0).applyMatrix4(mesh.matrixWorld)
     },
     { autoInvalidate: false }

--- a/packages/extras/src/lib/components/Grid/gridShaders.ts
+++ b/packages/extras/src/lib/components/Grid/gridShaders.ts
@@ -49,6 +49,7 @@ export const fragmentShader = /*glsl*/ `
 	uniform vec3 sectionColor;
 	uniform float fadeDistance;
 	uniform float fadeStrength;
+	uniform vec3 fadeOrigin;
 	uniform float cellThickness;
 	uniform float sectionThickness;
 	uniform vec3 backgroundColor;
@@ -143,7 +144,7 @@ if (!infiniteGrid && circleGridMaxRadius > 0.0 && rad > circleGridMaxRadius + th
 			g2 = getPolarGrid(sectionSize, sectionThickness, polarSectionDividers, localPos);
 		}
 
-		float dist = distance(worldCamProjPosition, worldPosition.xyz);
+		float dist = distance(fadeOrigin, worldPosition.xyz);
 		float d = 1.0 - min(dist / fadeDistance, 1.0);
 		float fadeFactor = pow(d, fadeStrength) * 0.95;
 

--- a/packages/extras/src/lib/components/Grid/types.ts
+++ b/packages/extras/src/lib/components/Grid/types.ts
@@ -1,5 +1,5 @@
 import type { Props } from '@threlte/core'
-import type { ColorRepresentation, Mesh, Side } from 'three'
+import type { ColorRepresentation, Mesh, Side, Vector3 } from 'three'
 
 export type GridProps = Props<Mesh> & {
   /**
@@ -71,6 +71,11 @@ export type GridProps = Props<Mesh> & {
    * @default 1
    */
   fadeStrength?: number
+
+  /**
+   * @default undefined, uses camera.current.position
+   */
+  fadeOrigin?: Vector3
 
   /**
    * @default Three.DoubleSide


### PR DESCRIPTION
This is a simple attempt at #1443 and allows overriding the fading point of origin to not just be the camera positon. Custom things like fading around an OrbitControl's lookAt vector or offsets thereof can be achieved more easily with this.

Let me know if there are any problems with this or additional steps are required to get this in.