### PR TITLE
Remove self ref assignment in Environment component

### DIFF
--- a/.changeset/smart-walls-suffer.md
+++ b/.changeset/smart-walls-suffer.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Remove self ref assignment in Environment component

--- a/packages/extras/src/lib/components/environment/Environment/Environment.svelte
+++ b/packages/extras/src/lib/components/environment/Environment/Environment.svelte
@@ -62,7 +62,7 @@
     return loaders.tex
   })
 
-  $effect(() => {
+  $effect.pre(() => {
     if (url === undefined || loader === undefined) {
       return
     }
@@ -91,12 +91,7 @@
   {#if texture}
     <T
       is={GroundedSkybox}
-      oncreate={() => {
-        return () => {
-          skybox = undefined
-        }
-      }}
-      bind:ref={skybox as GroundedSkybox}
+      bind:ref={skybox}
       args={[texture, options.height ?? 1, options.radius ?? 1, options.resolution ?? 128]}
     />
   {/if}


### PR DESCRIPTION
The `skybox = undefined` assignment is unnecessary and causes infinite effect loop problems if `oncreate` is run in an $effect - which is the case[ in the performance refactor PR](https://github.com/threlte/threlte/pull/1533).