### PR TITLE
docs: replace localhost links with relative paths

### DIFF
--- a/apps/docs/src/content/blog/Building Infinite Turtles.mdx
+++ b/apps/docs/src/content/blog/Building Infinite Turtles.mdx
@@ -19,7 +19,7 @@ most well designed card game of all time but hopefully it is fun to play! In thi
 basic overview of how the game works, focusing on how the 3D scene and UI work together.
 
 If you are not familiar with Threlte it may be worth reading
-[this introduction](http://localhost:4321/docs/learn/getting-started/introduction)
+[this introduction](/docs/learn/getting-started/introduction)
 first to understand how it links Three.js and Svelte together.
 
 Lets get started...
@@ -129,7 +129,7 @@ when they are 'attacked'.
 
 We need to display the cards from this array on screen, so to do this in our `Cards.svelte`
 component we use
-[useTask](http://localhost:4321/docs/reference/core/use-task) to loop through this array every frame
+[useTask](/docs/reference/core/use-task) to loop through this array every frame
 to set the position and rotation of our 3D meshes.
 
 ## 3D Scene

--- a/apps/docs/src/content/reference/extras/portal.mdx
+++ b/apps/docs/src/content/reference/extras/portal.mdx
@@ -31,7 +31,7 @@ You can use the prop `id` to render into a `<PortalTarget>`.
 Some objects such as the [`THREE.DirectionalLightHelper`](https://threejs.org/docs/index.html#api/en/helpers/DirectionalLightHelper)
 need to be added to the scene itself to be functional.
 
-In this case, the portal target is easily accessible, and passing the `scene` object to the `<T>` component's [attach](http://localhost:4321/docs/reference/core/t#attach) property can accomplish everything we need.
+In this case, the portal target is easily accessible, and passing the `scene` object to the `<T>` component's [attach](/docs/reference/core/t#attach) property can accomplish everything we need.
 
 <Example path="extras/portals/helper" />
 

--- a/apps/docs/src/content/reference/rapier/framerate.mdx
+++ b/apps/docs/src/content/reference/rapier/framerate.mdx
@@ -74,8 +74,8 @@ In this example we're looking at two invokations of `requestAnimationFrame`.
 
 <Tip type="info">
   Threlte is making use of [the scheduler's
-  ability](/docs/learn/basics/scheduling-tasks#creating-a-stage) to run the
-  tasks of a stage multiple times per frame and with a fixed delta.
+  ability](/docs/learn/basics/scheduling-tasks#creating-a-stage) to run the tasks of a stage
+  multiple times per frame and with a fixed delta.
 </Tip>
 
 We'd like to advance the physics simulation 200 times per second, so 5ms per step.

--- a/apps/docs/src/content/reference/rapier/framerate.mdx
+++ b/apps/docs/src/content/reference/rapier/framerate.mdx
@@ -74,7 +74,7 @@ In this example we're looking at two invokations of `requestAnimationFrame`.
 
 <Tip type="info">
   Threlte is making use of [the scheduler's
-  ability](http://localhost:4321/docs/learn/basics/scheduling-tasks#creating-a-stage) to run the
+  ability](/docs/learn/basics/scheduling-tasks#creating-a-stage) to run the
   tasks of a stage multiple times per frame and with a fixed delta.
 </Tip>
 


### PR DESCRIPTION
Several docs pages contained hardcoded `http://localhost:4321` links, which are broken on the live site. This replaces them with relative `/docs/...` paths, matching the convention used by all other internal links.

Affected pages: `reference/rapier/framerate`, `reference/extras/portal`, and the "Building Infinite Turtles" blog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)