### PR TITLE
[chore] type imports adjustments

### DIFF
--- a/.changeset/loud-squids-laugh.md
+++ b/.changeset/loud-squids-laugh.md
@@ -1,0 +1,10 @@
+---
+"@threlte/extras": patch
+"@threlte/flex": patch
+"@threlte/rapier": patch
+"@threlte/studio": patch
+"@threlte/theatre": patch
+"@threlte/docs": patch
+---
+
+[chore] type imports adjustments

--- a/apps/docs/src/examples/rapier/framerate-debug/Scene.svelte
+++ b/apps/docs/src/examples/rapier/framerate-debug/Scene.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
+  import type { RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
   import { T } from '@threlte/core'
   import { Attractor, AutoColliders, RigidBody } from '@threlte/rapier'
 

--- a/apps/docs/src/examples/rapier/rocketry/IsStatic.svelte
+++ b/apps/docs/src/examples/rapier/rocketry/IsStatic.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type RigidBody as RapierRigidBody, type Vector } from '@dimforge/rapier3d-compat'
+  import type { RigidBody as RapierRigidBody, Vector } from '@dimforge/rapier3d-compat'
   import { useTask } from '@threlte/core'
   import { useRapier } from '@threlte/rapier'
   import { Vector3 } from 'three'

--- a/apps/docs/src/examples/rapier/rocketry/Player.svelte
+++ b/apps/docs/src/examples/rapier/rocketry/Player.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
+  import type { RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
   import { T, useTask } from '@threlte/core'
   import { Portal, Text } from '@threlte/extras'
   import { useRapier } from '@threlte/rapier'

--- a/apps/docs/src/examples/studio/getting-started/Tour/Tour/instructions/Instructions.ts
+++ b/apps/docs/src/examples/studio/getting-started/Tour/Tour/instructions/Instructions.ts
@@ -1,4 +1,4 @@
-import { type Placement } from '@floating-ui/dom'
+import type { Placement } from '@floating-ui/dom'
 
 export interface Instructions {
   content: {

--- a/packages/extras/src/lib/components/environment/CubeEnvironment/types.ts
+++ b/packages/extras/src/lib/components/environment/CubeEnvironment/types.ts
@@ -1,4 +1,4 @@
-import { type CubeTexture } from 'three'
+import type { CubeTexture } from 'three'
 import type { CommonEnvironmentProps } from '../types'
 
 export type CubeEnvironmentProps = CommonEnvironmentProps<CubeTexture> & {

--- a/packages/flex/src/lib/Box/types.ts
+++ b/packages/flex/src/lib/Box/types.ts
@@ -1,4 +1,4 @@
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 import type { NodeProps } from '../lib/props'
 
 export type BoxProps = NodeProps & {

--- a/packages/rapier/src/lib/components/Colliders/AutoColliders/types.ts
+++ b/packages/rapier/src/lib/components/Colliders/AutoColliders/types.ts
@@ -1,5 +1,5 @@
 import type { CoefficientCombineRule, Collider } from '@dimforge/rapier3d-compat'
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 import type { Euler, Vector3 } from 'three'
 import type { AutoCollidersShapes, ColliderEvents, CreateEvent } from '../../../types/types'
 

--- a/packages/rapier/src/lib/components/Colliders/Collider/types.ts
+++ b/packages/rapier/src/lib/components/Colliders/Collider/types.ts
@@ -4,7 +4,7 @@ import type {
   ColliderDesc,
   Collider as RapierCollider
 } from '@dimforge/rapier3d-compat'
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 import type { Euler, Vector3 } from 'three'
 import type { ColliderEvents, CreateEvent } from '../../../types/types'
 

--- a/packages/rapier/src/lib/components/CollisionGroups/types.ts
+++ b/packages/rapier/src/lib/components/CollisionGroups/types.ts
@@ -1,4 +1,4 @@
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 
 type N = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15
 

--- a/packages/rapier/src/lib/components/RigidBody/types.ts
+++ b/packages/rapier/src/lib/components/RigidBody/types.ts
@@ -1,5 +1,5 @@
 import { RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 import type { Euler, Vector3 } from 'three'
 import type { RigidBodyTypeString } from '../../lib/parseRigidBodyType'
 import type { CreateEvent, RigidBodyEvents } from '../../types/types'

--- a/packages/rapier/src/lib/components/RigidBody/types.ts
+++ b/packages/rapier/src/lib/components/RigidBody/types.ts
@@ -1,4 +1,4 @@
-import { RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
+import type { RigidBody as RapierRigidBody } from '@dimforge/rapier3d-compat'
 import type { Snippet } from 'svelte'
 import type { Euler, Vector3 } from 'three'
 import type { RigidBodyTypeString } from '../../lib/parseRigidBodyType'

--- a/packages/rapier/src/lib/components/World/types.ts
+++ b/packages/rapier/src/lib/components/World/types.ts
@@ -14,7 +14,7 @@ import type {
   RawSerializationPipeline
 } from '@dimforge/rapier3d-compat/raw'
 import type { Key, Stage } from '@threlte/core'
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 import type { Vector3 } from 'three'
 
 export type WorldProps = {

--- a/packages/studio/src/lib/extensions/inspector/Inspector.svelte
+++ b/packages/studio/src/lib/extensions/inspector/Inspector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Element, Pane, Separator } from 'svelte-tweakpane-ui'
-  import { type Pane as TpPane } from 'tweakpane'
+  import type { Pane as TpPane } from 'tweakpane'
   import ToolbarButton from '../../components/ToolbarButton.svelte'
   import ToolbarItem from '../../components/ToolbarItem.svelte'
   import { browser } from '../../internal/browser'

--- a/packages/studio/src/lib/extensions/scene-hierarchy/SceneHierarchy.svelte
+++ b/packages/studio/src/lib/extensions/scene-hierarchy/SceneHierarchy.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Element, Pane } from 'svelte-tweakpane-ui'
-  import { type Pane as TpPane } from 'tweakpane'
+  import type { Pane as TpPane } from 'tweakpane'
   import Portal from '../../components/Portal.svelte'
   import ToolbarButton from '../../components/ToolbarButton.svelte'
   import ToolbarItem from '../../components/ToolbarItem.svelte'

--- a/packages/theatre/src/lib/sheetObject/types.ts
+++ b/packages/theatre/src/lib/sheetObject/types.ts
@@ -1,5 +1,5 @@
 import type { ISheetObject, UnknownShorthandCompoundProps } from '@theatre/core'
-import { type Snippet } from 'svelte'
+import type { Snippet } from 'svelte'
 import type Declare from './declare/Declare.svelte'
 import type Sync from './sync/Sync.svelte'
 import type Transform from './transform/Transform.svelte'


### PR DESCRIPTION
used AI to generate the following regex to vscode search the monorepo. 

`import\s*\{\s*(?=.*type\s+\w)((type\s+\w+\s*,?\s*)*(\w+\s*,?\s*))*\}\s*from\s*['"][^'"]+['"]`

We probably good enough on this front