### PR TITLE
[@threlte/xr] Stability improvements and bugfixes (2)

### DIFF
--- a/.changeset/blue-doors-poke.md
+++ b/.changeset/blue-doors-poke.md
@@ -1,0 +1,5 @@
+---
+"@threlte/xr": patch
+---
+
+Fix: controllers slot populated by hand-tracking input sources

--- a/.changeset/curvy-bats-talk.md
+++ b/.changeset/curvy-bats-talk.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fix: interactivity hover now keys plain meshes by uuid, so sweeping across faces no longer spams pointerenter/pointerleave

--- a/.changeset/great-guests-attend.md
+++ b/.changeset/great-guests-attend.md
@@ -1,0 +1,5 @@
+---
+"@threlte/xr": patch
+---
+
+Add handedness to XR event payloads

--- a/.changeset/healthy-cheetahs-do.md
+++ b/.changeset/healthy-cheetahs-do.md
@@ -1,0 +1,5 @@
+---
+"@threlte/xr": patch
+---
+
+Fix: useHandJoint task ran every frame, now gated by isPresenting

--- a/.changeset/neat-spoons-explain.md
+++ b/.changeset/neat-spoons-explain.md
@@ -1,0 +1,5 @@
+---
+"@threlte/xr": patch
+---
+
+Fix pointerControls: raycast origin now comes from matrixWorld instead of local position / rotation

--- a/.changeset/quiet-dancers-think.md
+++ b/.changeset/quiet-dancers-think.md
@@ -1,0 +1,5 @@
+---
+"@threlte/xr": patch
+---
+
+Fix: redundant removeHandlers() in observe else branches

--- a/.changeset/shiny-bees-fold.md
+++ b/.changeset/shiny-bees-fold.md
@@ -1,0 +1,6 @@
+---
+"@threlte/xr": patch
+---
+
+Fix: pointerMissed fired per hit instead of per event (aligned to interactivity pattern)  
+

--- a/.changeset/tender-seahorses-jump.md
+++ b/.changeset/tender-seahorses-jump.md
@@ -1,0 +1,6 @@
+---
+"@threlte/xr": patch
+---
+
+Fix: Hover identity keys plain meshes by uuid only, so sweeping across faces no longer spams pointerenter/pointerleave.  
+

--- a/apps/docs/src/content/reference/xr/pointer-controls.mdx
+++ b/apps/docs/src/content/reference/xr/pointer-controls.mdx
@@ -78,6 +78,20 @@ While a controller or hand is pointed at this mesh...
 - `pointerover` and `pointerout` fire when the ray of the pointing device is moved onto an object, or onto one of its children. It bubbles, meaning it can trigger on the object that the pointer is over or any of its ancestor objects.
 - `pointerenter` and `pointerleave` fire when the ray of the pointing device enters / leaves the boundaries of an object, and does not bubble. It only triggers on the exact element the pointer has entered / left.
 
