### PR TITLE
Bump troika-three-text in extras. 

### DIFF
--- a/.changeset/green-pillows-pretend.md
+++ b/.changeset/green-pillows-pretend.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": minor
+---
+
+Bump troika-three-text 0.50.3 -> 0.52.4

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -94,6 +94,6 @@
     "three-mesh-bvh": "^0.7.4",
     "three-perf": "github:jerzakm/three-perf#three-kit-threlte-fork",
     "three-viewport-gizmo": "^2.0.2",
-    "troika-three-text": "^0.50.3"
+    "troika-three-text": "^0.52.4"
   }
 }


### PR DESCRIPTION
Addressing getter/setter changes of customDepthMaterial in threejs 0.175.0. See https://github.com/protectwise/troika/commit/78e00b512eb9618623d248070ba75ea0c55803ee