### PR TITLE
fix: Better TransformControl for Grid fadeOrigin demo

### DIFF
--- a/apps/docs/src/examples/extras/grid/App.svelte
+++ b/apps/docs/src/examples/extras/grid/App.svelte
@@ -222,14 +222,14 @@
 
 <div>
   <Canvas>
-    <TransformControls
-      showX={useFadeOrigin}
-      showY={useFadeOrigin}
-      showZ={useFadeOrigin}
-      onobjectChange={(e) => {
-        fadeOrigin = e.target.object.position.clone()
-      }}
-    />
+    {#if useFadeOrigin}
+      <TransformControls
+        position={fadeOrigin.toArray()}
+        onobjectChange={(e) => {
+          fadeOrigin = e.target.object.position.clone()
+        }}
+      />
+    {/if}
     {#if gridGeometryIsTerrain}
       <Grid
         position.y={-2}


### PR DESCRIPTION
When implementing the demo for this the other day I ran into problems with the disposal of the TransformControl. However, after going at it fresh now, it seems to work as intended just fine. This fixes an issue with the control potentially causing infinity or NaN values when hidden around 0,0,0 while the user rotates the OrbitControls.