### PR TITLE
Add `@threlte/core/webgpu` export

### DIFF
--- a/.changeset/spicy-countries-provide.md
+++ b/.changeset/spicy-countries-provide.md
@@ -1,0 +1,5 @@
+---
+"@threlte/core": minor
+---
+
+Add `@threlte/core/webgpu` export

--- a/apps/docs/src/content/learn/advanced/webgpu.mdx
+++ b/apps/docs/src/content/learn/advanced/webgpu.mdx
@@ -37,6 +37,12 @@ internally, and points `<T>` at `three/webgpu` so node materials (e.g.
 
 <Example path="renderers/WebGPU" />
 
+<small>
+  Adapted from [this Three.js
+  example](https://threejs.org/examples/?q=webgpu#webgpu_performance_renderbundle), demonstrating
+  WebGPU [render bundles](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundle).
+</small>
+
 <Tip type="note">
   WebGPU is still young and has [limited availability across major
   browsers](https://caniuse.com/?search=webgpu). Three.js's `WebGPURenderer` will fall back to WebGL
@@ -67,12 +73,6 @@ factory. The `<Canvas>` still awaits `init()` for you.
   <Scene />
 </Canvas>
 ```
-
-<small>
-  Adapted from [this Three.js
-  example](https://threejs.org/examples/?q=webgpu#webgpu_performance_renderbundle), demonstrating
-  WebGPU [render bundles](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundle).
-</small>
 
 ### Vite
 

--- a/apps/docs/src/content/learn/advanced/webgpu.mdx
+++ b/apps/docs/src/content/learn/advanced/webgpu.mdx
@@ -11,6 +11,8 @@ swaps the default renderer for `WebGPURenderer`, awaits `renderer.init()`
 internally, and points `<T>` at `three/webgpu` so node materials (e.g.
 `<T.MeshPhysicalNodeMaterial />`) resolve out of the box.
 
+`useThrelte` from the `webgpu` export is also updated to have `WebGPURenderer` types.
+
 ```svelte title="App.svelte"
 <script>
   import Scene from './Scene.svelte'
@@ -33,7 +35,7 @@ internally, and points `<T>` at `three/webgpu` so node materials (e.g.
 </T.Mesh>
 ```
 
-`useThrelte` from the `webgpu` export is also updated to have `WebGPURenderer` types.
+<Example path="renderers/WebGPU" />
 
 <Tip type="note">
   WebGPU is still young and has [limited availability across major
@@ -65,8 +67,6 @@ factory. The `<Canvas>` still awaits `init()` for you.
   <Scene />
 </Canvas>
 ```
-
-<Example path="renderers/WebGPU" />
 
 <small>
   Adapted from [this Three.js

--- a/apps/docs/src/content/learn/advanced/webgpu.mdx
+++ b/apps/docs/src/content/learn/advanced/webgpu.mdx
@@ -4,28 +4,52 @@ title: WebGPU and TSL
 order: 1
 ---
 
-<Tip type="experimental">
-  The WebGPU specification is still in active development. WebGPU support in Three.js is in an early
-  stage and is subject to frequent breaking changes. As of now, we do not recommend using WebGPU in
-  production.
-</Tip>
-
-<Tip type="warning">
-  We highly recommend targeting [version r171](https://github.com/mrdoob/three.js/releases/tag/r171)
-  onwards because of potential [duplication and configuration
-  issues](https://github.com/mrdoob/three.js/pull/29404).
-</Tip>
-
 ## WebGPU
 
-To use the WebGPU renderer, import it and then initialize it within your
-`<Canvas>`'s `createRenderer` prop. This will replace the default WebGL
-renderer.
+`@threlte/core` ships a `webgpu` export that mirrors the regular library but
+swaps the default renderer for `WebGPURenderer`, awaits `renderer.init()`
+internally, and points `<T>` at `three/webgpu` so node materials (e.g.
+`<T.MeshPhysicalNodeMaterial />`) resolve out of the box.
 
-```svelte title="App.svelte" {4}+ {8-14}+
+```svelte title="App.svelte"
 <script>
   import Scene from './Scene.svelte'
-  import { Canvas } from '@threlte/core'
+  import { Canvas } from '@threlte/core/webgpu'
+</script>
+
+<Canvas>
+  <Scene />
+</Canvas>
+```
+
+```svelte title="Scene.svelte"
+<script>
+  import { T } from '@threlte/core/webgpu'
+</script>
+
+<T.Mesh>
+  <T.BoxGeometry />
+  <T.MeshPhysicalNodeMaterial />
+</T.Mesh>
+```
+
+`useThrelte` from the `webgpu` export is also updated to have `WebGPURenderer` types.
+
+<Tip type="note">
+  WebGPU is still young and has [limited availability across major
+  browsers](https://caniuse.com/?search=webgpu). Three.js's `WebGPURenderer` will fall back to WebGL
+  when WebGPU is not available.
+</Tip>
+
+### Customizing the renderer
+
+To configure the renderer (e.g. force a specific backend), pass a `createRenderer`
+factory. The `<Canvas>` still awaits `init()` for you.
+
+```svelte title="App.svelte"
+<script>
+  import Scene from './Scene.svelte'
+  import { Canvas } from '@threlte/core/webgpu'
   import { WebGPURenderer } from 'three/webgpu'
 </script>
 
@@ -42,46 +66,13 @@ renderer.
 </Canvas>
 ```
 
-<Tip type="note">
-  WebGPU is still young and has [limited availability across major
-  browsers](https://caniuse.com/?search=webgpu). For this reason, Three.js's WebGPU renderer
-  fallbacks to WebGL when WebGPU is not available.
-</Tip>
+<Example path="renderers/WebGPU" />
 
-<Tip type="tip">
-  This same approach can be used to swap out the default renderer for any other custom renderer.
-</Tip>
-
-The WebGPU renderer doesn't immediately render. If the renderer you provide
-needs to delay rendering, you can defer rendering by initially setting the
-renderMode to `manual`.
-
-```svelte title="App.svelte"
-<script>
-  import { Canvas, T } from '@threlte/core'
-  import { WebGPURenderer } from 'three/webgpu'
-  let renderMode = $state('manual')
-</script>
-
-<Canvas
-  {renderMode}
-  createRenderer={(canvas) => {
-    const renderer = new WebGPURenderer({
-      canvas,
-      antialias: true,
-      forceWebGL: false
-    })
-
-    renderer.init().then(() => {
-      renderMode = 'on-demand'
-    })
-
-    return renderer
-  }}
->
-  <Scene />
-</Canvas>
-```
+<small>
+  Adapted from [this Three.js
+  example](https://threejs.org/examples/?q=webgpu#webgpu_performance_renderbundle), demonstrating
+  WebGPU [render bundles](https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundle).
+</small>
 
 ### Vite
 
@@ -105,17 +96,9 @@ Alternatively,
 [`vite-plugin-top-level-await`](https://github.com/Menci/vite-plugin-top-level-await)
 can be used, although less success has been reported with this method.
 
-<Example path="renderers/WebGPU" />
-
-<small>
-  Adapted from [this Three.js
-  example](https://threejs.org/examples/?q=webgpu#webgpu_performance_renderbundle).
-</small>
-
 ## TSL
 
-A question that comes up often in Three.js development is "How do I extend
-Three.js materials?". External libraries such as
+A question that comes up often in Three.js development is "How do I extend materials?". External libraries such as
 [three-custom-shader-material](https://www.npmjs.com/package/three-custom-shader-material)
 use a find and replace solution to get this job done. Three.js has identified
 that it's not an ideal solution and recommends using the [Three.js Shading
@@ -125,151 +108,10 @@ TSL for short.
 The example below is an adaptation of
 [this](https://threejs.org/examples/?q=tsl#webgpu_tsl_angular_slicing) Three.js
 example. There are many more [TSL
-examples](https://threejs.org/examples/?q=tsl) within Three.js that you can use
+examples](https://threejs.org/examples/?q=tsl) that you can use
 or adapt for your project.
 
 <Example path="shaders/webgpu/slice" />
-
-### Using the `<T>` catalogue
-
-The `<T>` component defaults to all the exports from `three` and will error on
-webgpu things like `<T.MeshPhysicalNodeMaterial />`. This is because the
-`MeshPhysicalNodeMaterial` class is an export of `three/webgpu` and not
-`three`. Here are a few options to resolve this.
-
-#### Option 1
-
-Extend `<T>` with all the definitions from `three/webgpu` by using the
-[`extend`](/docs/reference/core/t#extending-the-default-component-catalogue)
-function. Adding all of the definitions will increase the bundle size of
-your application because both `three` and `three/webgpu` will be imported in
-a non-tree-shakeable way.
-
-```svelte title="App.svelte" {3-4}+ {6}+
-<script>
-  import Scene from './Scene.svelte'
-  import { Canvas, extend } from '@threlte/core'
-  import * as THREE from 'three/webgpu'
-
-  extend(THREE)
-</script>
-
-<Canvas
-  createRenderer={(canvas) => {
-    return new THREE.WebGPURenderer({
-      canvas,
-      antialias: true,
-      forceWebGL: false
-    })
-  }}
->
-  <Scene />
-</Canvas>
-```
-
-#### Option 2
-
-Use explicit imports for the objects, functions, and other classes that you
-use from `three/webgpu`. You can then use `<T>`'s
-[`is`](/docs/reference/core/t#property-is) prop with those imports from
-`three/webgpu`.
-
-```svelte title="Scene.svelte" {3}+ {5}+ {10}+
-<script>
-  import { T } from '@threlte/core'
-  import { MeshPhysicalNodeMaterial } from 'three/webgpu'
-
-  const material = new MeshPhysicalNodeMaterial()
-</script>
-
-<T.Mesh>
-  <T.BoxGeometry />
-  <T is={material} />
-</T.Mesh>
-```
-
-#### Option 3
-
-Same as option #2 but using
-[`extend`](/docs/reference/core/t#extending-the-default-component-catalogue)
-with the imports so that you can have `<T.MeshPhysicalNodeMaterial />`
-etc...
-
-```svelte title="App.svelte" {3-4}+ {6}+
-<script>
-  import Scene from './Scene.svelte'
-  import { Canvas, extend } from '@threlte/core'
-  import { WebGPURenderer, MeshPhysicalNodeMaterial } from 'three/webgpu'
-
-  extend({ MeshPhysicalNodeMaterial })
-</script>
-
-<Canvas
-  createRenderer={(canvas) => {
-    return new WebGPURenderer({
-      canvas,
-      antialias: true,
-      forceWebGL: false
-    })
-  }}
->
-  <Scene />
-</Canvas>
-```
-
-```svelte title=Scene.svelte
-<script>
-  import { T } from '@threlte/core'
-</script>
-
-<T.Mesh>
-  <T.BoxGeometry />
-  <T.MeshPhysicalNodeMaterial />
-</T.Mesh>
-```
-
-Options 2 and 3 will keep the bundle size of your application small but you'll
-have to keep it updated as you go.
-
-#### Careful! `three` and `three/webgpu` don't mix well
-
-You will need to overwrite some of the default catalogue if you use
-`three/webgpu`. For example, if you're using a `MeshPhysicalNodeMaterial`, you
-need to update any lighing classes you use like so:
-
-```svelte title="App.svelte"
-<script>
-  import { DirectionalLight, MeshPhysicalNodeMaterial } from 'three/webgpu'
-
-  // tell <T.DirectionalLight> to use the definition from `three/webgpu`
-  extend({ MeshPhysicalNodeMaterial, DirectionalLight })
-</script>
-
-<Canvas>
-  <Scene />
-</Canvas>
-```
-
-```svelte title="Scene.svelte"
-<script>
-  import { T } from '@threlte/core'
-</script>
-
-<T.DirectionalLight />
-
-<T.Mesh>
-  <T.BoxGeometry />
-  <T.MeshPhysicalNodeMaterial />
-</T.Mesh>
-```
-
-This is because the exports from `three/webgpu` are different than those in
-`three` and make use of the additional features that node materials have.
-
-<Tip type="tip">
-  An easy option for projects is to start with option #1 and then transition to the other options
-  when bundle size becomes an issue or you need to ship to production.
-</Tip>
 
 ### Nodes
 
@@ -301,12 +143,12 @@ attach the material.
 <T is={material} />
 ```
 
-Node materials give you the ability to modify three's builtin materials. In the
+Node materials give you the ability to modify builtin materials. In the
 sliced gear example, two nodes are modified; the `outputNode` and the
 `castShadowNode`. The `outputNode` is set up in such a way that it discards any
 fragments that are outside the permitted `startAngle` and `arcAngle`. If a
 fragment is not discarded and it is not front-facing, it is assigned the color
 in the `uColor` uniform. The material needs its `side` set to
-`THREE.DoubleSide` otherwise three.js will cull them out if they are facing
+`THREE.DoubleSide` otherwise they will be culled if they are facing
 away from the camera. Any fragment that is discarded in the shadowNode will not
 cast shadows.

--- a/apps/docs/src/examples/renderers/WebGPU/App.svelte
+++ b/apps/docs/src/examples/renderers/WebGPU/App.svelte
@@ -1,21 +1,10 @@
 <script lang="ts">
-  import { Canvas, extend } from '@threlte/core'
+  import { Canvas } from '@threlte/core/webgpu'
   import Scene from './Scene.svelte'
-  import * as THREE from 'three/webgpu'
-
-  extend(THREE)
 </script>
 
 <div>
-  <Canvas
-    createRenderer={(canvas) => {
-      return new THREE.WebGPURenderer({
-        canvas,
-        antialias: true,
-        forceWebGL: false
-      })
-    }}
-  >
+  <Canvas>
     <Scene />
   </Canvas>
 </div>

--- a/apps/docs/src/examples/renderers/WebGPU/Scene.svelte
+++ b/apps/docs/src/examples/renderers/WebGPU/Scene.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { T, useTask, useThrelte } from '@threlte/core'
+  import { T, useTask, useThrelte } from '@threlte/core/webgpu'
   import { OrbitControls } from '@threlte/extras'
   import Stats from 'three/addons/libs/stats.module.js'
   import * as THREE from 'three/webgpu'

--- a/apps/docs/src/examples/shaders/webgpu/slice/App.svelte
+++ b/apps/docs/src/examples/shaders/webgpu/slice/App.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
   import Scene from './Scene.svelte'
-  import { Canvas, extend } from '@threlte/core'
+  import { Canvas } from '@threlte/core/webgpu'
   import { Checkbox, Color, Folder, Pane, Slider } from 'svelte-tweakpane-ui'
   import { ACESFilmicToneMapping, MathUtils } from 'three'
-  import {
-    DirectionalLight,
-    MeshPhysicalNodeMaterial,
-    MeshStandardMaterial,
-    WebGPURenderer
-  } from 'three/webgpu'
-
-  extend({ DirectionalLight, MeshPhysicalNodeMaterial, MeshStandardMaterial })
 
   let arcAngleDegrees = $state(90)
   let startAngleDegrees = $state(60)
@@ -50,16 +42,7 @@
     />
   </Folder>
 </Pane>
-<Canvas
-  toneMapping={ACESFilmicToneMapping}
-  createRenderer={(canvas) => {
-    return new WebGPURenderer({
-      antialias: true,
-      canvas,
-      forceWebGL: false
-    })
-  }}
->
+<Canvas toneMapping={ACESFilmicToneMapping}>
   <Scene
     {rotate}
     {arcAngle}

--- a/apps/docs/src/examples/shaders/webgpu/slice/Scene.svelte
+++ b/apps/docs/src/examples/shaders/webgpu/slice/Scene.svelte
@@ -3,7 +3,7 @@
   import type { ColorRepresentation, Mesh } from 'three/webgpu'
   import { DoubleSide, Group } from 'three/webgpu'
   import { Environment, OrbitControls, useDraco, useGltf } from '@threlte/extras'
-  import { T, useTask, useThrelte } from '@threlte/core'
+  import { T, useTask, useThrelte } from '@threlte/core/webgpu'
 
   type SceneProps = {
     arcAngle: number
@@ -51,7 +51,10 @@
   position.y={5}
   position.z={12}
 >
-  <OrbitControls enableDamping />
+  <OrbitControls
+    enableDamping
+    enableZoom={false}
+  />
 </T.PerspectiveCamera>
 
 <T.DirectionalLight

--- a/apps/docs/src/examples/shaders/webgpu/slice/SliceMaterial.svelte
+++ b/apps/docs/src/examples/shaders/webgpu/slice/SliceMaterial.svelte
@@ -9,7 +9,7 @@
 
 <script lang="ts">
   import type { SliceMaterialProps } from './types'
-  import { T } from '@threlte/core'
+  import { T } from '@threlte/core/webgpu'
   import { atan, Fn, frontFacing, If, output, PI2, positionLocal, uniform, vec4 } from 'three/tsl'
   import { Color } from 'three/webgpu'
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,10 @@
     ".": {
       "types": "./src/lib/types.d.ts",
       "svelte": "./src/lib/index.ts"
+    },
+    "./webgpu": {
+      "types": "./src/lib/webgpu/types.d.ts",
+      "svelte": "./src/lib/webgpu/index.ts"
     }
   },
   "types": "./src/lib/types.d.ts",
@@ -90,6 +94,10 @@
       ".": {
         "types": "./dist/types.d.ts",
         "svelte": "./dist/index.js"
+      },
+      "./webgpu": {
+        "types": "./dist/webgpu/types.d.ts",
+        "svelte": "./dist/webgpu/index.js"
       }
     },
     "types": "./dist/types.d.ts"

--- a/packages/core/src/lib/Canvas.svelte
+++ b/packages/core/src/lib/Canvas.svelte
@@ -4,7 +4,7 @@
   import type { CreateThrelteContextOptions } from './context/createThrelteContext.svelte.js'
   import type { Renderer } from './context/fragments/renderer.svelte.js'
 
-  type Props = Omit<CreateThrelteContextOptions<Renderer>, 'canvas' | 'dom'> & {
+  interface Props extends Omit<CreateThrelteContextOptions<Renderer>, 'canvas' | 'dom'> {
     children?: Snippet
   }
 

--- a/packages/core/src/lib/__tests__/__fixtures__/CanvasContext.svelte
+++ b/packages/core/src/lib/__tests__/__fixtures__/CanvasContext.svelte
@@ -4,7 +4,7 @@
   import type { Renderer } from '../../context/fragments/renderer.svelte.js'
   import { useThrelte, type ThrelteContext } from '../../context/compounds/useThrelte.js'
 
-  type Props = Omit<CreateThrelteContextOptions<Renderer>, 'canvas' | 'dom'> & {
+  interface Props extends Omit<CreateThrelteContextOptions<Renderer>, 'canvas' | 'dom'> {
     oncontext?: (ctx: ThrelteContext<Renderer>) => void
   }
 

--- a/packages/core/src/lib/webgpu/Canvas.svelte
+++ b/packages/core/src/lib/webgpu/Canvas.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { WebGPURenderer } from 'three/webgpu'
+  import Context from '../components/Context/Context.svelte'
+  import type { CreateThrelteContextOptions } from '../context/createThrelteContext.svelte.js'
+
+  type Props = Omit<CreateThrelteContextOptions<WebGPURenderer>, 'canvas' | 'dom'> & {
+    children?: Snippet
+  }
+
+  let { children, createRenderer, ...rest }: Props = $props()
+
+  let canvas = $state.raw<HTMLCanvasElement>()
+  let dom = $state.raw<HTMLDivElement>()
+  let renderer = $state.raw<WebGPURenderer>()
+
+  $effect(() => {
+    if (!canvas) return
+
+    const instance = createRenderer
+      ? createRenderer(canvas)
+      : new WebGPURenderer({ canvas, antialias: true })
+
+    let disposed = false
+
+    instance.init().then(() => {
+      if (disposed) {
+        instance.dispose()
+        return
+      }
+      renderer = instance
+    })
+
+    return () => {
+      disposed = true
+      renderer = undefined
+    }
+  })
+</script>
+
+<div bind:this={dom}>
+  <canvas bind:this={canvas}>
+    {#if canvas && dom && renderer}
+      {@const initialized = renderer}
+      <Context
+        {dom}
+        {canvas}
+        createRenderer={() => initialized}
+        {...rest}
+      >
+        {@render children?.()}
+      </Context>
+    {/if}
+  </canvas>
+</div>
+
+<style>
+  div {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  canvas {
+    display: block;
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/packages/core/src/lib/webgpu/Canvas.svelte
+++ b/packages/core/src/lib/webgpu/Canvas.svelte
@@ -4,7 +4,7 @@
   import Context from '../components/Context/Context.svelte'
   import type { CreateThrelteContextOptions } from '../context/createThrelteContext.svelte.js'
 
-  type Props = Omit<CreateThrelteContextOptions<WebGPURenderer>, 'canvas' | 'dom'> & {
+  interface Props extends Omit<CreateThrelteContextOptions<WebGPURenderer>, 'canvas' | 'dom'> {
     children?: Snippet
   }
 

--- a/packages/core/src/lib/webgpu/T.ts
+++ b/packages/core/src/lib/webgpu/T.ts
@@ -30,10 +30,23 @@ export const extend = (extensions: Extensions) => {
 /**
  * ## `<T>` (WebGPU)
  *
- * Variant of Threlte's `<T>` whose name lookups resolve against `three/webgpu`,
- * so e.g. `<T.MeshStandardMaterial>` uses the WebGPU-native class rather than
- * the WebGL one, and the Node material classes (`MeshStandardNodeMaterial`,
- * etc.) are addressable directly.
+ * Threlte's `<T>` component is a wrapper around Three.js objects. It is a generic component
+ * that can be used to create any Three.js object.
+ *
+ * @example
+ *
+ * ```svelte
+ * <script>
+ * 	import { T } from 'threlte'
+ * </script>
+ *
+ * <T.PerspectiveCamera makeDefault />
+ *
+ * <T.Mesh>
+ * 	<T.BoxGeometry />
+ * 	<T.MeshBasicMaterial color="red" />
+ * </T.Mesh>
+ * ```
  */
 export const T = new Proxy(TComp, {
   get(_target, is: keyof typeof THREE) {

--- a/packages/core/src/lib/webgpu/T.ts
+++ b/packages/core/src/lib/webgpu/T.ts
@@ -1,0 +1,59 @@
+import type { Component } from 'svelte'
+import * as THREE from 'three/webgpu'
+import TComp from '../components/T/T.svelte'
+import type { Props } from '../components/T/types.js'
+import { setIs } from '../components/T/utils/useIs.js'
+
+type Extensions = Record<string, unknown>
+
+type ThreeCatalogue = {
+  [K in keyof typeof THREE]: (typeof THREE)[K]
+}
+
+type TComponentProxy = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  [K in keyof ThreeCatalogue]: Component<Props<ThreeCatalogue[K]>, {}, 'ref'>
+}
+
+const catalogue: Extensions = {}
+
+/**
+ * Extends the WebGPU `three/webgpu` namespace and allows using custom Three.js
+ * objects with `<T>` from `@threlte/core/webgpu`.
+ *
+ * This catalogue is independent of the one used by `@threlte/core`'s `extend`.
+ */
+export const extend = (extensions: Extensions) => {
+  Object.assign(catalogue, extensions)
+}
+
+/**
+ * ## `<T>` (WebGPU)
+ *
+ * Variant of Threlte's `<T>` whose name lookups resolve against `three/webgpu`,
+ * so e.g. `<T.MeshStandardMaterial>` uses the WebGPU-native class rather than
+ * the WebGL one, and the Node material classes (`MeshStandardNodeMaterial`,
+ * etc.) are addressable directly.
+ */
+export const T = new Proxy(TComp, {
+  get(_target, is: keyof typeof THREE) {
+    if (typeof is !== 'string') {
+      return Reflect.get(_target, is)
+    }
+
+    const module = catalogue[is] || THREE[is]
+
+    if (module === undefined) {
+      throw new Error(`No Three.js module found for ${is}. Did you forget to extend the catalogue?`)
+    }
+
+    return (...args: Parameters<typeof TComp>) => {
+      setIs(module)
+      return TComp(...args)
+    }
+  }
+}) as typeof TComp &
+  TComponentProxy & {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    [Key in keyof Threlte.UserCatalogue]: Component<Props<Threlte.UserCatalogue[Key]>, {}, 'ref'>
+  } & Record<string, Component>

--- a/packages/core/src/lib/webgpu/__tests__/__fixtures__/CanvasContext.svelte
+++ b/packages/core/src/lib/webgpu/__tests__/__fixtures__/CanvasContext.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { WebGPURenderer } from 'three/webgpu'
+  import Canvas from '../../Canvas.svelte'
+  import type { CreateThrelteContextOptions } from '../../../context/createThrelteContext.svelte.js'
+  import { useThrelte, type ThrelteContext } from '../../../context/compounds/useThrelte.js'
+
+  type Props = Omit<CreateThrelteContextOptions<WebGPURenderer>, 'canvas' | 'dom'> & {
+    oncontext?: (ctx: ThrelteContext<WebGPURenderer>) => void
+  }
+
+  let { oncontext, ...rest }: Props = $props()
+</script>
+
+<Canvas {...rest}>
+  {@const ctx = useThrelte<WebGPURenderer>()}
+  {oncontext?.(ctx)}
+</Canvas>

--- a/packages/core/src/lib/webgpu/index.ts
+++ b/packages/core/src/lib/webgpu/index.ts
@@ -1,0 +1,86 @@
+import type { WebGPURenderer } from 'three/webgpu'
+import {
+  useThrelte as useThrelteGeneric,
+  type ThrelteContext
+} from '../context/compounds/useThrelte.js'
+import {
+  useRenderer as useRendererGeneric,
+  type RendererContext
+} from '../context/fragments/renderer.svelte.js'
+
+export const VERSION = 8
+
+// canvas component (webgpu)
+export { default as Canvas } from './Canvas.svelte'
+
+// components (v6) — T proxy resolves names against `three/webgpu`
+export { T, extend } from './T.js'
+export type { Props } from '../components/T/types.js'
+
+// plugins
+export { injectPlugin } from '../plugins/injectPlugin.js'
+export type { Plugin } from '../plugins/types.js'
+
+// hooks — narrowed to WebGPURenderer
+export const useThrelte = (): ThrelteContext<WebGPURenderer> =>
+  useThrelteGeneric<WebGPURenderer>()
+export const useRenderer = (): RendererContext<WebGPURenderer> =>
+  useRendererGeneric<WebGPURenderer>()
+
+// hooks
+export { useStage } from '../hooks/useStage.js'
+export { useTask, type ThrelteUseTask, type ThrelteUseTaskOptions } from '../hooks/useTask.svelte.js'
+export { useThrelteUserContext } from '../hooks/useThrelteUserContext.js'
+
+// task scheduling system types
+export type {
+  Key,
+  Schedule,
+  Scheduler,
+  Stage,
+  Task,
+  TaskCallback
+} from '../frame-scheduling/index.js'
+
+// useLoader
+export {
+  useLoader,
+  type UseLoaderLoadOptions,
+  type UseLoaderLoadInput,
+  type UseLoaderLoadResult,
+  type UseLoaderOptions
+} from '../hooks/useLoader.js'
+
+// contexts
+export type { ThrelteContext } from '../context/compounds/useThrelte.js'
+export { createThrelteContext } from '../context/createThrelteContext.svelte.js'
+export { createCacheContext, useCache } from '../context/fragments/cache.js'
+export { createCameraContext, useCamera } from '../context/fragments/camera.svelte.js'
+export { createDOMContext, useDOM } from '../context/fragments/dom.svelte.js'
+export { createDisposalContext, useDisposal } from '../context/fragments/disposal.svelte.js'
+export {
+  createParentContext_deprecated as createParentContext,
+  useParent_deprecated as useParent
+} from '../context/fragments/parent.js'
+export {
+  createParentObject3DContext_deprecated as createParentObject3DContext,
+  useParentObject3D_deprecated as useParentObject3D
+} from '../context/fragments/parentObject3D.js'
+export { createRendererContext } from '../context/fragments/renderer.svelte.js'
+export { createSceneContext, useScene } from '../context/fragments/scene.js'
+export { createSchedulerContext, useScheduler } from '../context/fragments/scheduler.svelte.js'
+export { createUserContext } from '../context/fragments/user.js'
+
+// utils
+export { observe } from '../utilities/observe.svelte.js'
+export { isInstanceOf } from '../utilities/isInstanceOf.js'
+export { type AsyncWritable, asyncWritable } from '../utilities/asyncWritable.js'
+export { revision } from '../utilities/revision.js'
+export { watch } from '../utilities/watch.js'
+export {
+  type CurrentWritable,
+  type CurrentReadable,
+  currentWritable,
+  toCurrentReadable
+} from '../utilities/currentWritable.js'
+export { resolvePropertyPath } from '../utilities/resolvePropertyPath.js'

--- a/packages/core/src/lib/webgpu/index.ts
+++ b/packages/core/src/lib/webgpu/index.ts
@@ -1,63 +1,64 @@
 import type { WebGPURenderer } from 'three/webgpu'
-import {
-  useThrelte as useThrelteGeneric,
-  type ThrelteContext
-} from '../context/compounds/useThrelte.js'
-import {
-  useRenderer as useRendererGeneric,
-  type RendererContext
-} from '../context/fragments/renderer.svelte.js'
 
-export const VERSION = 8
+import { useThrelte as useThrelteGeneric, useRenderer as useRendererGeneric } from '../index.js'
 
-// canvas component (webgpu)
 export { default as Canvas } from './Canvas.svelte'
-
-// components (v6) — T proxy resolves names against `three/webgpu`
 export { T, extend } from './T.js'
-export type { Props } from '../components/T/types.js'
 
-// plugins
-export { injectPlugin } from '../plugins/injectPlugin.js'
-export type { Plugin } from '../plugins/types.js'
+// narrowed to WebGPURenderer
+export const useThrelte = useThrelteGeneric<WebGPURenderer>
+export const useRenderer = useRendererGeneric<WebGPURenderer>
 
-// hooks — narrowed to WebGPURenderer
-export const useThrelte = (): ThrelteContext<WebGPURenderer> =>
-  useThrelteGeneric<WebGPURenderer>()
-export const useRenderer = (): RendererContext<WebGPURenderer> =>
-  useRendererGeneric<WebGPURenderer>()
-
-// hooks
-export { useStage } from '../hooks/useStage.js'
-export { useTask, type ThrelteUseTask, type ThrelteUseTaskOptions } from '../hooks/useTask.svelte.js'
-export { useThrelteUserContext } from '../hooks/useThrelteUserContext.js'
-
-// task scheduling system types
-export type {
-  Key,
-  Schedule,
-  Scheduler,
-  Stage,
-  Task,
-  TaskCallback
-} from '../frame-scheduling/index.js'
-
-// useLoader
 export {
+  VERSION,
+  type Props,
+  injectPlugin,
+  type Plugin,
+  useStage,
+  useTask,
+  type ThrelteUseTask,
+  type ThrelteUseTaskOptions,
+  useThrelteUserContext,
+  type Key,
+  type Schedule,
+  type Scheduler,
+  type Stage,
+  type Task,
+  type TaskCallback,
   useLoader,
   type UseLoaderLoadOptions,
   type UseLoaderLoadInput,
   type UseLoaderLoadResult,
-  type UseLoaderOptions
-} from '../hooks/useLoader.js'
+  type UseLoaderOptions,
+  type ThrelteContext,
+  createThrelteContext,
+  createCacheContext,
+  useCache,
+  createCameraContext,
+  useCamera,
+  createDOMContext,
+  useDOM,
+  createDisposalContext,
+  useDisposal,
+  createRendererContext,
+  createSceneContext,
+  useScene,
+  createSchedulerContext,
+  useScheduler,
+  createUserContext,
+  observe,
+  isInstanceOf,
+  type AsyncWritable,
+  asyncWritable,
+  revision,
+  watch,
+  type CurrentWritable,
+  type CurrentReadable,
+  currentWritable,
+  toCurrentReadable,
+  resolvePropertyPath
+} from '../index.js'
 
-// contexts
-export type { ThrelteContext } from '../context/compounds/useThrelte.js'
-export { createThrelteContext } from '../context/createThrelteContext.svelte.js'
-export { createCacheContext, useCache } from '../context/fragments/cache.js'
-export { createCameraContext, useCamera } from '../context/fragments/camera.svelte.js'
-export { createDOMContext, useDOM } from '../context/fragments/dom.svelte.js'
-export { createDisposalContext, useDisposal } from '../context/fragments/disposal.svelte.js'
 export {
   createParentContext_deprecated as createParentContext,
   useParent_deprecated as useParent
@@ -66,21 +67,3 @@ export {
   createParentObject3DContext_deprecated as createParentObject3DContext,
   useParentObject3D_deprecated as useParentObject3D
 } from '../context/fragments/parentObject3D.js'
-export { createRendererContext } from '../context/fragments/renderer.svelte.js'
-export { createSceneContext, useScene } from '../context/fragments/scene.js'
-export { createSchedulerContext, useScheduler } from '../context/fragments/scheduler.svelte.js'
-export { createUserContext } from '../context/fragments/user.js'
-
-// utils
-export { observe } from '../utilities/observe.svelte.js'
-export { isInstanceOf } from '../utilities/isInstanceOf.js'
-export { type AsyncWritable, asyncWritable } from '../utilities/asyncWritable.js'
-export { revision } from '../utilities/revision.js'
-export { watch } from '../utilities/watch.js'
-export {
-  type CurrentWritable,
-  type CurrentReadable,
-  currentWritable,
-  toCurrentReadable
-} from '../utilities/currentWritable.js'
-export { resolvePropertyPath } from '../utilities/resolvePropertyPath.js'

--- a/packages/core/src/lib/webgpu/types.d.ts
+++ b/packages/core/src/lib/webgpu/types.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="../types.d.ts" />
+
+export * from './index.js'

--- a/packages/core/src/lib/webgpu/types.d.ts
+++ b/packages/core/src/lib/webgpu/types.d.ts
@@ -1,3 +1,3 @@
-/// <reference path="../types.d.ts" />
+import '../types.js'
 
 export * from './index.js'


### PR DESCRIPTION
### Overview

This PR adds a new export: `@threlte/core/webgpu` in order to purely import from `three/webgpu` to supply the WebGPURenderer by default and do `three/webgpu` lookups within the T component. For example:

```svelte
<script>
  import Scene from './Scene.svelte'
  import { Canvas } from '@threlte/core/webgpu'
</script>

<Canvas>
```
```svelte
<script>
  import { T } from '@threlte/core/webgpu'
</script>
<T.Mesh>
  <T.BoxGeometry />
  <!-- uses three/webgpu for lookups -->
  <T.MeshPhysicalNodeMaterial />
</T.Mesh>
```

The WebGPU docs page has also been updated to use this import. See https://threlte.xyz/previews/pr-1830/docs/learn/advanced/webgpu/