+Each controller/hand fires these events **independently**. If both hands hover the same object, you'll receive `pointerenter` twice — once with `event.handedness === 'left'` and once with `'right'`. When one hand stops hovering, its `pointerleave` fires even if the other hand is still on the object. Apps that need "is any hand hovering?" should track per-hand state and aggregate:
+
+```svelte
+<script>
+  const hovering = $state({ left: false, right: false })
+  const isHovered = $derived(hovering.left || hovering.right)
+</script>
+
+<T.Mesh
+  onpointerenter={(e) => (hovering[e.handedness] = true)}
+  onpointerleave={(e) => (hovering[e.handedness] = false)}
+/>
+```
+
 To replace the default ray and cursor that are created by the plugin, the following snippets can be added to a `<Controller>` or a `<Hand>`:
 
 ```svelte

--- a/apps/docs/src/examples/xr/pointer-controls/Scene.svelte
+++ b/apps/docs/src/examples/xr/pointer-controls/Scene.svelte
@@ -20,8 +20,7 @@
   const hovering = $state({ left: false, right: false, desktop: false })
   const happy = $derived(hovering.left || hovering.right || hovering.desktop)
 
-  const sourceOf = (event: { handedness?: 'left' | 'right' }) =>
-    event.handedness ?? 'desktop'
+  const sourceOf = (event: { handedness?: 'left' | 'right' }) => event.handedness ?? 'desktop'
 
   const mesh = new Mesh()
 

--- a/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
+++ b/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
@@ -3,8 +3,19 @@ import { type InteractivityContext, useInteractivity } from './context.js'
 import type { DomEvent, Intersection, IntersectionEvent } from './types.js'
 import { fromStore } from 'svelte/store'
 
+// Hover identity must match the dedup key used in `getHits`, otherwise the ID
+// changes mid-hover (e.g. the hit's face index changes as the ray sweeps a
+// plain mesh) and the object flickers between pointerout/pointerenter every
+// frame.
 function createIntersectionId(intersection: Intersection) {
-  return `${(intersection.eventObject || intersection.object).uuid}|${intersection.index}|${intersection.instanceId}`
+  const target = intersection.eventObject ?? intersection.object
+  if (intersection.instanceId !== undefined) {
+    return `${target.uuid}|${intersection.instanceId}`
+  }
+  if ((intersection.object as Points).isPoints) {
+    return `${target.uuid}|${intersection.index}`
+  }
+  return target.uuid
 }
 
 const DOM_EVENTS = [

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -21,6 +21,7 @@
     "@sveltejs/package": "catalog:",
     "@sveltejs/vite-plugin-svelte": "catalog:",
     "@threlte/core": "workspace:*",
+    "@threlte/extras": "workspace:*",
     "@types/three": "catalog:",
     "@types/webxr": "catalog:",
     "autoprefixer": "^10.4.19",

--- a/packages/xr/src/lib/components/Controller.svelte
+++ b/packages/xr/src/lib/components/Controller.svelte
@@ -117,7 +117,10 @@
   {/if}
 
   {#if targetRay}
-    <T is={targetRay}>
+    <T
+      is={targetRay}
+      attach={scene}
+    >
       {@render targetRaySnippet?.()}
 
       {#if hasPointerControls || hasTeleportControls}

--- a/packages/xr/src/lib/components/Hand.svelte
+++ b/packages/xr/src/lib/components/Hand.svelte
@@ -117,7 +117,10 @@
   </T>
 
   {#if targetRay !== undefined}
-    <T is={xrHand.targetRay}>
+    <T
+      is={xrHand.targetRay}
+      attach={scene}
+    >
       {@render targetRay()}
     </T>
   {/if}

--- a/packages/xr/src/lib/components/XR.svelte
+++ b/packages/xr/src/lib/components/XR.svelte
@@ -128,7 +128,7 @@ This should be placed within a Threlte `<Canvas />`.
   }
 
   const handleInputSourcesChange = (event: XRInputSourcesChangeEvent) => {
-    isHandTracking.current = Object.values(event.session.inputSources).some((source) => source.hand)
+    isHandTracking.current = Array.from(event.session.inputSources).some((source) => source.hand)
     oninputsourceschange?.(event)
   }
 

--- a/packages/xr/src/lib/components/internal/Cursor.svelte
+++ b/packages/xr/src/lib/components/internal/Cursor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Color, DoubleSide, RawShaderMaterial, type ColorRepresentation } from 'three'
+  import { Color, DoubleSide, ShaderMaterial, type ColorRepresentation } from 'three'
   import { T } from '@threlte/core'
 
   interface Props {
@@ -11,10 +11,6 @@
   const { color = new Color('white'), size = 0.03, thickness = 0.035 }: Props = $props()
 
   const vertexShader = `
