### PR TITLE
Patch `mitt` and remove workarounds

### DIFF
--- a/.changeset/wicked-suits-obey.md
+++ b/.changeset/wicked-suits-obey.md
@@ -1,0 +1,6 @@
+---
+'@threlte/core': patch
+'@threlte/flex': patch
+---
+
+patch mitt and remove workarounds

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
       "vite": "catalog:"
     },
     "patchedDependencies": {
-      "@theatre/studio": "patches/@theatre__studio.patch"
+      "@theatre/studio": "patches/@theatre__studio.patch",
+      "mitt": "patches/mitt.patch"
     }
   },
   "engines": {

--- a/packages/core/src/lib/frame-scheduling/DAG.ts
+++ b/packages/core/src/lib/frame-scheduling/DAG.ts
@@ -1,9 +1,4 @@
-import { type Emitter } from 'mitt'
-
-// We need to cast here because TypeScript with "moduleResolution": "NodeNext"
-// fails to resolve the default export otherwise.
-import mittModule from 'mitt'
-const mitt = mittModule as unknown as typeof import('mitt').default
+import mitt, { type Emitter } from 'mitt'
 
 type Vertex<T> = { value: T | undefined; previous: Set<Key>; next: Set<Key> }
 

--- a/packages/flex/src/lib/Flex/context.ts
+++ b/packages/flex/src/lib/Flex/context.ts
@@ -1,9 +1,5 @@
 import type { CurrentWritable } from '@threlte/core'
-import type { Emitter } from 'mitt'
-// We need to cast here because TypeScript with "moduleResolution": "NodeNext"
-// fails to resolve the default export otherwise.
-import mittModule from 'mitt'
-const mitt = mittModule as unknown as typeof import('mitt').default
+import mitt, { type Emitter } from 'mitt'
 import { getContext, onDestroy, setContext } from 'svelte'
 import type { Group } from 'three'
 import type { Node } from 'yoga-layout'

--- a/patches/mitt.patch
+++ b/patches/mitt.patch
@@ -1,0 +1,26 @@
+diff --git a/package.json b/package.json
+index e51397cb4104da5424936208509d2aa0dc73313f..6f35005d143a4f52b8acd99ca0979ca573d79491 100644
+--- a/package.json
++++ b/package.json
+@@ -8,12 +8,16 @@
+   "umd:main": "dist/mitt.umd.js",
+   "source": "src/index.ts",
+   "typings": "index.d.ts",
++  "type": "module",
+   "exports": {
+-    "types": "./index.d.ts",
+-    "module": "./dist/mitt.mjs",
+-    "import": "./dist/mitt.mjs",
+-    "require": "./dist/mitt.js",
+-    "default": "./dist/mitt.mjs"
++    "import": {
++      "types": "./index.d.ts",
++      "default": "./dist/mitt.mjs"
++    },
++    "require": {
++      "types": "./index.d.ts",
++      "default": "./dist/mitt.js"
++    }
+   },
+   "scripts": {
+     "test": "npm-run-all --silent typecheck lint mocha test-types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ patchedDependencies:
   '@theatre/studio':
     hash: 1be11589f12d362f0a72e118ac4ef7b2c48bbd564289a80be63f7f5ac6f4e07f
     path: patches/@theatre__studio.patch
+  mitt:
+    hash: 325af173b7ab05fc16e066f43bc80a68f7fd58ddbfc1d0df37f773af1c79bb42
+    path: patches/mitt.patch
 
 importers:
 
@@ -343,7 +346,7 @@ importers:
     dependencies:
       mitt:
         specifier: ^3.0.1
-        version: 3.0.1
+        version: 3.0.1(patch_hash=325af173b7ab05fc16e066f43bc80a68f7fd58ddbfc1d0df37f773af1c79bb42)
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -531,7 +534,7 @@ importers:
     dependencies:
       mitt:
         specifier: ^3.0.1
-        version: 3.0.1
+        version: 3.0.1(patch_hash=325af173b7ab05fc16e066f43bc80a68f7fd58ddbfc1d0df37f773af1c79bb42)
       yoga-layout:
         specifier: ^3.2.1
         version: 3.2.1
@@ -14495,7 +14498,7 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  mitt@3.0.1: {}
+  mitt@3.0.1(patch_hash=325af173b7ab05fc16e066f43bc80a68f7fd58ddbfc1d0df37f773af1c79bb42): {}
 
   mixme@0.5.4: {}
 


### PR DESCRIPTION
For the sake of consistency, I would like to also remove the `mitt` workarounds and patch the package instead.