### PR TITLE
Change renderer effects to effects.pre

### DIFF
--- a/.changeset/ninety-planets-own.md
+++ b/.changeset/ninety-planets-own.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": patch
+---
+
+Change renderer.svelte.ts effects to effects.pre

--- a/packages/core/src/lib/context/fragments/renderer.svelte.ts
+++ b/packages/core/src/lib/context/fragments/renderer.svelte.ts
@@ -175,19 +175,19 @@ export const createRendererContext = <T extends Renderer>(
     }
   })
 
-  $effect(() => {
+  $effect.pre(() => {
     context.colorManagementEnabled.set(options.colorManagementEnabled ?? true)
   })
-  $effect(() => {
+  $effect.pre(() => {
     context.colorSpace.set(options.colorSpace ?? 'srgb')
   })
-  $effect(() => {
+  $effect.pre(() => {
     context.toneMapping.set(options.toneMapping ?? AgXToneMapping)
   })
-  $effect(() => {
+  $effect.pre(() => {
     context.shadows.set(options.shadows ?? PCFSoftShadowMap)
   })
-  $effect(() => {
+  $effect.pre(() => {
     context.dpr.set(options.dpr ?? window.devicePixelRatio)
   })
 


### PR DESCRIPTION
fix #1535 

Apply the value from options or the default value in effect.pre to avoid overwriting values in the onMount function of the children components. 