### PR TITLE
Fix: disallow calling .set on primitive values within createSetter internal

### DIFF
--- a/.changeset/pink-ways-melt.md
+++ b/.changeset/pink-ways-melt.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": patch
+---
+
+Fix: disallow calling .set on primitive values within createSetter internal

--- a/packages/core/src/lib/components/T/utils/useProps.ts
+++ b/packages/core/src/lib/components/T/utils/useProps.ts
@@ -53,7 +53,11 @@ const createSetter = (target: any, key: any, value: any): PropSetter => {
       target[key].setScalar(value)
     }
   } else {
-    if (typeof target[key]?.set === 'function' && typeof target === 'object' && target !== null) {
+    if (
+      typeof target[key]?.set === 'function' &&
+      typeof target[key] === 'object' &&
+      target[key] !== null
+    ) {
       // if the property has a "set" function, we can use it
       if (Array.isArray(value)) {
         return (target: any, key: any, value: any) => {


### PR DESCRIPTION
### Overview

`createSetter` will currently call `.set` on primitive values, like numbers, if they have had their prototype modified. Koota is an example of a library that does this. This is because a mistaken check is done on the parent of the prop rather than the prop itself. This PR fixes that.