### PR TITLE
update screen-quad example improvements

### DIFF
--- a/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
+++ b/apps/docs/src/content/examples/postprocessing/ScreenQuad.mdx
@@ -4,25 +4,25 @@ This example demonstrates a well-known technique for doing simple postprocessing
 
 ## Overview
 
-The basic idea of postprocessing is to draw the scene to a frame-buffer that can then be sent into another shader. The output of this shader is used as the texture or material for a mesh that covers the screen. To do this we need two things:
+The basic idea of postprocessing is to draw the scene to a frame-buffer ortexture that can then be sent into another shader. The output of this shader is used as the texture or material for a mesh that covers the screen. To do this we need two things:
 
 1. a WebGL render target.
 2. a separate scene from the one that Threlte provides.
 
-A [WebGLRenderTarget](https://threejs.org/docs/index.html?q=webgl#api/en/renderers/WebGLRenderTarget) is created and its size is set up to follow the size of the canvas.
+Threlte's `useFBO` can give us a [WebGLRenderTarget](https://threejs.org/docs/index.html?q=webgl#api/en/renderers/WebGLRenderTarget) automatically resizes when the size of the canvas changes.
 
-A separate scene is needed so that we can add the screen-quad mesh to it and render it. The idea is that the only thing in this scene will be the screen-quad mesh that has the post-processed scene as its material. This mesh can't be added to the main scene because it would cause a circular dependency.
+A separate scene is needed so that we can add the screen-quad mesh to it and render it. The only thing in this scene will be the screen-quad mesh that has the post-processed scene as its material texture. This mesh should not be added to the main scene because it would cause a circular dependency.
 
 So the steps are as follows:
 
-1. render the "main" scene to the render target.
-2. render the separate scene.
+1. render the "main" scene to the render target. The target's texture is passed as a uniform into the post-procssing shader
+2. render the scene that only contains the screen-quad mesh.
 
 There are some sub-steps inbetween but these are the two important bits that happen in the `useTask` callback in the `<Scene>` component.
 
 ## ScreenQuadGeometry
 
-This component creates a right triangle such that its right angle is positioned in the lower-left of the canvas. The size of the triangle is such that the hypotenuse only touches the top-right corner of the canvas. The triangle is in clip-space so we need a special vertex shader to use it.
+This component creates a right triangle such that its right angle is positioned in the lower left of the canvas. The size of the triangle is such that the hypotenuse only touches the top right corner of the canvas. The triangle is in clip-space so we need a special vertex shader to use it.
 
 The vertex shader string is exported from the `<ScreenQuadGeometry>` component to be used with either a `Three.RawShaderMaterial` or `Three.ShaderMaterial`.
 
@@ -30,10 +30,36 @@ The vertex shader string is exported from the `<ScreenQuadGeometry>` component t
 
 There are a few notable techniques in the `<Scene>` component.
 
-Firstly, The screen-quad mesh is not frustrum culled. This is because the geometry is so simple that culling it would actually requare more work. If you culled its geometry, you'd actually be creating more vertices.
+Firstly, The screen-quad mesh is not frustrum culled. This is because the geometry is always visible, so no point in culling it.
 
 This `<T.Mesh>` uses threlte's `attach` prop to add it to the secondary scene instead of the default scene created by threlte.
 
 Secondly, the render task that threlte automatically uses is disabled and a custom render task is used instead. This is explained on the [`useTask`](/docs/reference/core/use-task) page.
 
-Lastly, the uvs are used in the fragment shader to use as an index into the scene texture. For this reason, the resolution of the canvas is sent into the shader as a uniform. An effect is ran to keep the uniform in sync with the current size of the canvas.
+Lastly, the uvs are used in the fragment shader as an index into the render target's texture. Note that you can get a perfect circle by sending the size of the renderer into the fragment shader as a uniform.
+
+```ts
+const fragmentShader = `
+	// ...
+	uniform vec2 uSize;
+
+	vec2 uv = gl_FragCoord.xy / uSize.xy;
+	// ...
+`
+
+const uSize = new Uniform(new Vector2())
+
+const { size } = useThrelte()
+
+$effect(() => {
+  uSize.value.set($size.width, $size.height)
+})
+
+const material = new RawShaderMaterial({
+  fragmentShader,
+  vertexShader,
+  uniforms: {
+    uSize
+  }
+})
+```

--- a/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
+++ b/apps/docs/src/examples/postprocessing/screen-quad/Scene.svelte
@@ -1,26 +1,34 @@
 <script lang="ts">
   import ScreenQuadGeometry, { vertexShader } from './ScreenQuadGeometry.svelte'
-  import { Environment, OrbitControls, useGltf } from '@threlte/extras'
-  import { Scene, Uniform, WebGLRenderTarget } from 'three'
+  import { Environment, OrbitControls, useFBO, useGltf } from '@threlte/extras'
+  import { OrthographicCamera, Scene, Uniform } from 'three'
   import { T, useTask, useThrelte } from '@threlte/core'
 
-  const { camera, renderStage, renderer, scene, size } = useThrelte()
+  const { camera, renderStage, renderer, scene } = useThrelte()
 
-  const target = new WebGLRenderTarget(1, 1)
-
-  $effect(() => {
-    target.setSize($size.width, $size.height)
+  useGltf('/models/spaceships/Bob.gltf').then((gltf) => {
+    scene.add(gltf.scene)
   })
 
+  const target = useFBO()
+
+  // this scene will hold the triangle and nothing else. remember, the idea is to render a triangle that uses the main scene as a texture and do interesting effects with it
   const _scene = new Scene()
+
+  // the triangle mesh covers the screen, it doesn't really matter what camera we use but most post-processing passes will use an orthographic camera
+  const ortho = new OrthographicCamera()
 
   useTask(
     () => {
       const last = renderer.getRenderTarget()
+
+      // set and draw to thet target that will be sent into the custom shader as a texture
       renderer.setRenderTarget(target)
       renderer.render(scene, camera.current)
+
+      // restore the previous target and render the triangle scene
       renderer.setRenderTarget(last)
-      renderer.render(_scene, camera.current)
+      renderer.render(_scene, ortho)
     },
     {
       stage: renderStage
@@ -28,51 +36,49 @@
   )
 
   /**
-   * put your interesting effects in this shader.
+   * put your interesting effects in this shader. note that your shader will probaby not need some of the stuff below
    */
   const fragmentShader = `
 		precision highp float;
 
 		uniform sampler2D uScene;
-		uniform vec2 uMouse;
 		uniform float uRadius;
 		varying vec2 vUv;
 
 		void main() {
-
-			vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
+			gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
 
 			vec2 center = vec2(0.5, 0.5);
 
 			if (length(center - vUv) - uRadius < 0.0) {
-				color = texture2D(uScene, vUv);
+				gl_FragColor = texture2D(uScene, vUv);
 			}
-
-			gl_FragColor = color;
 		}
 	`
 
-  const gltf = useGltf('/models/spaceships/Bob.gltf')
-
   const uScene = new Uniform(target.texture)
-
   const uRadius = new Uniform(0)
+  const uniforms = {
+    uScene,
+    uRadius
+  }
 
   let time = 0
   useTask((delta) => {
     time += delta
+
+    // oscillate the radius between 0 and 1
     uRadius.value = 1 - 0.5 * (1 + Math.sin(time))
   })
 </script>
 
 <T.PerspectiveCamera
   makeDefault
-  position={5}
+  position={7}
 >
   <OrbitControls />
 </T.PerspectiveCamera>
 
-<!-- this geometry is so simple that frustrum culling it would actually be more work -->
 <T.Mesh
   frustrumCulled={false}
   attach={_scene}
@@ -80,15 +86,10 @@
   <T.RawShaderMaterial
     {vertexShader}
     {fragmentShader}
-    uniforms.uScene={uScene}
-    uniforms.uRadius={uRadius}
+    {uniforms}
   />
   <ScreenQuadGeometry />
 </T.Mesh>
-
-{#await gltf then { scene }}
-  <T is={scene} />
-{/await}
 
 <Environment
   url="/textures/equirectangular/hdr/shanghai_riverside_1k.hdr"


### PR DESCRIPTION
- updates some of the example mdx content with more correct information
- simplifies some of the shader code and component code, notably using `useFBO` which does everything we want it to do instead of creating a RenderTarget and doing it all ourselves.