### PR TITLE
Update stackblitz main.ts

### DIFF
--- a/apps/docs/src/components/Example/stackblitz-files/src/main.ts
+++ b/apps/docs/src/components/Example/stackblitz-files/src/main.ts
@@ -1,6 +1,7 @@
+import { mount } from 'svelte'
 import App from './Layout.svelte'
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app')!
 })
 


### PR DESCRIPTION
When using the StackBlitz button in the docs to create a playground for testing or sharing reproducable demos, the main entry still uses an old way of creating the Svelte app that I always had to fix manually, so far. This should update it baseline so that manual fixing is not necessary.