### PR TITLE
[extras/interactivity] feat: add `eventOptions` option

### DIFF
--- a/.changeset/weak-colts-exercise.md
+++ b/.changeset/weak-colts-exercise.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": minor
+---
+
+Add eventOptions option to interactivity plugin

--- a/apps/docs/src/content/reference/extras/interactivity.mdx
+++ b/apps/docs/src/content/reference/extras/interactivity.mdx
@@ -216,6 +216,23 @@ You can filter and sort events by passing a `filter` to the `interactivity` plug
 </script>
 ```
 
+## Event options
+
+Certain configuration options are available for DOM events via `eventOptions`. Setting `enabled: false` for a specified event will prevent its respective listener from being added.
+
+```svelte title="Scene.svelte"
+<script>
+  import { interactivity } from '@threlte/extras'
+
+  interactivity({
+    eventOptions: {
+      wheel: { passive: true },
+      click: { enabled: false }
+    }
+  })
+</script>
+```
+
 ## Interactivity state
 
 To access the interactivity state, you can use the `useInteractivity` hook in any child component of the component that implements the `interactivity` plugin as follows:
@@ -248,6 +265,7 @@ export type State = {
   filter?: FilterFunction
   clickDistanceThreshold: number
   clickTimeThreshold: number
+  eventOptions?: EventOptions
 }
 ```
 

--- a/apps/docs/src/content/reference/extras/interactivity.mdx
+++ b/apps/docs/src/content/reference/extras/interactivity.mdx
@@ -216,9 +216,9 @@ You can filter and sort events by passing a `filter` to the `interactivity` plug
 </script>
 ```
 
-## Event options
+## Setting passive or active events
 
-Certain configuration options are available for DOM events via `eventOptions`. Setting `enabled: false` for a specified event will prevent its respective listener from being added.
+The events on the canvas that drive interactivity can have their active / passive options modified by passing an `eventOptions` object:
 
 ```svelte title="Scene.svelte"
 <script>
@@ -226,8 +226,7 @@ Certain configuration options are available for DOM events via `eventOptions`. S
 
   interactivity({
     eventOptions: {
-      wheel: { passive: true },
-      click: { enabled: false }
+      wheel: { passive: true }
     }
   })
 </script>

--- a/packages/extras/src/lib/interactivity/context.ts
+++ b/packages/extras/src/lib/interactivity/context.ts
@@ -64,7 +64,7 @@ export type InteractivityContext = {
   filter?: FilterFunction | undefined
   clickDistanceThreshold: number
   clickTimeThreshold: number
-  eventOptions?: EventOptions
+  eventOptions: EventOptions | undefined
   addInteractiveObject: (object: Object3D, events: Events) => void
   removeInteractiveObject: (object: Object3D) => void
 }

--- a/packages/extras/src/lib/interactivity/context.ts
+++ b/packages/extras/src/lib/interactivity/context.ts
@@ -1,8 +1,8 @@
-import { currentWritable, type CurrentWritable, useDOM } from '@threlte/core'
+import { currentWritable, useDOM, type CurrentWritable } from '@threlte/core'
 import { getContext, setContext } from 'svelte'
-import { Vector2, Raycaster, type Object3D, type Intersection } from 'three'
-import type { IntersectionEvent, DomEvent } from './types.js'
+import { Raycaster, Vector2, type Intersection, type Object3D } from 'three'
 import { getDefaultComputeFunction } from './defaults.svelte.js'
