### PR TITLE
[docs] Add SVG render order example

### DIFF
--- a/apps/docs/public/images/docs/extras/svg/ordering.svg
+++ b/apps/docs/public/images/docs/extras/svg/ordering.svg
@@ -1,0 +1,8 @@
+<svg id="color-fill" xmlns="http://www.w3.org/2000/svg" version="1.1" width="300" height="300" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <rect x="25" y="25" width="250" height="250" style="fill:#ff0000;fill-opacity:0.2;stroke:none" />
+    <rect x="50" y="50" width="100" height="200" style="fill:#000000;fill-opacity:1;stroke:none" />
+    <rect x="75" y="75" width="150" height="150" style="fill:#00ff00;fill-opacity:0.5;stroke:none" />
+    <rect x="100" y="100" width="100" height="100" style="fill:#000080;fill-opacity:1;stroke:none" />
+
+</svg>

--- a/apps/docs/src/examples/extras/svg/App.svelte
+++ b/apps/docs/src/examples/extras/svg/App.svelte
@@ -2,13 +2,31 @@
   import { NoToneMapping } from 'three'
   import { Canvas } from '@threlte/core'
   import Scene from './Scene.svelte'
+  import { Pane, List, type ListOptions } from 'svelte-tweakpane-ui'
+
+  const options: ListOptions<number> = {
+    logo: 0,
+    ordering: 1
+  }
+  let selection = 0
 </script>
 
 <div>
   <Canvas toneMapping={NoToneMapping}>
-    <Scene />
+    <Scene {selection} />
   </Canvas>
 </div>
+
+<Pane
+  position="fixed"
+  title="SVG"
+>
+  <List
+    bind:value={selection}
+    label="scene"
+    {options}
+  ></List>
+</Pane>
 
 <style>
   div {

--- a/apps/docs/src/examples/extras/svg/Scene.svelte
+++ b/apps/docs/src/examples/extras/svg/Scene.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { T } from '@threlte/core'
   import { SVG, OrbitControls } from '@threlte/extras'
+
+  interface Props {
+    selection: number
+  }
+  let { selection }: Props = $props()
 </script>
 
 <T.PerspectiveCamera
@@ -15,9 +20,18 @@
   />
 </T.PerspectiveCamera>
 
-<SVG
-  src="/icons/svelte.svg"
-  scale={0.005}
-  position.x={-1.2}
-  position.y={1.5}
-/>
+{#if selection == 0}
+  <SVG
+    src="/icons/svelte.svg"
+    scale={0.005}
+    position.x={-1.2}
+    position.y={1.5}
+  />
+{:else}
+  <SVG
+    src="/images/docs/extras/svg/ordering.svg"
+    scale={0.005}
+    position.x={-1.2}
+    position.y={1.5}
+  />
+{/if}

--- a/packages/extras/src/lib/components/Svg/Svg.svelte
+++ b/packages/extras/src/lib/components/Svg/Svg.svelte
@@ -55,6 +55,9 @@
       }
     }
   })
+
+  // svelte-ignore non_reactive_update
+  let renderOrder = 0
 </script>
 
 <T.Group
@@ -64,10 +67,10 @@
   <T.Group scale.y={-1}>
     {#each paths as path, p (path)}
       {#if !skipFill && path.userData?.style.fill !== undefined && path.userData.style.fill !== 'none'}
-        {#each SVGLoader.createShapes(path) as shape, i (shape)}
+        {#each SVGLoader.createShapes(path) as shape (shape)}
           <T.Mesh
             {...fillMeshProps}
-            renderOrder={i}
+            renderOrder={renderOrder++}
           >
             <T.ShapeGeometry args={[shape]} />
             <T.MeshBasicMaterial
@@ -88,7 +91,7 @@
             <T.Mesh
               geometry={strokeGeometries[p]?.[s]}
               {...strokeMeshProps}
-              renderOrder={s}
+              renderOrder={renderOrder++}
             >
               <T.MeshBasicMaterial
                 color={path.userData?.style.stroke}

--- a/packages/extras/src/lib/components/Svg/Svg.svelte
+++ b/packages/extras/src/lib/components/Svg/Svg.svelte
@@ -55,8 +55,6 @@
       }
     }
   })
-
-  let renderOrder = 0
 </script>
 
 <T.Group
@@ -66,10 +64,10 @@
   <T.Group scale.y={-1}>
     {#each paths as path, p (path)}
       {#if !skipFill && path.userData?.style.fill !== undefined && path.userData.style.fill !== 'none'}
-        {#each SVGLoader.createShapes(path) as shape (shape)}
+        {#each SVGLoader.createShapes(path) as shape, i (shape)}
           <T.Mesh
             {...fillMeshProps}
-            renderOrder={renderOrder++}
+            renderOrder={i}
           >
             <T.ShapeGeometry args={[shape]} />
             <T.MeshBasicMaterial
@@ -90,7 +88,7 @@
             <T.Mesh
               geometry={strokeGeometries[p]?.[s]}
               {...strokeMeshProps}
-              renderOrder={renderOrder++}
+              renderOrder={s}
             >
               <T.MeshBasicMaterial
                 color={path.userData?.style.stroke}


### PR DESCRIPTION
So I was stupid and tried to remove the `renderOrder` variable within the SVG component 😅 

The variable is needed and is not just a old quirk lying around in the three.js [example code](https://github.com/mrdoob/three.js/blob/0af9729d0c143a86a1d725d6e2c3ad83301f3f34/examples/webgl_loader_svg.html#L170).

To resolve the warning I've added a svelte ignore comment `// svelte-ignore non_reactive_update`

We could add an effect like so:

```ts
$effect.pre(() => {
    if (src) {
      renderOrder = 0
    }
  })
```

for completeness's sake if someone updates `src`  reactively a bunch of times .... but even then the variable will just keep going up so not worth worrying about imo