### PR TITLE
update tsconfigs

### DIFF
--- a/.changeset/good-feet-mix.md
+++ b/.changeset/good-feet-mix.md
@@ -1,0 +1,11 @@
+---
+"@threlte/theatre": patch
+"@threlte/extras": patch
+"@threlte/rapier": patch
+"@threlte/studio": patch
+"@threlte/core": patch
+"@threlte/flex": patch
+"@threlte/xr": patch
+---
+
+Update tsconfig

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,15 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
-    "strict": true
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
   }
 }

--- a/packages/extras/tsconfig.json
+++ b/packages/extras/tsconfig.json
@@ -1,6 +1,15 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
-    "strict": true
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
   }
 }

--- a/packages/flex/tsconfig.json
+++ b/packages/flex/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
     "strict": true,
-    "moduleResolution": "Bundler"
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
   }
 }

--- a/packages/rapier/tsconfig.json
+++ b/packages/rapier/tsconfig.json
@@ -2,7 +2,16 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "noErrorTruncation": true,
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
     "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "paths": {
       "$lib": ["./src/lib"],
       "$lib/*": ["./src/lib/*"],

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
     "strict": true,
-    "moduleResolution": "Bundler"
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
   }
 }

--- a/packages/theatre/tsconfig.json
+++ b/packages/theatre/tsconfig.json
@@ -2,6 +2,15 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "noErrorTruncation": true,
-    "strict": true
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
   }
 }

--- a/packages/xr/tsconfig.json
+++ b/packages/xr/tsconfig.json
@@ -2,16 +2,19 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "resolveJsonModule": true,
-    "moduleResolution": "bundler",
-
     "allowJs": true,
     "checkJs": true,
-    "verbatimModuleSyntax": true,
-
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
     "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "target": "ESNext",
+
+    "verbatimModuleSyntax": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
closes #1471

rapier and studio packages had `"moduleResolution": "bundler",` which I changed but can revert if the edit was inappropriate there.

The thought process was to use the defaults that [ben talked about](https://github.com/threlte/threlte/issues/1471#issuecomment-2825443883) but could be slimmed down further to aiming at just the `"module": "NodeNext",` and `"moduleResolution": "NodeNext"` within the configs