### PR TITLE
move ShadowMaterial page to Visual Effects section

### DIFF
--- a/apps/docs/src/content/reference/extras/shadow-material.mdx
+++ b/apps/docs/src/content/reference/extras/shadow-material.mdx
@@ -1,5 +1,5 @@
 ---
-order: 4.14
+order: 5.9
 category: '@threlte/extras'
 name: <ShadowMaterial>
 sourcePath: 'packages/extras/src/lib/components/ShadowMaterial/ShadowMaterial.svelte'


### PR DESCRIPTION
it was in **Staging** but this moves it to **Visual Effects** with the rest of the material components

---

i think we need a better way to order content. i know some frameworks order things by the filename so we might try something like the following

- content
  - 01-01-ShadowMaterial.mdx
  - 01-02-PointsMaterial.mdx
  // ... etc.
  
i'll make a new issue about it later.