### PR TITLE
[docs] Fix link that currently 404s

### DIFF
--- a/apps/docs/src/content/learn/basics/app-structure.mdx
+++ b/apps/docs/src/content/learn/basics/app-structure.mdx
@@ -5,7 +5,7 @@ order: -900
 ---
 
 Threlte makes heavy use of [Svelte's Context
-API](https://svelte.dev/tutorial/context-api) as a way to pass data through the
+API](https://svelte.dev/tutorial/svelte/context-api) as a way to pass data through the
 component tree without having to pass props down manually at every level:
 
 ```svelte title="SomeComponent.svelte"


### PR DESCRIPTION
The first link in https://threlte.xyz/docs/learn/basics/app-structure currently leads to a 404 error. I updated the link to match the new svelte URL.