### PR TITLE
Windows Chrome scrollbar CSS fix

### DIFF
--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -21,23 +21,30 @@
   scrollbar-width: none; /* Firefox */
 }
 
-/* width */
-::-webkit-scrollbar {
-  width: 6px;
+/* Modern browsers with `scrollbar-*` support */
+@supports (scrollbar-width: auto) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: #2f7dc630 rgba(0, 0, 255, 0);
+  }
 }
 
-/* Track */
-::-webkit-scrollbar-track {
-  border-radius: 8px;
-}
+/* Legacy browsers with `::-webkit-scrollbar-*` support */
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar {
+    width: 6px;
+  }
 
-/* Handle */
-::-webkit-scrollbar-thumb {
-  background: #2f7dc630;
-  border-radius: 10px;
-}
+  ::-webkit-scrollbar-track {
+    border-radius: 8px;
+  }
 
-/* Handle on hover */
-::-webkit-scrollbar-thumb:hover {
-  background: #2f7dc6aa;
+  ::-webkit-scrollbar-thumb {
+    background: #2f7dc630;
+    border-radius: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #2f7dc6aa;
+  }
 }


### PR DESCRIPTION
This fix is for an issue affecting Chrome on Windows where the left sidebar content is not rendering correctly:

https://github.com/user-attachments/assets/e8a9e2b6-afd2-4506-be6a-2f1baebe1ddf

This fix uses scrollbar-* CSS properties and the recommended backwards-compatible approach suggested here:

https://developer.chrome.com/docs/css-ui/scrollbar-styling#supporting_older_browser_versions

Tested in Windows (Chrome/Edge/Firefox) and macOS (Safari/Chrome).