### PR TITLE
[core] only reset default camera if no T components with makeDefault exist

### DIFF
--- a/.changeset/small-tips-heal.md
+++ b/.changeset/small-tips-heal.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": patch
+---
+
+Fix: only reset default camera if no T components with makeDefault exist

--- a/packages/core/src/lib/components/T/T.svelte
+++ b/packages/core/src/lib/components/T/T.svelte
@@ -85,7 +85,7 @@
       isInstanceOf(internalRef, 'OrthographicCamera')
     ) {
       useCamera(
-        internalRef,
+        () => internalRef,
         () => manual,
         () => makeDefault
       )

--- a/packages/core/src/lib/components/T/__tests__/__fixtures__/Camera.svelte
+++ b/packages/core/src/lib/components/T/__tests__/__fixtures__/Camera.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+
+  interface Props {
+    perspective: boolean
+  }
+
+  let { perspective }: Props = $props()
+</script>
+
+{#if perspective}
+  <T.PerspectiveCamera
+    makeDefault
+    position={[1, 2, 3]}
+  />
+{:else}
+  <T.OrthographicCamera
+    makeDefault
+    position={[4, 5, 6]}
+  />
+{/if}

--- a/packages/core/src/lib/context/fragments/camera.ts
+++ b/packages/core/src/lib/context/fragments/camera.ts
@@ -28,6 +28,12 @@ export const createCameraContext = (): CameraContext => {
     }
   })
 
+  watch(camera, ($camera) => {
+    if ($camera === undefined) {
+      camera.set(defaultCamera)
+    }
+  })
+
   const context: CameraContext = { camera }
 
   setContext<CameraContext>('threlte-camera-context', context)


### PR DESCRIPTION
Also adds test coverage for multiple cameras with `makeDefault` props