### PR TITLE
[@threlte/extras] Add hooks for accessing all controls

### DIFF
--- a/.changeset/controls-accessor-hooks.md
+++ b/.changeset/controls-accessor-hooks.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": minor
+---
+
+Add `useCameraControls`, `useOrbitControls`, `useTrackballControls` and `useTransformControls` hooks

--- a/apps/docs/src/content/reference/extras/camera-controls.mdx
+++ b/apps/docs/src/content/reference/extras/camera-controls.mdx
@@ -86,6 +86,23 @@ A camera can also optionally be passed to the controls as a prop.
 Finally, if the component is created without an attached camera
 it will use the scene's default camera as provided by `useThrelte`.
 
+## `useCameraControls`
+
+To access the underlying `CameraControls` instance from another component —
+without a `bind:ref` — use the `useCameraControls` hook. It returns a reactive
+accessor whose `current` is the instance registered by the nearest
+`<CameraControls>` within the `<Canvas>`, or `undefined` until it has mounted.
+
+```svelte title="FrameButton.svelte"
+<script lang="ts">
+  import { useCameraControls } from '@threlte/extras'
+
+  const controls = useCameraControls()
+</script>
+
+<button onclick={() => controls.current?.setLookAt(5, 5, 5, 0, 0, 0, true)}> Frame scene </button>
+```
+
 ## Examples
 
 ### Basic Example

