### PR TITLE
[core] Fix: unattach correct object3d reference on unmount

### DIFF
--- a/.changeset/hungry-eggs-divide.md
+++ b/.changeset/hungry-eggs-divide.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": patch
+---
+
+Fix: unattach correct object3d reference on unmount

--- a/packages/core/src/lib/components/T/__tests__/__fixtures__/Attach.svelte
+++ b/packages/core/src/lib/components/T/__tests__/__fixtures__/Attach.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+  import AttachChild from './AttachChild.svelte'
+  import { Mesh } from 'three'
+
+  interface Props {
+    attach: boolean
+  }
+
+  let { attach }: Props = $props()
+
+  let object3d = $derived(attach ? new Mesh() : undefined)
+</script>
+
+<T.Group name="parent">
+  {#if object3d}
+    <AttachChild {object3d} />
+  {:else}
+    <T.Group name="child2" />
+  {/if}
+</T.Group>

--- a/packages/core/src/lib/components/T/__tests__/__fixtures__/AttachChild.svelte
+++ b/packages/core/src/lib/components/T/__tests__/__fixtures__/AttachChild.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+
+  let { object3d } = $props()
+</script>
+
+<T
+  is={object3d}
+  name="child"
+/>
+
+<T.BoxHelper args={[object3d, 'red']} />

--- a/packages/core/src/lib/components/T/__tests__/attach.spec.ts
+++ b/packages/core/src/lib/components/T/__tests__/attach.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render } from '@threlte/test'
 import { T } from '../T'
 import Scene from './__fixtures__/Scene.svelte'
+import Attach from './__fixtures__/Attach.svelte'
 
 describe('<T> attach', () => {
   it('attaches and detaches to an object that is passed to "attach"', () => {
@@ -89,5 +90,28 @@ describe('<T> attach', () => {
 
     unmount()
     expect(material.map).toBeFalsy()
+  })
+
+  it('attaches and detaches a conditionally rendered component', async () => {
+    const { scene, rerender } = render(Attach, { props: { attach: false } })
+
+    const parent = scene.getObjectByName('parent')
+    expect(scene.getObjectByName('child')).toBeFalsy()
+    expect(scene.getObjectByName('child2')).toBeTruthy()
+    expect(parent?.children.length).toBe(1)
+
+    await rerender({ attach: true })
+
+    const child = scene.getObjectByName('child')
+    expect(child?.parent).toBe(parent)
+    expect(scene.getObjectByName('child2')).toBeFalsy()
+    expect(parent?.children.length).toBe(2)
+
+    await rerender({ attach: false })
+
+    expect(child?.parent).toBeFalsy()
+    expect(scene.getObjectByName('child')).toBeFalsy()
+    expect(scene.getObjectByName('child2')).toBeTruthy()
+    expect(parent?.children.length).toBe(1)
   })
 })

--- a/packages/core/src/lib/components/T/utils/useCamera.svelte.ts
+++ b/packages/core/src/lib/components/T/utils/useCamera.svelte.ts
@@ -20,12 +20,14 @@ export const useCamera = (
       return
     }
 
-    defaultCameras.add(camera)
-    defaultCamera.set(camera)
+    const current = camera
+
+    defaultCameras.add(current)
+    defaultCamera.set(current)
     invalidate()
 
     return () => {
-      defaultCameras.delete(camera)
+      defaultCameras.delete(current)
       if (defaultCameras.size === 0) {
         defaultCamera.set(undefined!)
         invalidate()


### PR DESCRIPTION
* Fixes incorrect reference being removed from scene when the source of `<T is={...}>` is a `$derived` that can become undefined.
* Adds tests