+import type { DomEvent, DomEventName, IntersectionEvent } from './types.js'
 
 export type FilterFunction = (
   items: Intersection[],
@@ -38,6 +38,12 @@ export type InteractivityOptions = {
    * matching native DOM behavior.
    */
   clickTimeThreshold?: number
+  /**
+   * Optionally disable listening to certain events.
+   * When an event name is included in this array,
+   * the plugin will not add a listener for the event.
+   */
+  disabledEvents?: DomEventName[]
 }
 
 type Events = Record<string, (arg: unknown) => void>
@@ -59,6 +65,7 @@ export type InteractivityContext = {
   filter?: FilterFunction | undefined
   clickDistanceThreshold: number
   clickTimeThreshold: number
+  disabledEvents?: DomEventName[]
   addInteractiveObject: (object: Object3D, events: Events) => void
   removeInteractiveObject: (object: Object3D) => void
 }
@@ -89,6 +96,7 @@ export const setInteractivityContext = (options?: InteractivityOptions) => {
     filter: options?.filter,
     clickDistanceThreshold: options?.clickDistanceThreshold ?? 8,
     clickTimeThreshold: options?.clickTimeThreshold ?? Number.POSITIVE_INFINITY,
+    disabledEvents: options?.disabledEvents,
     addInteractiveObject: (object: Object3D, events: Events) => {
       // Always update handlers so re-registration picks up new callbacks,
       // even if the object is already in the list.

--- a/packages/extras/src/lib/interactivity/context.ts
+++ b/packages/extras/src/lib/interactivity/context.ts
@@ -2,7 +2,7 @@ import { currentWritable, useDOM, type CurrentWritable } from '@threlte/core'
 import { getContext, setContext } from 'svelte'
 import { Raycaster, Vector2, type Intersection, type Object3D } from 'three'
 import { getDefaultComputeFunction } from './defaults.svelte.js'
-import type { DomEvent, DomEventName, EventOptions, IntersectionEvent } from './types.js'
+import type { DomEvent, EventOptions, IntersectionEvent } from './types.js'
 
 export type FilterFunction = (
   items: Intersection[],
@@ -38,14 +38,9 @@ export type InteractivityOptions = {
    * matching native DOM behavior.
    */
   clickTimeThreshold?: number
-  /**
-   * Optionally disable listening to certain events.
-   * When an event name is included in this array,
-   * its respective listener will not be added.
-   */
-  disabledEvents?: DomEventName[]
   /* 
-    Optionally configure `passive` option for specified events.
+    Optionally configure `passive` and `enabled` options for specified events.
+    Specifying `enabled: false` for an event will prevent its respective listener from being added.
   */
   eventOptions?: EventOptions
 }
@@ -69,7 +64,6 @@ export type InteractivityContext = {
   filter?: FilterFunction | undefined
   clickDistanceThreshold: number
   clickTimeThreshold: number
-  disabledEvents?: DomEventName[]
   eventOptions?: EventOptions
   addInteractiveObject: (object: Object3D, events: Events) => void
   removeInteractiveObject: (object: Object3D) => void
@@ -101,7 +95,6 @@ export const setInteractivityContext = (options?: InteractivityOptions) => {
     filter: options?.filter,
     clickDistanceThreshold: options?.clickDistanceThreshold ?? 8,
     clickTimeThreshold: options?.clickTimeThreshold ?? Number.POSITIVE_INFINITY,
-    disabledEvents: options?.disabledEvents,
     eventOptions: options?.eventOptions,
     addInteractiveObject: (object: Object3D, events: Events) => {
       // Always update handlers so re-registration picks up new callbacks,

--- a/packages/extras/src/lib/interactivity/context.ts
+++ b/packages/extras/src/lib/interactivity/context.ts
@@ -41,7 +41,7 @@ export type InteractivityOptions = {
   /**
    * Optionally disable listening to certain events.
    * When an event name is included in this array,
-   * the plugin will not add a listener for the event.
+   * its respective listener will not be added.
    */
   disabledEvents?: DomEventName[]
   /* 

--- a/packages/extras/src/lib/interactivity/context.ts
+++ b/packages/extras/src/lib/interactivity/context.ts
@@ -39,8 +39,7 @@ export type InteractivityOptions = {
    */
   clickTimeThreshold?: number
   /* 
-    Optionally configure `passive` and `enabled` options for specified events.
-    Specifying `enabled: false` for an event will prevent its respective listener from being added.
+    Optionally configure `passive` options for specified events.
   */
   eventOptions?: EventOptions
 }

--- a/packages/extras/src/lib/interactivity/context.ts
+++ b/packages/extras/src/lib/interactivity/context.ts
@@ -2,7 +2,7 @@ import { currentWritable, useDOM, type CurrentWritable } from '@threlte/core'
 import { getContext, setContext } from 'svelte'
 import { Raycaster, Vector2, type Intersection, type Object3D } from 'three'
 import { getDefaultComputeFunction } from './defaults.svelte.js'
-import type { DomEvent, DomEventName, IntersectionEvent } from './types.js'
+import type { DomEvent, DomEventName, EventOptions, IntersectionEvent } from './types.js'
 
 export type FilterFunction = (
   items: Intersection[],
@@ -44,6 +44,10 @@ export type InteractivityOptions = {
    * the plugin will not add a listener for the event.
    */
   disabledEvents?: DomEventName[]
+  /* 
+    Optionally configure `passive` option for specified events.
+  */
+  eventOptions?: EventOptions
 }
 
 type Events = Record<string, (arg: unknown) => void>
@@ -66,6 +70,7 @@ export type InteractivityContext = {
   clickDistanceThreshold: number
   clickTimeThreshold: number
   disabledEvents?: DomEventName[]
+  eventOptions?: EventOptions
   addInteractiveObject: (object: Object3D, events: Events) => void
   removeInteractiveObject: (object: Object3D) => void
 }
@@ -97,6 +102,7 @@ export const setInteractivityContext = (options?: InteractivityOptions) => {
     clickDistanceThreshold: options?.clickDistanceThreshold ?? 8,
     clickTimeThreshold: options?.clickTimeThreshold ?? Number.POSITIVE_INFINITY,
     disabledEvents: options?.disabledEvents,
+    eventOptions: options?.eventOptions,
     addInteractiveObject: (object: Object3D, events: Events) => {
       // Always update handlers so re-registration picks up new callbacks,
       // even if the object is already in the list.

--- a/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
+++ b/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
@@ -295,7 +295,7 @@ export const setupInteractivity = (context: InteractivityContext) => {
 
   const disconnect = (target: HTMLElement) => {
     for (const [eventName] of DOM_EVENTS) {
-      if (context.disabledEvents?.includes(eventName)) continue
+      if (context.eventOptions?.[eventName]?.enabled === false) continue
 
       if (eventName === 'pointerleave' || eventName === 'pointercancel') {
         target.removeEventListener(eventName, handlePointerLeaveOrCancel)
@@ -311,7 +311,7 @@ export const setupInteractivity = (context: InteractivityContext) => {
 
   const connect = (target: HTMLElement) => {
     for (const [eventName, defaultPassive] of DOM_EVENTS) {
-      if (context.disabledEvents?.includes(eventName)) continue
+      if (context.eventOptions?.[eventName]?.enabled === false) continue
 
       const passive = context.eventOptions?.[eventName]?.passive ?? defaultPassive
 

--- a/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
+++ b/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
@@ -310,8 +310,10 @@ export const setupInteractivity = (context: InteractivityContext) => {
   }
 
   const connect = (target: HTMLElement) => {
-    for (const [eventName, passive] of DOM_EVENTS) {
+    for (const [eventName, defaultPassive] of DOM_EVENTS) {
       if (context.disabledEvents?.includes(eventName)) continue
+
+      const passive = context.eventOptions?.[eventName]?.passive ?? defaultPassive
 
       if (eventName === 'pointerleave' || eventName === 'pointercancel') {
         target.addEventListener(eventName, handlePointerLeaveOrCancel, { passive })

--- a/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
+++ b/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
@@ -1,7 +1,7 @@
-import type { Points, Object3D } from 'three'
-import { type InteractivityContext, useInteractivity } from './context.js'
-import type { DomEvent, Intersection, IntersectionEvent } from './types.js'
 import { fromStore } from 'svelte/store'
+import type { Object3D, Points } from 'three'
+import { type InteractivityContext, useInteractivity } from './context.js'
+import type { DomEvent, DomEventName, Intersection, IntersectionEvent } from './types.js'
 
 // Hover identity must match the dedup key used in `getHits`, otherwise the ID
 // changes mid-hover (e.g. the hit's face index changes as the ray sweeps a
@@ -18,7 +18,7 @@ function createIntersectionId(intersection: Intersection) {
   return target.uuid
 }
 
-const DOM_EVENTS = [
+const DOM_EVENTS: [DomEventName, boolean][] = [
   ['click', false],
   ['contextmenu', false],
   ['dblclick', false],
@@ -29,7 +29,7 @@ const DOM_EVENTS = [
   ['pointerenter', true],
   ['pointermove', true],
   ['pointercancel', true]
-] as const
+]
 
 export const setupInteractivity = (context: InteractivityContext) => {
   const { handlers } = useInteractivity()
@@ -295,6 +295,8 @@ export const setupInteractivity = (context: InteractivityContext) => {
 
   const disconnect = (target: HTMLElement) => {
     for (const [eventName] of DOM_EVENTS) {
+      if (context.disabledEvents?.includes(eventName)) continue
+
       if (eventName === 'pointerleave' || eventName === 'pointercancel') {
         target.removeEventListener(eventName, handlePointerLeaveOrCancel)
       } else if (eventName === 'pointermove') {
@@ -309,6 +311,8 @@ export const setupInteractivity = (context: InteractivityContext) => {
 
   const connect = (target: HTMLElement) => {
     for (const [eventName, passive] of DOM_EVENTS) {
+      if (context.disabledEvents?.includes(eventName)) continue
+
       if (eventName === 'pointerleave' || eventName === 'pointercancel') {
         target.addEventListener(eventName, handlePointerLeaveOrCancel, { passive })
       } else if (eventName === 'pointermove') {

--- a/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
+++ b/packages/extras/src/lib/interactivity/setupInteractivity.svelte.ts
@@ -295,8 +295,6 @@ export const setupInteractivity = (context: InteractivityContext) => {
 
   const disconnect = (target: HTMLElement) => {
     for (const [eventName] of DOM_EVENTS) {
-      if (context.eventOptions?.[eventName]?.enabled === false) continue
-
       if (eventName === 'pointerleave' || eventName === 'pointercancel') {
         target.removeEventListener(eventName, handlePointerLeaveOrCancel)
       } else if (eventName === 'pointermove') {
@@ -311,8 +309,6 @@ export const setupInteractivity = (context: InteractivityContext) => {
 
   const connect = (target: HTMLElement) => {
     for (const [eventName, defaultPassive] of DOM_EVENTS) {
-      if (context.eventOptions?.[eventName]?.enabled === false) continue
-
       const passive = context.eventOptions?.[eventName]?.passive ?? defaultPassive
 
       if (eventName === 'pointerleave' || eventName === 'pointercancel') {

--- a/packages/extras/src/lib/interactivity/types.ts
+++ b/packages/extras/src/lib/interactivity/types.ts
@@ -66,4 +66,4 @@ export type DomEventName =
   | 'pointermove'
   | 'pointercancel'
 
-export type EventOptions = Partial<Record<DomEventName, { passive?: boolean }>>
+export type EventOptions = Partial<Record<DomEventName, { passive?: boolean; enabled?: boolean }>>

--- a/packages/extras/src/lib/interactivity/types.ts
+++ b/packages/extras/src/lib/interactivity/types.ts
@@ -53,3 +53,15 @@ export type ThrelteEvents = {
 export type InteractivityProps = {
   [K in keyof ThrelteEvents]?: (event: ThrelteEvents[K]) => void
 }
+
+export type DomEventName =
+  | 'click'
+  | 'contextmenu'
+  | 'dblclick'
+  | 'wheel'
+  | 'pointerdown'
+  | 'pointerup'
+  | 'pointerleave'
+  | 'pointerenter'
+  | 'pointermove'
+  | 'pointercancel'

--- a/packages/extras/src/lib/interactivity/types.ts
+++ b/packages/extras/src/lib/interactivity/types.ts
@@ -66,4 +66,4 @@ export type DomEventName =
   | 'pointermove'
   | 'pointercancel'
 
-export type EventOptions = Partial<Record<DomEventName, { passive?: boolean; enabled?: boolean }>>
+export type EventOptions = Partial<Record<DomEventName, { passive?: boolean }>>

--- a/packages/extras/src/lib/interactivity/types.ts
+++ b/packages/extras/src/lib/interactivity/types.ts
@@ -65,3 +65,5 @@ export type DomEventName =
   | 'pointerenter'
   | 'pointermove'
   | 'pointercancel'
+
+export type EventOptions = Partial<Record<DomEventName, { passive?: boolean }>>


### PR DESCRIPTION
Adds `eventOptions` for `interactivity`:
- `passive` allows overriding default `passive` option for a given DOM event
- `enabled` allows disabling certain DOM events that are not needed by the user, preventing their listeners from being added

This PR also adds an "Event options" section to the interactivity doc. 

Fixes https://github.com/threlte/threlte/issues/1821.

#### Usage example: 
```
interactivity({ 
  eventOptions: {
     wheel: { passive: true },
     click: { enabled: false },
  }
})
  ```