--- a/apps/docs/src/content/reference/extras/orbit-controls.mdx
+++ b/apps/docs/src/content/reference/extras/orbit-controls.mdx
@@ -52,3 +52,20 @@ docs](https://threejs.org/docs/#examples/en/controls/OrbitControls).
 `<OrbitControls>` is a light wrapper that will use its parent as the target
 camera (or the default camera if not a child of one) and the DOM element the
 renderer is rendering to as the DOM element to listen to pointer events.
+
+## `useOrbitControls`
+
+To access the underlying `OrbitControls` instance from another component —
+without a `bind:ref` — use the `useOrbitControls` hook. It returns a reactive
+accessor whose `current` is the instance registered by the nearest
+`<OrbitControls>` within the `<Canvas>`, or `undefined` until it has mounted.
+
+```svelte title="ResetButton.svelte"
+<script lang="ts">
+  import { useOrbitControls } from '@threlte/extras'
+
+  const controls = useOrbitControls()
+</script>
+
+<button onclick={() => controls.current?.reset()}>Reset camera</button>
+```

--- a/apps/docs/src/content/reference/extras/trackball-controls.mdx
+++ b/apps/docs/src/content/reference/extras/trackball-controls.mdx
@@ -53,3 +53,20 @@ This example shows off just a few of the configurable properties of `<TrackballC
 (or the default camera if not a child of one) and the DOM element the renderer is
 rendering to as the DOM element to listen to. It will also by demand invalidate the
 frame loop.
+
+## `useTrackballControls`
+
+To access the underlying `TrackballControls` instance from another component —
+without a `bind:ref` — use the `useTrackballControls` hook. It returns a reactive
+accessor whose `current` is the instance registered by the nearest
+`<TrackballControls>` within the `<Canvas>`, or `undefined` until it has mounted.
+
+```svelte title="ResetButton.svelte"
+<script lang="ts">
+  import { useTrackballControls } from '@threlte/extras'
+
+  const controls = useTrackballControls()
+</script>
+
+<button onclick={() => controls.current?.reset()}>Reset camera</button>
+```

--- a/apps/docs/src/content/reference/extras/transform-controls.mdx
+++ b/apps/docs/src/content/reference/extras/transform-controls.mdx
@@ -68,6 +68,25 @@ Any object with an `enabled` property works:
 </TransformControls>
 ```
 
+## `useTransformControls`
+
+To access the underlying `TransformControls` instance from another component —
+without a `bind:controls` — use the `useTransformControls` hook. It returns a
+reactive accessor whose `current` is the instance registered by the nearest
+`<TransformControls>` within the `<Canvas>`, or `undefined` until it has mounted.
+
+```svelte title="ModeToggle.svelte"
+<script lang="ts">
+  import { useTransformControls } from '@threlte/extras'
+
+  const controls = useTransformControls()
+</script>
+
+<button onclick={() => controls.current?.setMode('translate')}>Translate</button>
+<button onclick={() => controls.current?.setMode('rotate')}>Rotate</button>
+<button onclick={() => controls.current?.setMode('scale')}>Scale</button>
+```
+
 ## Examples
 
 ### Basic usage

--- a/packages/extras/src/lib/components/CameraControls/useCameraControls.ts
+++ b/packages/extras/src/lib/components/CameraControls/useCameraControls.ts
@@ -1,0 +1,36 @@
+import type CameraControls from 'camera-controls'
+import { fromStore } from 'svelte/store'
+import { useControlsContext } from '../controls/useControlsContext.js'
+
+/**
+ * ### `useCameraControls`
+ *
+ * Access the `CameraControls` instance created by the `<CameraControls>`
+ * component mounted within the current `<Canvas>`. Useful for imperatively
+ * driving the camera (`setLookAt`, `dolly`, `rotate`, …) from sibling or
+ * parent components without a `bind:ref`.
+ *
+ * `current` is `undefined` until `<CameraControls>` has mounted, and again
+ * after it unmounts, so reads are always safe.
+ *
+ * ```svelte
+ * <script>
+ *   import { useCameraControls } from '@threlte/extras'
+ *
+ *   const controls = useCameraControls()
+ *
+ *   const frameScene = () => {
+ *     controls.current?.setLookAt(5, 5, 5, 0, 0, 0, true)
+ *   }
+ * </script>
+ * ```
+ */
+export const useCameraControls = (): { readonly current: CameraControls | undefined } => {
+  const { cameraControls } = useControlsContext()
+  const controls = fromStore(cameraControls)
+  return {
+    get current() {
+      return controls.current
+    }
+  }
+}

--- a/packages/extras/src/lib/components/controls/OrbitControls/useOrbitControls.ts
+++ b/packages/extras/src/lib/components/controls/OrbitControls/useOrbitControls.ts
@@ -1,0 +1,36 @@
+import { fromStore } from 'svelte/store'
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { useControlsContext } from '../useControlsContext.js'
+
+/**
+ * ### `useOrbitControls`
+ *
+ * Access the `OrbitControls` instance created by the `<OrbitControls>`
+ * component mounted within the current `<Canvas>`. Useful for reading or
+ * mutating the controls (`target`, `enabled`, `update`, …) from sibling or
+ * parent components without a `bind:ref`.
+ *
+ * `current` is `undefined` until `<OrbitControls>` has mounted, and again
+ * after it unmounts, so reads are always safe.
+ *
+ * ```svelte
+ * <script>
+ *   import { useOrbitControls } from '@threlte/extras'
+ *
+ *   const controls = useOrbitControls()
+ *
+ *   const reset = () => {
+ *     controls.current?.reset()
+ *   }
+ * </script>
+ * ```
+ */
+export const useOrbitControls = (): { readonly current: OrbitControls | undefined } => {
+  const { orbitControls } = useControlsContext()
+  const controls = fromStore(orbitControls)
+  return {
+    get current() {
+      return controls.current
+    }
+  }
+}

--- a/packages/extras/src/lib/components/controls/TrackballControls/useTrackballControls.ts
+++ b/packages/extras/src/lib/components/controls/TrackballControls/useTrackballControls.ts
@@ -1,0 +1,36 @@
+import { fromStore } from 'svelte/store'
+import type { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js'
+import { useControlsContext } from '../useControlsContext.js'
+
+/**
+ * ### `useTrackballControls`
+ *
+ * Access the `TrackballControls` instance created by the `<TrackballControls>`
+ * component mounted within the current `<Canvas>`. Useful for reading or
+ * mutating the controls (`target`, `enabled`, `update`, …) from sibling or
+ * parent components without a `bind:ref`.
+ *
+ * `current` is `undefined` until `<TrackballControls>` has mounted, and again
+ * after it unmounts, so reads are always safe.
+ *
+ * ```svelte
+ * <script>
+ *   import { useTrackballControls } from '@threlte/extras'
+ *
+ *   const controls = useTrackballControls()
+ *
+ *   const reset = () => {
+ *     controls.current?.reset()
+ *   }
+ * </script>
+ * ```
+ */
+export const useTrackballControls = (): { readonly current: TrackballControls | undefined } => {
+  const { trackballControls } = useControlsContext()
+  const controls = fromStore(trackballControls)
+  return {
+    get current() {
+      return controls.current
+    }
+  }
+}

--- a/packages/extras/src/lib/components/controls/TransformControls/TransformControls.svelte
+++ b/packages/extras/src/lib/components/controls/TransformControls/TransformControls.svelte
@@ -22,7 +22,12 @@
 
   const { camera, dom, invalidate, scene } = useThrelte()
 
-  const { orbitControls, trackballControls, cameraControls } = useControlsContext()
+  const {
+    orbitControls,
+    trackballControls,
+    cameraControls,
+    transformControls: transformControlsContext
+  } = useControlsContext()
 
   let isDragging = $state(false)
 
@@ -88,6 +93,13 @@
   $effect.pre(() => {
     transformControls?.attach(object ?? attachGroup)
     return () => transformControls?.detach()
+  })
+
+  $effect.pre(() => {
+    transformControlsContext.set(transformControls)
+    return () => {
+      transformControlsContext.set(undefined)
+    }
   })
 
   // This component is receiving the props for the controls as well as the props

--- a/packages/extras/src/lib/components/controls/TransformControls/useTransformControls.ts
+++ b/packages/extras/src/lib/components/controls/TransformControls/useTransformControls.ts
@@ -1,0 +1,36 @@
+import { fromStore } from 'svelte/store'
+import type { TransformControls } from 'three/examples/jsm/controls/TransformControls.js'
+import { useControlsContext } from '../useControlsContext.js'
+
+/**
+ * ### `useTransformControls`
+ *
+ * Access the `TransformControls` instance created by the `<TransformControls>`
+ * component mounted within the current `<Canvas>`. Useful for reading or
+ * mutating the controls (`setMode`, `setSpace`, `enabled`, …) from sibling or
+ * parent components without a `bind:controls`.
+ *
+ * `current` is `undefined` until `<TransformControls>` has mounted, and again
+ * after it unmounts, so reads are always safe.
+ *
+ * ```svelte
+ * <script>
+ *   import { useTransformControls } from '@threlte/extras'
+ *
+ *   const controls = useTransformControls()
+ *
+ *   const rotate = () => {
+ *     controls.current?.setMode('rotate')
+ *   }
+ * </script>
+ * ```
+ */
+export const useTransformControls = (): { readonly current: TransformControls | undefined } => {
+  const { transformControls } = useControlsContext()
+  const controls = fromStore(transformControls)
+  return {
+    get current() {
+      return controls.current
+    }
+  }
+}

--- a/packages/extras/src/lib/components/controls/useControlsContext.ts
+++ b/packages/extras/src/lib/components/controls/useControlsContext.ts
@@ -3,24 +3,35 @@ import type CameraControls from 'camera-controls'
 import { writable, type Writable } from 'svelte/store'
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import type { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js'
+import type { TransformControls } from 'three/examples/jsm/controls/TransformControls.js'
 
 type ControlsContext = {
   orbitControls: Writable<OrbitControls | undefined>
   trackballControls: Writable<TrackballControls | undefined>
   cameraControls: Writable<CameraControls | undefined>
+  transformControls: Writable<TransformControls | undefined>
 }
 
 /**
  * ### `useControlsContext`
  *
- * This hook is used to register the `OrbitControls` or `TrackballControls instance
- * with the `ControlsContext`. We're using this context to enable and disable the
- * controls when the user is interacting with the TransformControls.
+ * Internal registry of the controls instances mounted within the current
+ * `<Canvas>`. Each controls component (`<OrbitControls>`,
+ * `<TrackballControls>`, `<CameraControls>`, `<TransformControls>`) registers
+ * itself here on mount and clears its entry on unmount.
+ *
+ * It powers two things:
+ * - `<TransformControls>` reads the camera controls to enable/disable them
+ *   while a transform gizmo is being dragged.
+ * - The public `useCameraControls`, `useOrbitControls`, `useTrackballControls`
+ *   and `useTransformControls` hooks expose the registered instance to user
+ *   code.
  */
 export const useControlsContext = (): ControlsContext => {
   return useThrelteUserContext<ControlsContext>('threlte-controls', {
     orbitControls: writable<OrbitControls | undefined>(undefined),
     trackballControls: writable<TrackballControls | undefined>(undefined),
-    cameraControls: writable<CameraControls | undefined>(undefined)
+    cameraControls: writable<CameraControls | undefined>(undefined),
+    transformControls: writable<TransformControls | undefined>(undefined)
   })
 }

--- a/packages/extras/src/lib/index.ts
+++ b/packages/extras/src/lib/index.ts
@@ -20,6 +20,10 @@ export { useFollow } from './hooks/useFollow.svelte.js'
 export { useMask } from './hooks/useMask.js'
 export { useViewport } from './hooks/useViewport.svelte.js'
 export { useTrailTexture } from './hooks/useTrailTexture.svelte.js'
+export { useCameraControls } from './components/CameraControls/useCameraControls.js'
+export { useOrbitControls } from './components/controls/OrbitControls/useOrbitControls.js'
+export { useTrackballControls } from './components/controls/TrackballControls/useTrackballControls.js'
+export { useTransformControls } from './components/controls/TransformControls/useTransformControls.js'
 export { meshBounds } from './utilities/meshBounds.js'
 
 // abstractions


### PR DESCRIPTION
### Overview

This PR adds hooks to access the ref for `cameraControls`, `trackballControls`, `orbitControls` and `transformControls` extras components.

Fixes https://github.com/threlte/threlte/issues/1385