### PR TITLE
[fix/docs] adds color input to the ShadowMaterial example.

### DIFF
--- a/.changeset/blue-birds-tickle.md
+++ b/.changeset/blue-birds-tickle.md
@@ -1,5 +1,0 @@
----
-"@threlte/extras": patch
----
-
-fix RadialGradientTexture to clear its canvas whenever the `stops` prop is updated

--- a/.changeset/blue-birds-tickle.md
+++ b/.changeset/blue-birds-tickle.md
@@ -1,5 +1,5 @@
 ---
-"@threlte/extras": major
+"@threlte/extras": patch
 ---
 
 fix RadialGradientTexture to clear its canvas whenever the `stops` prop is updated

--- a/.changeset/blue-birds-tickle.md
+++ b/.changeset/blue-birds-tickle.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": major
+---
+
+fix RadialGradientTexture to clear its canvas whenever the `stops` prop is updated

--- a/.changeset/silent-tomatoes-prove.md
+++ b/.changeset/silent-tomatoes-prove.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+fix RadialGradientTexture to clear its canvas whenever the `stops` prop is updated and a new gradient is created

--- a/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
+++ b/apps/docs/src/content/reference/extras/radial-gradient-texture.mdx
@@ -83,7 +83,7 @@ The `innerRadius` and `outerRadius` props control the size of the gradient. The 
 
 ## Gradient Stops
 
-`<RadialGradientTexture>` accepts a `stops` prop which is an array of color stops that define the gradient. A stop is defined by two things; an `offset` and a `color`. Gradient stops are identical to how you would use them with a 2D context, notably the `offset` should be a number between 0 and 1 inclusive. Stop colors can be any valid color representation in Three.js. Here are a couple examples of valid stops.
+`<RadialGradientTexture>` accepts a `stops` prop which is an array of color stops that define the gradient. A stop is defined by two things; an `offset` and a `color`. Gradient stops are identical to how you would use them with a 2D context, notably the `offset` should be a number between 0 and 1 inclusive. Stop colors must be any acceptable CSS string. Here are a couple examples of valid stops.
 
 ```svelte
 <RadialGradientTexture
@@ -92,23 +92,15 @@ The `innerRadius` and `outerRadius` props control the size of the gradient. The 
     { color: 'white', offset: 1 }
   ]}
 />
-
-<RadialGradientTexture
-  stops={[
-    { color: '#00ffff', offset: 0 },
-    { color: '#ff00ff', offset: 0.5 },
-    { color: '#ffff00', offset: 1 }
-  ]}
-/>
 ```
 
-You can even mix and match color representations
+Three.js's Color class conveniently has a `getHexString` method which you can use to convert a color to a css color string.
 
 ```svelte
 <RadialGradientTexture
   stops={[
     { color: 'red', offset: 0 },
-    { color: 0xff_00_00, offset: 0.25 },
+    { color: new Color(0xff_00_00).getHexString(), offset: 0.25 },
     { color: 'rgb(255, 0, 0)', offset: 0.5 },
     { color: '#ff0000', offset: 0.75 },
     { color: new Color(new Color(new Color())).set(1, 0, 0), offset: 1 }

--- a/apps/docs/src/examples/extras/shadow-material/App.svelte
+++ b/apps/docs/src/examples/extras/shadow-material/App.svelte
@@ -1,8 +1,22 @@
 <script lang="ts">
   import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
+  import { Color, Pane } from 'svelte-tweakpane-ui'
+
+  let color = $state('#000000')
+
+  $inspect(color)
 </script>
 
 <Canvas>
-  <Scene />
+  <Scene {color} />
+  <Pane
+    title="shadow material"
+    position="fixed"
+  >
+    <Color
+      bind:value={color}
+      label="shadow color"
+    />
+  </Pane>
 </Canvas>

--- a/apps/docs/src/examples/extras/shadow-material/App.svelte
+++ b/apps/docs/src/examples/extras/shadow-material/App.svelte
@@ -8,13 +8,13 @@
 
 <Canvas>
   <Scene {color} />
-  <Pane
-    title="shadow material"
-    position="fixed"
-  >
-    <Color
-      bind:value={color}
-      label="shadow color"
-    />
-  </Pane>
 </Canvas>
+<Pane
+  title="shadow material"
+  position="fixed"
+>
+  <Color
+    bind:value={color}
+    label="shadow color"
+  />
+</Pane>

--- a/apps/docs/src/examples/extras/shadow-material/App.svelte
+++ b/apps/docs/src/examples/extras/shadow-material/App.svelte
@@ -4,8 +4,6 @@
   import { Color, Pane } from 'svelte-tweakpane-ui'
 
   let color = $state('#000000')
-
-  $inspect(color)
 </script>
 
 <Canvas>

--- a/apps/docs/src/examples/extras/shadow-material/Scene.svelte
+++ b/apps/docs/src/examples/extras/shadow-material/Scene.svelte
@@ -3,6 +3,8 @@
   import { OrbitControls, ShadowMaterial } from '@threlte/extras'
   import { T, useTask } from '@threlte/core'
 
+  let { color = '#000000' } = $props()
+
   const plane = new Mesh()
 
   const sphere = new Mesh()
@@ -55,6 +57,6 @@
     position.z={0.01}
   >
     <T.PlaneGeometry />
-    <ShadowMaterial />
+    <ShadowMaterial {color} />
   </T>
 </T.Group>

--- a/packages/extras/src/lib/components/GradientTexture/radial/RadialGradientTexture.svelte
+++ b/packages/extras/src/lib/components/GradientTexture/radial/RadialGradientTexture.svelte
@@ -68,13 +68,15 @@
   const { invalidate } = useThrelte()
 
   $effect(() => {
-    context.save()
     context.fillStyle = gradient
     context.fillRect(0, 0, context.canvas.width, context.canvas.height)
-    context.restore()
 
     texture.needsUpdate = true
     invalidate()
+
+    return () => {
+      context.clearRect(0, 0, context.canvas.width, context.canvas.height)
+    }
   })
 </script>
 


### PR DESCRIPTION
adds a color input to the ShadowMaterial example

fixes a bug where updating the color prop didn't fully clear the texture's canvas. now, when `stops` updates which causes a new gradient to be created, the canvas is cleared using `context.clearRect` before the gradient is filled in.

also removes the save/restore method calls since updates to the canvas are only ever in response to prop updates and happens internally. the user can't really interact with the texture's canvas (it's possible but they really shouldn't). saving the context is a lot of extra work when most of the canvas's context isn't accessed and all draws to the canvas are full wipes and redraws.

updates RadialGradientTexture docs to correctly show which types of colors strings are acceptable in the color stops