-    uniform mat4 projectionMatrix;
-    uniform mat4 modelViewMatrix;
-    attribute vec2 uv;
-    attribute vec3 position;
     varying vec2 vUv;
     void main() {
       vUv = uv;
@@ -23,14 +19,13 @@
   `
 
   const fragmentShader = `
-    precision mediump float;
     uniform float thickness;
     uniform vec3 color;
     varying vec2 vUv;
     void main() {
-      float radius = 0.1;
-      float dist = length(vUv - vec2(0.5));
-      float alpha = 1.0 - step(thickness, abs(distance(vUv, vec2(0.5)) - 0.25));
+      float d = abs(distance(vUv, vec2(0.5)) - 0.25);
+      float edge = fwidth(d);
+      float alpha = 1.0 - smoothstep(thickness - edge, thickness + edge, d);
       gl_FragColor = vec4(color, alpha);
     }
   `
@@ -40,7 +35,7 @@
     color: { value: color }
   }
 
-  const shaderMaterial = new RawShaderMaterial({
+  const shaderMaterial = new ShaderMaterial({
     vertexShader,
     fragmentShader,
     uniforms,

--- a/packages/xr/src/lib/components/internal/PointerCursor.svelte
+++ b/packages/xr/src/lib/components/internal/PointerCursor.svelte
@@ -29,7 +29,7 @@
 
   const ref = new Group()
 
-  const SURFACE_OFFSET = 0.005
+  const SURFACE_OFFSET = 0.002
 
   useTask(
     () => {

--- a/packages/xr/src/lib/components/internal/PointerCursor.svelte
+++ b/packages/xr/src/lib/components/internal/PointerCursor.svelte
@@ -11,6 +11,7 @@
 
 <script lang="ts">
   import { T, useTask, useThrelte } from '@threlte/core'
+  import { untrack } from 'svelte'
   import { pointerIntersection, pointerState } from '../../internal/state.svelte.js'
   import Cursor from './Cursor.svelte'
   import type { Snippet } from 'svelte'
@@ -28,6 +29,8 @@
 
   const ref = new Group()
 
+  const SURFACE_OFFSET = 0.005
+
   useTask(
     () => {
       if (intersection === undefined) {
@@ -43,17 +46,28 @@
 
       normalMatrix.getNormalMatrix(object.matrixWorld)
       worldNormal.copy(face.normal).applyMatrix3(normalMatrix).normalize()
-      ref.lookAt(vec3.addVectors(point, worldNormal))
+
+      // Float the reticle just above the surface so it doesn't z-fight
+      // with the coplanar face underneath.
+      ref.position.addScaledVector(worldNormal, SURFACE_OFFSET)
+
+      ref.lookAt(vec3.addVectors(ref.position, worldNormal))
     },
     {
       running: () => hovering && intersection !== undefined
     }
   )
 
+  // Snap to the hit point on hover entry so the reticle doesn't visibly
+  // fly in from its previous location. `intersection` is read untracked
+  // so this only reruns on hover transitions, not every frame.
   $effect.pre(() => {
-    if (hovering && intersection) {
-      ref.position.copy(intersection.point)
-    }
+    if (!hovering) return
+    untrack(() => {
+      if (intersection) {
+        ref.position.copy(intersection.point)
+      }
+    })
   })
 </script>
 

--- a/packages/xr/src/lib/components/internal/TeleportCursor.svelte
+++ b/packages/xr/src/lib/components/internal/TeleportCursor.svelte
@@ -40,7 +40,10 @@
       if (face) {
         normalMatrix.getNormalMatrix(object.matrixWorld)
         worldNormal.copy(face.normal).applyMatrix3(normalMatrix).normalize()
-        ref.lookAt(vec3.addVectors(point, worldNormal))
+        // lookAt from the lerped position (matches PointerCursor) — using the
+        // raw hit point here causes orientation to wobble while position is
+        // still easing toward the target.
+        ref.lookAt(vec3.addVectors(ref.position, worldNormal))
       }
     },
     {

--- a/packages/xr/src/lib/hooks/useHandJoint.svelte.ts
+++ b/packages/xr/src/lib/hooks/useHandJoint.svelte.ts
@@ -2,6 +2,7 @@ import type { XRJointSpace } from 'three'
 import { useTask, useThrelte } from '@threlte/core'
 import type { HandJoints } from '../lib/handJoints.js'
 import { hands } from './useHand.svelte.js'
+import { isPresenting } from '../internal/state.svelte.js'
 import { toCurrentReadable } from './currentReadable.svelte.js'
 
 /**
@@ -13,20 +14,23 @@ export const useHandJoint = (handedness: 'left' | 'right', joint: HandJoints) =>
 
   let jointSpace = $state.raw<XRJointSpace>()
 
-  useTask(() => {
-    const space = xrhand?.hand.joints[joint]
-    // The joint radius is a good indicator that the joint is ready.
-    // Re-check each frame so we pick up reconnects and clear on disconnect.
-    if (space?.jointRadius !== undefined) {
-      if (jointSpace !== space) {
-        jointSpace = space
+  useTask(
+    () => {
+      const space = xrhand?.hand.joints[joint]
+      // The joint radius is a good indicator that the joint is ready.
+      // Re-check each frame so we pick up reconnects and clear on disconnect.
+      if (space?.jointRadius !== undefined) {
+        if (jointSpace !== space) {
+          jointSpace = space
+          invalidate()
+        }
+      } else if (jointSpace !== undefined) {
+        jointSpace = undefined
         invalidate()
       }
-    } else if (jointSpace !== undefined) {
-      jointSpace = undefined
-      invalidate()
-    }
-  })
+    },
+    { running: () => isPresenting.current }
+  )
 
   return toCurrentReadable(() => jointSpace)
 }

--- a/packages/xr/src/lib/internal/setupControllers.ts
+++ b/packages/xr/src/lib/internal/setupControllers.ts
@@ -12,14 +12,13 @@ export const setupControllers = (factory?: XRControllerModelFactory) => {
   const hasHands = useHandTrackingState()
   const targetRaySpaces = [xr.getController(0), xr.getController(1)]
   const indexMap = new Map()
+  const modelFactory = factory ?? new XRControllerModelFactory()
 
   targetRaySpaces.forEach((targetRay, index) => {
-    const model = (factory ?? new XRControllerModelFactory()).createControllerModel(targetRay)
-
     indexMap.set(targetRay, {
       targetRay,
       grip: xr.getControllerGrip(index),
-      model
+      model: modelFactory.createControllerModel(targetRay)
     })
   })
 
@@ -33,8 +32,14 @@ export const setupControllers = (factory?: XRControllerModelFactory) => {
     }
 
     function handleConnected(this: XRTargetRaySpace, event: XRControllerEvent<'connected'>) {
-      const { model, targetRay, grip } = indexMap.get(this)
       const { data: inputSource } = event
+
+      // The targetRaySpace 'connected' event fires for both controller and
+      // hand-tracking input sources. The controllers slot represents a physical
+      // controller — setupHands handles the hand-tracking side.
+      if (inputSource.hand) return
+
+      const { model, targetRay, grip } = indexMap.get(this)
 
       controllers[event.data.handedness] = {
         inputSource,

--- a/packages/xr/src/lib/internal/setupHands.ts
+++ b/packages/xr/src/lib/internal/setupHands.ts
@@ -12,14 +12,13 @@ export const setupHands = (factory?: XRHandModelFactory) => {
   const hasHands = useHandTrackingState()
   const handSpaces = [xr.getHand(0), xr.getHand(1)]
   const map = new Map()
+  const modelFactory = factory ?? new XRHandModelFactory()
 
   handSpaces.forEach((handSpace, index) => {
-    const model = (factory ?? new XRHandModelFactory()).createHandModel(handSpace, 'mesh')
-
     map.set(handSpace, {
       hand: handSpace,
       targetRay: xr.getController(index),
-      model
+      model: modelFactory.createHandModel(handSpace, 'mesh')
     })
   })
 

--- a/packages/xr/src/lib/lib/toggleXRSession.ts
+++ b/packages/xr/src/lib/lib/toggleXRSession.ts
@@ -20,10 +20,10 @@ export const toggleXRSession = async (
   if (force === 'enter' && hasSession) return currentSession
   if (force === 'exit' && !hasSession) return
 
-  // Exit a session if entered
+  // Exit a session if entered. `session.current` is cleared by XR.svelte's
+  // `handleSessionEnd` when the 'end' event fires — don't duplicate that here.
   if (hasSession) {
     await currentSession.end()
-    session.current = undefined
     return
   }
 

--- a/packages/xr/src/lib/plugins/pointerControls/compute.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/compute.ts
@@ -4,6 +4,7 @@ import { controllers } from '../../hooks/useController.svelte.js'
 
 export type ComputeFunction = (state: ControlsContext, handState: HandContext) => void
 
+const origin = new Vector3()
 const forward = new Vector3()
 
 export const defaultComputeFunction: ComputeFunction = (
@@ -14,7 +15,13 @@ export const defaultComputeFunction: ComputeFunction = (
 
   if (targetRay === undefined) return
 
-  forward.set(0, 0, -1).applyQuaternion(targetRay.quaternion)
+  // Use the world matrix so the ray matches the visibly-rendered controller
+  // even when <Controller> is nested in a parent transform (e.g. a dolly rig).
+  // Force-update because this runs before the frame's scene.updateMatrixWorld.
+  targetRay.updateWorldMatrix(true, false)
 
-  context.raycaster.set(targetRay.position, forward)
+  origin.setFromMatrixPosition(targetRay.matrixWorld)
+  forward.set(0, 0, -1).transformDirection(targetRay.matrixWorld)
+
+  context.raycaster.set(origin, forward)
 }

--- a/packages/xr/src/lib/plugins/pointerControls/compute.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/compute.ts
@@ -4,7 +4,6 @@ import { controllers } from '../../hooks/useController.svelte.js'
 
 export type ComputeFunction = (state: ControlsContext, handState: HandContext) => void
 
-const origin = new Vector3()
 const forward = new Vector3()
 
 export const defaultComputeFunction: ComputeFunction = (
@@ -15,13 +14,11 @@ export const defaultComputeFunction: ComputeFunction = (
 
   if (targetRay === undefined) return
 
-  // Use the world matrix so the ray matches the visibly-rendered controller
-  // even when <Controller> is nested in a parent transform (e.g. a dolly rig).
-  // Force-update because this runs before the frame's scene.updateMatrixWorld.
-  targetRay.updateWorldMatrix(true, false)
+  // `<Controller>` attaches targetRay to the scene root so local === world;
+  // we can read `.position`/`.quaternion` directly without a matrixWorld
+  // roundtrip (which would force-recompose the matrix three.js writes from
+  // the XR pose and introduce a drift against the visible render).
+  forward.set(0, 0, -1).applyQuaternion(targetRay.quaternion)
 
-  origin.setFromMatrixPosition(targetRay.matrixWorld)
-  forward.set(0, 0, -1).transformDirection(targetRay.matrixWorld)
-
-  context.raycaster.set(origin, forward)
+  context.raycaster.set(targetRay.position, forward)
 }

--- a/packages/xr/src/lib/plugins/pointerControls/index.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/index.ts
@@ -13,8 +13,6 @@ import {
 import type { FilterFunction, HandContext } from './types.js'
 import { pointerState } from '../../internal/state.svelte.js'
 
-let controlsCounter = 0
-
 export type PointerControlsOptions = {
   enabled?: boolean
   /**
@@ -78,8 +76,7 @@ export const pointerControls = (handedness: 'left' | 'right', options?: PointerC
   observe.pre(
     () => [handContext.enabled],
     ([enabled]) => {
-      controlsCounter += enabled ? 1 : -1
-      pointerState[handedness].enabled = controlsCounter > 0
+      pointerState[handedness].enabled = enabled
     }
   )
 

--- a/packages/xr/src/lib/plugins/pointerControls/plugin.svelte.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/plugin.svelte.ts
@@ -1,16 +1,10 @@
 import { injectPlugin, isInstanceOf } from '@threlte/core'
 import { usePointerControls } from './hook.js'
-import { events, type ThrelteXREvents } from './types.js'
+import { events } from './types.js'
 
 export const injectPointerControlsPlugin = (): void => {
   injectPlugin('threlte-pointer-controls', (args) => {
     if (!isInstanceOf(args.ref, 'Object3D')) return
-
-    const hasEventHandlers = Object.entries(args.props).some(([key, value]) => {
-      return value !== undefined && events.includes(key as keyof ThrelteXREvents)
-    })
-
-    if (!hasEventHandlers) return
 
     const { addInteractiveObject, removeInteractiveObject } = usePointerControls()
 

--- a/packages/xr/src/lib/plugins/pointerControls/setup.svelte.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/setup.svelte.ts
@@ -15,8 +15,19 @@ import { isPresenting, pointerIntersection } from '../../internal/state.svelte.j
 
 type PointerEventName = (typeof events)[number]
 
+// Hover identity must match the dedup key used in `getHits`, otherwise the ID
+// changes mid-hover (e.g. the hit's face index changes as the ray sweeps a
+// plain mesh) and the object flickers between pointerout/pointerenter every
+// frame.
 const getIntersectionId = (intersection: Intersection) => {
-  return `${(intersection.eventObject || intersection.object).uuid}|${intersection.index}|${intersection.instanceId}`
+  const target = intersection.eventObject ?? intersection.object
+  if (intersection.instanceId !== undefined) {
+    return `${target.uuid}|${intersection.instanceId}`
+  }
+  if ((intersection.object as Points).isPoints) {
+    return `${target.uuid}|${intersection.index}`
+  }
+  return target.uuid
 }
 
 const EPSILON = 0.0001
@@ -34,7 +45,6 @@ export const setupPointerControls = (
   let hits: Intersection[] = []
 
   const lastPosition = new Vector3()
-  const currentPosition = new Vector3()
 
   const handlePointerDown = (event: Event) => {
     // Save initial coordinates on pointer-down
@@ -53,32 +63,21 @@ export const setupPointerControls = (
   }
 
   const handleClick = (event: Event) => {
-    // If a click yields no results, pass it back to the user as a miss
-    // Missed events have to come first in order to establish user-land side-effect clean up
-    if (hits.length === 0) {
-      pointerMissed(context.interactiveObjects, event)
-    }
-
     handleEvent('onclick', event)
   }
 
   function cancelPointer(intersections: Intersection[]) {
     if (handContext.hovered.size === 0) return
 
+    const currentIds = new Set<string>()
+    for (const hit of intersections) {
+      currentIds.add(getIntersectionId(hit))
+    }
+
     const toRemove: [string, IntersectionEvent][] = []
 
     for (const [id, hoveredObj] of handContext.hovered) {
-      // When no objects were hit or the hovered object wasn't found underneath the cursor
-      // we call pointerout and delete the object from the hovered elements map
-      if (
-        intersections.length === 0 ||
-        !intersections.some(
-          (hit) =>
-            hit.object === hoveredObj.object &&
-            hit.index === hoveredObj.index &&
-            hit.instanceId === hoveredObj.instanceId
-        )
-      ) {
+      if (!currentIds.has(id)) {
         toRemove.push([id, hoveredObj])
       }
     }
@@ -161,7 +160,17 @@ export const setupPointerControls = (
     const isPointerMove = name === 'onpointermove'
     const isClickEvent = name === 'onclick' || name === 'oncontextmenu'
 
-    // Take care of unhover
+    // Fire pointermissed for objects that were not under the pointer at pointerdown.
+    // Must come before the dispatch loop so user-land cleanup runs first.
+    if (isClickEvent) {
+      pointerMissed(
+        context.interactiveObjects.filter((object) => !handContext.initialHits.includes(object)),
+        event
+      )
+    }
+
+    // Update hover state before dispatch so that pointerout/pointerleave fire
+    // before pointerover/pointerenter on newly hit objects.
     if (isPointerMove) cancelPointer(hits)
 
     let stopped = false
@@ -176,6 +185,7 @@ export const setupPointerControls = (
         stopped,
         ...hit,
         intersections: hits,
+        handedness,
         stopPropagation() {
           stopped = true
           intersectionEvent.stopped = true
@@ -221,23 +231,11 @@ export const setupPointerControls = (
 
         // Call pointer move
         events.onpointermove?.(intersectionEvent)
-      } else if (
-        (!isClickEvent || handContext.initialHits.includes(hit.eventObject)) &&
-        events[name] !== undefined
-      ) {
-        // Missed events have to come first
-        pointerMissed(
-          context.interactiveObjects.filter((object) => !handContext.initialHits.includes(object)),
-          event
-        )
-
-        // Call the event
-        events[name]?.(intersectionEvent)
-      } else if (isClickEvent && handContext.initialHits.includes(hit.eventObject)) {
-        pointerMissed(
-          context.interactiveObjects.filter((object) => !handContext.initialHits.includes(object)),
-          event
-        )
+      } else if (events[name] !== undefined) {
+        // All other events
+        if (!isClickEvent || handContext.initialHits.includes(hit.eventObject)) {
+          events[name]?.(intersectionEvent)
+        }
       }
 
       if (stopped) break dispatchEvents
@@ -252,15 +250,11 @@ export const setupPointerControls = (
 
       if (targetRay === undefined) return
 
-      // Use world position so motion is detected even when the controller
-      // is nested inside a moving parent (e.g. a dolly rig).
-      targetRay.getWorldPosition(currentPosition)
-
-      if (currentPosition.distanceTo(lastPosition) > EPSILON) {
+      if (targetRay.position.distanceTo(lastPosition) > EPSILON) {
         handleEvent('onpointermove')
       }
 
-      lastPosition.copy(currentPosition)
+      lastPosition.copy(targetRay.position)
     },
     {
       fixedStep,
@@ -271,23 +265,16 @@ export const setupPointerControls = (
   observe.pre(
     () => [controller, handContext.enabled],
     ([controller, $enabled]) => {
-      if (controller === undefined) return
+      if (controller === undefined || !$enabled) return
 
-      const removeHandlers = () => {
+      controller.targetRay.addEventListener('selectstart', handlePointerDown)
+      controller.targetRay.addEventListener('selectend', handlePointerUp)
+      controller.targetRay.addEventListener('select', handleClick)
+
+      return () => {
         controller.targetRay.removeEventListener('selectstart', handlePointerDown)
         controller.targetRay.removeEventListener('selectend', handlePointerUp)
         controller.targetRay.removeEventListener('select', handleClick)
-      }
-
-      if ($enabled) {
-        controller.targetRay.addEventListener('selectstart', handlePointerDown)
-        controller.targetRay.addEventListener('selectend', handlePointerUp)
-        controller.targetRay.addEventListener('select', handleClick)
-
-        return removeHandlers
-      } else {
-        removeHandlers()
-        return
       }
     }
   )
@@ -295,23 +282,16 @@ export const setupPointerControls = (
   observe.pre(
     () => [hand, handContext.enabled],
     ([input, enabled]) => {
-      if (input === undefined) return
+      if (input === undefined || !enabled) return
 
-      const removeHandlers = () => {
+      input.hand.addEventListener('pinchstart', handlePointerDown)
+      input.hand.addEventListener('pinchend', handlePointerUp)
+      input.hand.addEventListener('pinchend', handleClick)
+
+      return () => {
         input.hand.removeEventListener('pinchstart', handlePointerDown)
         input.hand.removeEventListener('pinchend', handlePointerUp)
         input.hand.removeEventListener('pinchend', handleClick)
-      }
-
-      if (enabled) {
-        input.hand.addEventListener('pinchstart', handlePointerDown)
-        input.hand.addEventListener('pinchend', handlePointerUp)
-        input.hand.addEventListener('pinchend', handleClick)
-
-        return removeHandlers
-      } else {
-        removeHandlers()
-        return
       }
     }
   )

--- a/packages/xr/src/lib/plugins/pointerControls/setup.svelte.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/setup.svelte.ts
@@ -34,6 +34,7 @@ export const setupPointerControls = (
   let hits: Intersection[] = []
 
   const lastPosition = new Vector3()
+  const currentPosition = new Vector3()
 
   const handlePointerDown = (event: Event) => {
     // Save initial coordinates on pointer-down
@@ -251,11 +252,15 @@ export const setupPointerControls = (
 
       if (targetRay === undefined) return
 
-      if (targetRay.position.distanceTo(lastPosition) > EPSILON) {
+      // Use world position so motion is detected even when the controller
+      // is nested inside a moving parent (e.g. a dolly rig).
+      targetRay.getWorldPosition(currentPosition)
+
+      if (currentPosition.distanceTo(lastPosition) > EPSILON) {
         handleEvent('onpointermove')
       }
 
-      lastPosition.copy(targetRay.position)
+      lastPosition.copy(currentPosition)
     },
     {
       fixedStep,

--- a/packages/xr/src/lib/plugins/pointerControls/types.ts
+++ b/packages/xr/src/lib/plugins/pointerControls/types.ts
@@ -24,6 +24,8 @@ export interface IntersectionEvent extends Intersection {
   eventObject: Object3D
   /** An array of intersections */
   intersections: Intersection[]
+  /** Which hand dispatched this event. Each controller/hand fires enter/leave/etc. independently. */
+  handedness: 'left' | 'right'
   /** Normalized event coordinates */
   pointer: Vector3
   /** Delta between first click and this event */
@@ -91,5 +93,6 @@ export const events: (keyof ThrelteXREvents)[] = [
   'onpointerout',
   'onpointerenter',
   'onpointerleave',
-  'onpointermove'
+  'onpointermove',
+  'onpointermissed'
 ]

--- a/packages/xr/src/lib/plugins/teleportControls/compute.ts
+++ b/packages/xr/src/lib/plugins/teleportControls/compute.ts
@@ -4,7 +4,6 @@ import type { Context, HandContext } from './context.js'
 
 export type ComputeFunction = (context: Context, handContext: HandContext) => void
 
-const origin = new Vector3()
 const forward = new Vector3()
 
 export const defaultComputeFunction = (context: Context, handContext: HandContext) => {
@@ -12,13 +11,11 @@ export const defaultComputeFunction = (context: Context, handContext: HandContex
 
   if (targetRay === undefined) return
 
-  // Use the world matrix so the ray matches the visibly-rendered controller
-  // even when <Controller> is nested in a parent transform (e.g. a dolly rig).
-  // Force-update because this runs before the frame's scene.updateMatrixWorld.
-  targetRay.updateWorldMatrix(true, false)
+  // `<Controller>` attaches targetRay to the scene root so local === world;
+  // we can read `.position`/`.quaternion` directly without a matrixWorld
+  // roundtrip (which would force-recompose the matrix three.js writes from
+  // the XR pose and introduce a drift against the visible render).
+  forward.set(0, 0, -1).applyQuaternion(targetRay.quaternion)
 
-  origin.setFromMatrixPosition(targetRay.matrixWorld)
-  forward.set(0, 0, -1).transformDirection(targetRay.matrixWorld)
-
-  context.raycaster.set(origin, forward)
+  context.raycaster.set(targetRay.position, forward)
 }

--- a/packages/xr/src/lib/plugins/teleportControls/compute.ts
+++ b/packages/xr/src/lib/plugins/teleportControls/compute.ts
@@ -4,6 +4,7 @@ import type { Context, HandContext } from './context.js'
 
 export type ComputeFunction = (context: Context, handContext: HandContext) => void
 
+const origin = new Vector3()
 const forward = new Vector3()
 
 export const defaultComputeFunction = (context: Context, handContext: HandContext) => {
@@ -11,7 +12,13 @@ export const defaultComputeFunction = (context: Context, handContext: HandContex
 
   if (targetRay === undefined) return
 
-  forward.set(0, 0, -1).applyQuaternion(targetRay.quaternion)
+  // Use the world matrix so the ray matches the visibly-rendered controller
+  // even when <Controller> is nested in a parent transform (e.g. a dolly rig).
+  // Force-update because this runs before the frame's scene.updateMatrixWorld.
+  targetRay.updateWorldMatrix(true, false)
 
-  context.raycaster.set(targetRay.position, forward)
+  origin.setFromMatrixPosition(targetRay.matrixWorld)
+  forward.set(0, 0, -1).transformDirection(targetRay.matrixWorld)
+
+  context.raycaster.set(origin, forward)
 }

--- a/packages/xr/src/lib/plugins/teleportControls/index.ts
+++ b/packages/xr/src/lib/plugins/teleportControls/index.ts
@@ -11,8 +11,6 @@ import { setHandContext } from './context.js'
 import { setupTeleportControls } from './setup.svelte.js'
 import { teleportState } from '../../internal/state.svelte.js'
 
-let controlsCounter = 0
-
 export interface TeleportControlsOptions {
   enabled?: boolean
 
@@ -44,8 +42,6 @@ export const teleportControls = (
   if (getHandContext(handedness) === undefined) {
     const enabled = options?.enabled ?? true
 
-    controlsCounter += enabled ? 1 : -1
-
     const ctx: HandContext = {
       hand: handedness,
       active: currentWritable(false),
@@ -63,8 +59,7 @@ export const teleportControls = (
   observe.pre(
     () => [handContext.enabled],
     ([enabled]) => {
-      controlsCounter += enabled ? 1 : -1
-      teleportState[handedness].enabled = controlsCounter > 0
+      teleportState[handedness].enabled = enabled
     }
   )
 

--- a/packages/xr/src/routes/pointer-controls/+page.svelte
+++ b/packages/xr/src/routes/pointer-controls/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { T, Canvas } from '@threlte/core'
+  import { XR, VRButton } from '$lib/index.js'
+  import Scene from './Scene.svelte'
+</script>
+
+<div>
+  <Canvas>
+    <Scene />
+
+    <XR>
+      {#snippet fallback()}
+        <T.PerspectiveCamera
+          makeDefault
+          position={[0, 1.5, 4]}
+          oncreate={(ref) => {
+            ref.lookAt(0, 1.5, 0)
+          }}
+        />
+      {/snippet}
+    </XR>
+
+    <T.AmbientLight />
+    <T.DirectionalLight
+      intensity={1.5}
+      position={[1, 1, 1]}
+    />
+  </Canvas>
+  <VRButton />
+</div>
+
+<style>
+  :global(body) {
+    margin: 0;
+  }
+  div {
+    height: 100dvh;
+  }
+</style>

--- a/packages/xr/src/routes/pointer-controls/Scene.svelte
+++ b/packages/xr/src/routes/pointer-controls/Scene.svelte
@@ -3,7 +3,7 @@
   import { T, useTask } from '@threlte/core'
   import { Text, interactivity } from '@threlte/extras'
   import { Spring } from 'svelte/motion'
-  import { pointerControls, useXR, Controller, Hand } from '@threlte/xr'
+  import { pointerControls, useXR, Controller, Hand } from '$lib/index.js'
 
   const { isPresenting } = useXR()
 

--- a/packages/xr/src/routes/pointer-controls/Scene.svelte
+++ b/packages/xr/src/routes/pointer-controls/Scene.svelte
@@ -20,8 +20,7 @@
   const hovering = $state({ left: false, right: false, desktop: false })
   const happy = $derived(hovering.left || hovering.right || hovering.desktop)
 
-  const sourceOf = (event: { handedness?: 'left' | 'right' }) =>
-    event.handedness ?? 'desktop'
+  const sourceOf = (event: { handedness?: 'left' | 'right' }) => event.handedness ?? 'desktop'
 
   const mesh = new Mesh()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -979,6 +979,9 @@ importers:
       '@threlte/core':
         specifier: workspace:*
         version: link:../core
+      '@threlte/extras':
+        specifier: workspace:*
+        version: link:../extras
       '@types/three':
         specifier: 'catalog:'
         version: 0.175.0


### PR DESCRIPTION
# Changelog 

* Add handedness to XR event payloads
* Fix: controllers slot populated by hand-tracking input sources
* Fix: useHandJoint task ran every frame, now gated by isPresenting
* Fix pointerControls: raycast origin now comes from matrixWorld instead of local position / rotation
* Fix: redundant removeHandlers() in observe else branches
* Fix: pointerMissed fired per hit instead of per event (aligned to interactivity pattern)
* Fix: Hover identity keys plain meshes by uuid only, so sweeping across faces no longer spams pointerenter/pointerleave.

Also fixes a small `interactivity()` bug found when comparing it against `pointerControls()`:
* Fix: interactivity hover now keys plain meshes by uuid, so sweeping across faces no longer spams pointerenter/pointerleave.       