### PR TITLE
docs: add Theatre.js animation tutorial

### DIFF
--- a/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
+++ b/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
@@ -114,7 +114,7 @@ On its own, `<Theatre>` only opens the editor — nothing is animatable yet. To 
 The Theatre.js Studio now overlays the scene, with a **Box** entry in the outline on the left. Select it and drag its transform — you're editing the scene live.
 
 <Tip type="info">
-  `<Theatre>` is the convenient all-in-one wrapper. When you need more control — multiple sheets, a custom project name, or showing the studio only in development — reach for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and [`<Studio>`](/docs/reference/theatre/studio) directly. We'll use those in the last step.
+  `<Theatre>` is the convenient all-in-one wrapper. When you need more control — multiple sheets, a custom project name, or showing the studio only in development — reach for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and [`<Studio>`](/docs/reference/theatre/studio) directly — see [Where to go next](#where-to-go-next).
 </Tip>
 
 ## Syncing more properties
@@ -144,3 +144,72 @@ Here we nest `<Sync color />` inside the material, and pull `Sync` out of the sa
 />
 
 Select the **Box** in the Studio and you'll now find a **color** control alongside its transform. Everything we want to animate is now exposed — next we'll actually animate it.
+
+## Animating on the timeline
+
+With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` in the panel), and Theatre.js records a **keyframe**. Set a few keyframes at different times and you've built an animation — no code required.
+
+There's one catch for a website: while you edit, the Studio saves your work to the browser's local storage. That's great for iterating, but it isn't something you can ship. To make an animation part of your app, you **export** it and load it back in:
+
+1. In the Studio, select the project (top-left) and click **Export** — you get a `state.json` file.
+2. Drop that file next to your components.
+3. Import it and hand it to Theatre.js through the `config` prop.
+
+```svelte title="App.svelte"
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+  import state from './state.json'
+</script>
+
+<Canvas>
+  <Theatre config={{ state }}>
+    <Scene />
+  </Theatre>
+</Canvas>
+```
+
+<Example
+  path="animating-with-theatre/step-4"
+  hideCode
+/>
+
+The example above loads a `state.json` we prepared earlier — the box is keyed to spin a full turn and bob up and down over four seconds. You can see the keyframes on the timeline, but nothing is moving yet. Loading a state doesn't play it; for that we need a sequence.
+
+## Playing it back
+
+A [`<Sequence>`](/docs/reference/theatre/sequence) plays a sheet's timeline. Wrap the scene in one: `autoplay` starts it on load, and `iterationCount={Infinity}` loops it forever.
+
+```svelte title="App.svelte"
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Sequence, Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+  import state from './state.json'
+</script>
+
+<Canvas>
+  <Theatre config={{ state }}>
+    <Sequence
+      autoplay
+      iterationCount={Infinity}
+    >
+      <Scene />
+    </Sequence>
+  </Theatre>
+</Canvas>
+```
+
+<Example
+  path="animating-with-theatre/step-5"
+  hideCode
+/>
+
+That's the whole workflow: build a scene, expose the parts you care about with `<SheetObject>`, keyframe them in the Studio, export the `state.json`, and play it back with `<Sequence>`.
+
+## Where to go next
+
+- **Drive playback yourself.** `<Sequence>` exposes `bind:playing`, `bind:position`, `play` and `pause`, so you can control the animation from your own UI instead of `autoplay`. See the [`<Sequence>`](/docs/reference/theatre/sequence) reference and the [`useSequence`](/docs/reference/theatre/use-sequence) hook.
+- **Hide the Studio in production.** You usually only want the editor while developing. Swap `<Theatre>` for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and a conditionally-rendered [`<Studio>`](/docs/reference/theatre/studio).
+- **Animate more.** Anything you can wrap in a `<Sync>` can be keyframed — light intensity and colour, camera position, material roughness. Try exposing a few more properties on this scene and animating them.

--- a/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
+++ b/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
@@ -116,6 +116,16 @@ On its own, `<Theatre>` only opens the editor — nothing is animatable yet. To 
 
 The Theatre.js Studio now overlays the scene, with a **Box** entry in the outline on the left. Select it and drag its transform — you're editing the scene live.
 
+<Tip
+  type="info"
+  title="Your edits are saved locally"
+>
+  The Studio autosaves everything you change to your browser's local storage — refresh the page and
+  your edits are still there, but they're only visible to you. Press `Alt` + `\` (`Option` + `\` on
+  macOS) to hide or show the Studio UI. To reset an example to its original state, clear the site's
+  local storage (or use a private window).
+</Tip>
+
 <Tip type="info">
   `<Theatre>` is the convenient all-in-one wrapper. When you need more control — multiple sheets, a custom project name, or showing the studio only in development — reach for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and [`<Studio>`](/docs/reference/theatre/studio) directly — see [Where to go next](#where-to-go-next).
 </Tip>

--- a/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
+++ b/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
@@ -132,7 +132,7 @@ The Theatre.js Studio now overlays the scene, with a **Box** entry in the outlin
 
 ## Syncing more properties
 
-`Transform` covers position, rotation and scale — but we want to animate the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sheet-object), which bridges a specific prop of an object to the Studio.
+`Transform` covers position, rotation and scale — but we want to animate the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sync), which bridges a specific prop of an object to the Studio.
 
 Here we nest `<Sync color />` inside the material, and pull `Sync` out of the same `children` snippet:
 

--- a/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
+++ b/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
@@ -9,7 +9,10 @@ order: 2
 In this tutorial we'll build one small scene and animate it from start to finish. Along the way we'll meet every piece of the package you need for real work: [`<Theatre>`](/docs/reference/theatre/theatre), [`<SheetObject>`](/docs/reference/theatre/sheet-object), the [`<Studio>`](/docs/reference/theatre/studio), and [`<Sequence>`](/docs/reference/theatre/sequence).
 
 <Tip type="info">
-  This guide assumes you're comfortable with the [Your First Scene](/docs/learn/getting-started/your-first-scene) basics. If Theatre.js itself is new to you, the [reference getting started](/docs/reference/theatre/getting-started) page is a good companion — it covers the same components as a quick reference.
+  This guide assumes you're comfortable with the [Your First
+  Scene](/docs/learn/getting-started/your-first-scene) basics. If Theatre.js itself is new to you,
+  the [reference getting started](/docs/reference/theatre/getting-started) page is a good companion
+  — it covers the same components as a quick reference.
 </Tip>
 
 ## The starting scene

--- a/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
+++ b/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
@@ -1,0 +1,146 @@
+---
+category: Advanced
+title: Animating with Theatre.js
+order: 2
+---
+
+[Theatre.js](https://www.theatrejs.com/) is an animation library with a visual, keyframe-based editor. The [`@threlte/theatre`](/docs/reference/theatre/getting-started) package connects it to your scene: you pick the properties you want to animate, keyframe them on a timeline in the browser, and play the result back.
+
+In this tutorial we'll build one small scene and animate it from start to finish. Along the way we'll meet every piece of the package you need for real work: [`<Theatre>`](/docs/reference/theatre/theatre), [`<SheetObject>`](/docs/reference/theatre/sheet-object), the [`<Studio>`](/docs/reference/theatre/studio), and [`<Sequence>`](/docs/reference/theatre/sequence).
+
+<Tip type="info">
+  This guide assumes you're comfortable with the [Your First Scene](/docs/learn/getting-started/your-first-scene) basics. If Theatre.js itself is new to you, the [reference getting started](/docs/reference/theatre/getting-started) page is a good companion — it covers the same components as a quick reference.
+</Tip>
+
+## The starting scene
+
+Before we bring in Theatre.js, we need something to animate. Here's a plain Threlte scene: a box on a floor, lit by a single directional light, viewed from a fixed camera. Nothing here is Theatre-specific yet.
+
+```svelte title="Scene.svelte"
+<script>
+  import { T } from '@threlte/core'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<T.Mesh position.y={0.5}>
+  <T.BoxGeometry />
+  <T.MeshStandardMaterial color="#ff3e00" />
+</T.Mesh>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>
+```
+
+<Example
+  path="animating-with-theatre/step-1"
+  hideCode
+/>
+
+The `App.svelte` entry point is the usual Threlte setup — a `<Canvas>` wrapping our `Scene`. We'll return to it in the next step, because wiring in Theatre.js starts there.
+
+## Bringing in the studio
+
+Two changes turn this static scene into something we can edit: we open the Theatre.js editor, and we tell it which object it's allowed to touch.
+
+First, in `App.svelte`, wrap the scene in [`<Theatre>`](/docs/reference/theatre/theatre). This one component sets up everything we need behind the scenes — a `<Project>`, a `<Sheet>` (the timeline our animation will live on), and the `<Studio>` (the visual editor):
+
+```svelte title="App.svelte"
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+</script>
+
+<Canvas>
+  <Theatre>
+    <Scene />
+  </Theatre>
+</Canvas>
+```
+
+On its own, `<Theatre>` only opens the editor — nothing is animatable yet. To expose the box, we wrap it in a [`<SheetObject>`](/docs/reference/theatre/sheet-object). Its `key` is the name the object gets in the Studio outline. The `children` snippet hands us a `Transform` component, which puts the box's position, rotation and scale under Theatre.js's control:
+
+```svelte title="Scene.svelte"
+<script>
+  import { T } from '@threlte/core'
+  import { SheetObject } from '@threlte/theatre'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<SheetObject key="Box">
+  {#snippet children({ Transform })}
+    <Transform>
+      <T.Mesh position.y={0.5}>
+        <T.BoxGeometry />
+        <T.MeshStandardMaterial color="#ff3e00" />
+      </T.Mesh>
+    </Transform>
+  {/snippet}
+</SheetObject>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>
+```
+
+<Example
+  path="animating-with-theatre/step-2"
+  hideCode
+/>
+
+The Theatre.js Studio now overlays the scene, with a **Box** entry in the outline on the left. Select it and drag its transform — you're editing the scene live.
+
+<Tip type="info">
+  `<Theatre>` is the convenient all-in-one wrapper. When you need more control — multiple sheets, a custom project name, or showing the studio only in development — reach for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and [`<Studio>`](/docs/reference/theatre/studio) directly. We'll use those in the last step.
+</Tip>
+
+## Syncing more properties
+
+`Transform` covers position, rotation and scale — but we want to animate the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sheet-object), which bridges a specific prop of an object to the Studio.
+
+Here we nest `<Sync color />` inside the material, and pull `Sync` out of the same `children` snippet:
+
+```svelte title="Scene.svelte"
+<SheetObject key="Box">
+  {#snippet children({ Transform, Sync })}
+    <Transform>
+      <T.Mesh position.y={0.5}>
+        <T.BoxGeometry />
+        <T.MeshStandardMaterial color="#ff3e00">
+          <Sync color />
+        </T.MeshStandardMaterial>
+      </T.Mesh>
+    </Transform>
+  {/snippet}
+</SheetObject>
+```
+
+<Example
+  path="animating-with-theatre/step-3"
+  hideCode
+/>
+
+Select the **Box** in the Studio and you'll now find a **color** control alongside its transform. Everything we want to animate is now exposed — next we'll actually animate it.

--- a/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
+++ b/apps/docs/src/content/learn/advanced/animating-with-theatre.mdx
@@ -122,8 +122,9 @@ The Theatre.js Studio now overlays the scene, with a **Box** entry in the outlin
 >
   The Studio autosaves everything you change to your browser's local storage — refresh the page and
   your edits are still there, but they're only visible to you. Press `Alt` + `\` (`Option` + `\` on
-  macOS) to hide or show the Studio UI. To reset an example to its original state, clear the site's
-  local storage (or use a private window).
+  macOS) to hide or show the Studio UI — one of several handy [keyboard
+  shortcuts](https://www.theatrejs.com/docs/latest/manual/keyboard-shortcuts). To reset an example
+  to its original state, clear the site's local storage (or use a private window).
 </Tip>
 
 <Tip type="info">
@@ -160,9 +161,9 @@ Select the **Box** in the Studio and you'll now find a **color** control alongsi
 
 ## Animating on the timeline
 
-With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` in the panel), and Theatre.js records a **keyframe**. Set a few keyframes at different times and you've built an animation — no code required.
+With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` in the panel), and Theatre.js records a **keyframe**. Set a few keyframes at different times and you've built an animation — no code required. The Theatre.js manual has a full guide to [adding and removing keyframes](https://www.theatrejs.com/docs/latest/manual/sequences#addingremoving-keyframes).
 
-There's one catch for a website: while you edit, the Studio saves your work to the browser's local storage. That's great for iterating, but it isn't something you can ship. To make an animation part of your app, you **export** it and load it back in:
+There's one catch for a website: while you edit, the Studio saves your work to the browser's local storage. That's great for iterating, but it isn't something you can ship. To make an animation part of your app, you [**export**](https://www.theatrejs.com/docs/latest/manual/projects#state) it and load it back in:
 
 1. In the Studio, select the project (top-left) and click **Export** — you get a `state.json` file.
 2. Drop that file next to your components.

--- a/apps/docs/src/content/reference/theatre/getting-started.mdx
+++ b/apps/docs/src/content/reference/theatre/getting-started.mdx
@@ -92,4 +92,4 @@ In your Scene, add the component `<SheetObject>` as a parent of any component yo
 </SheetObject>
 ```
 
-You will now see the Theatre.js studio interface. Make yourself comfortable with the controls and if you haven't done yet, please read the Theatre.js [studio manual](https://www.theatrejs.com/docs/0.5/manual/Studio) and [keyboard shortcuts](https://www.theatrejs.com/docs/0.5/manual/keyboard-shortcuts).
+You will now see the Theatre.js studio interface. Make yourself comfortable with the controls and if you haven't done yet, please read the Theatre.js [studio manual](https://www.theatrejs.com/docs/latest/manual/studio) and [keyboard shortcuts](https://www.theatrejs.com/docs/latest/manual/keyboard-shortcuts).

--- a/apps/docs/src/content/reference/theatre/sequence.mdx
+++ b/apps/docs/src/content/reference/theatre/sequence.mdx
@@ -84,7 +84,7 @@ Currently, you can only have one sequence in each sheet. Future versions of Thea
 
 #### Theatre.js Docs
 
-**Sequence** | [Sequence Manual](https://www.theatrejs.com/docs/latest/manual/sequences) | [Sequence API Reference](https://www.theatrejs.com/docs/0.5/api/core#sequence)
+**Sequence** | [Sequence Manual](https://www.theatrejs.com/docs/latest/manual/sequences) | [Sequence API Reference](https://www.theatrejs.com/docs/latest/api/core#sequence)
 
 ## Usage
 
@@ -100,7 +100,7 @@ Note that the underlying Theatre.js sheets are persisted even when unmounting a 
 
 ## Audio
 
-The audio options allow you to attach a soundtrack to your animation sequence. Theatre.js achieves this using the [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API). For more details, see [audio manual](https://www.theatrejs.com/docs/0.5/manual/audio) and [attach audio API reference](https://www.theatrejs.com/docs/0.5/api/core#sequence.attachaudio_opts_)
+The audio options allow you to attach a soundtrack to your animation sequence. Theatre.js achieves this using the [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API). For more details, see [audio manual](https://www.theatrejs.com/docs/latest/manual/audio) and [attach audio API reference](https://www.theatrejs.com/docs/latest/api/core#sequence.attachaudio_opts_)
 
 ## Snippet Prop
 

--- a/apps/docs/src/content/reference/theatre/sheet-object-action.mdx
+++ b/apps/docs/src/content/reference/theatre/sheet-object-action.mdx
@@ -11,9 +11,9 @@ The `createSheetObjectAction` hook allows you to animate DOM elements through a 
 
 #### Theatre.js Docs
 
-**Sheet Object** | [Sheet Object Manual](https://www.theatrejs.com/docs/latest/manual/objects) | [Sheet Object API Reference](https://www.theatrejs.com/docs/0.5/api/core#sheet.object)
+**Sheet Object** | [Sheet Object Manual](https://www.theatrejs.com/docs/latest/manual/objects) | [Sheet Object API Reference](https://www.theatrejs.com/docs/latest/api/core#object)
 
-**Prop Types** | [Prop Types Manual](https://www.theatrejs.com/docs/latest/manual/prop-types) | [Prop Types API reference](https://www.theatrejs.com/docs/0.5/api/core#prop-types)
+**Prop Types** | [Prop Types Manual](https://www.theatrejs.com/docs/latest/manual/prop-types) | [Prop Types API reference](https://www.theatrejs.com/docs/latest/api/core#prop-types)
 
 ## Usage
 
@@ -71,6 +71,6 @@ The action takes the following arguments:
 
 key (string) - The key of the object, shown in the studio UI (may be [namespaced with slashes](https://www.theatrejs.com/docs/latest/manual/objects#namespacing-objects))
 
-props (Props) - Declaration of your props and their types (see Theatre.js [manual entry](https://www.theatrejs.com/docs/latest/manual/prop-types) and [API reference](https://www.theatrejs.com/docs/0.5/api/core#prop-types))
+props (Props) - Declaration of your props and their types (see Theatre.js [manual entry](https://www.theatrejs.com/docs/latest/manual/prop-types) and [API reference](https://www.theatrejs.com/docs/latest/api/core#prop-types))
 
 callback ((node: HTMLElement, props: Props) => void) - A callback function called to update the HTMLElement node whenever the prop changes.

--- a/apps/docs/src/content/reference/theatre/sheet.mdx
+++ b/apps/docs/src/content/reference/theatre/sheet.mdx
@@ -20,7 +20,7 @@ The animated objects can adjusted in the [`<Studio>`](/docs/reference/theatre/st
 
 #### Theatre.js Docs
 
-**Sheet** | [Sheet Manual](https://www.theatrejs.com/docs/latest/manual/sheets) | [Sheet API Reference](https://www.theatrejs.com/docs/0.5/api/core#sheet)
+**Sheet** | [Sheet Manual](https://www.theatrejs.com/docs/latest/manual/sheets) | [Sheet API Reference](https://www.theatrejs.com/docs/latest/api/core#sheet)
 
 ## Creating Sheets
 

--- a/apps/docs/src/content/reference/theatre/your-first-animation.mdx
+++ b/apps/docs/src/content/reference/theatre/your-first-animation.mdx
@@ -131,7 +131,7 @@ The Theatre.js Studio now overlays the scene, with a **Box** entry in the outlin
 
 ## Syncing more properties
 
-`Transform` covers position, rotation and scale — but we want to animate the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sync), which bridges a specific prop of an object to the Studio.
+`Transform` covers position, rotation and scale — but we can expose the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sync), which bridges a specific prop of an object to the Studio.
 
 Here we nest `<Sync color />` inside the material, and pull `Sync` out of the same `children` snippet:
 

--- a/apps/docs/src/content/reference/theatre/your-first-animation.mdx
+++ b/apps/docs/src/content/reference/theatre/your-first-animation.mdx
@@ -4,15 +4,13 @@ category: '@threlte/theatre'
 title: 'Your First Animation'
 ---
 
-[Theatre.js](https://www.theatrejs.com/) is an animation library with a visual, keyframe-based editor. The [`@threlte/theatre`](/docs/reference/theatre/getting-started) package connects it to your scene: you pick the properties you want to animate, keyframe them on a timeline in the browser, and play the result back.
-
 In this tutorial we'll build one small scene and animate it from start to finish. Along the way we'll meet every piece of the package you need for real work: [`<Theatre>`](/docs/reference/theatre/theatre), [`<SheetObject>`](/docs/reference/theatre/sheet-object), the [`<Studio>`](/docs/reference/theatre/studio), and [`<Sequence>`](/docs/reference/theatre/sequence).
 
 <Tip type="info">
   This guide assumes you're comfortable with the [Your First
   Scene](/docs/learn/getting-started/your-first-scene) basics. For installation and a quick
-  component-by-component overview of `@threlte/theatre`, see [Getting
-  Started](/docs/reference/theatre/getting-started), directly above this page.
+  component-by-component overview of `@threlte/theatre`, see the [Getting
+  Started](/docs/reference/theatre/getting-started) page.
 </Tip>
 
 ## The starting scene
@@ -51,13 +49,13 @@ Before we bring in Theatre.js, we need something to animate. Here's a plain Thre
   hideCode
 />
 
-The `App.svelte` entry point is the usual Threlte setup — a `<Canvas>` wrapping our `Scene`. We'll return to it in the next step, because wiring in Theatre.js starts there.
+The `App.svelte` entry point is the usual Threlte setup — a `<Canvas>` wrapping our `<Scene>`. We'll return to it in the next step, because wiring in Theatre.js starts there.
 
 ## Bringing in the studio
 
-Two changes turn this static scene into something we can edit: we open the Theatre.js editor, and we tell it which object it's allowed to touch.
+Two changes turn this static scene into something we can edit for animations: the Theatre.js editor, and telling Theatre.js which objects it's allowed to touch.
 
-First, in `App.svelte`, wrap the scene in [`<Theatre>`](/docs/reference/theatre/theatre). This one component sets up everything we need behind the scenes — a `<Project>`, a `<Sheet>` (the timeline our animation will live on), and the `<Studio>` (the visual editor):
+First, in `App.svelte`, wrap the scene in the [`<Theatre>`](/docs/reference/theatre/theatre) component. This one component sets up everything we need behind the scenes — a `<Project>`, a `<Sheet>` (the timeline our animation will live on), and the `<Studio>` (the visual editor):
 
 ```svelte title="App.svelte"
 <script>
@@ -73,7 +71,7 @@ First, in `App.svelte`, wrap the scene in [`<Theatre>`](/docs/reference/theatre/
 </Canvas>
 ```
 
-On its own, `<Theatre>` only opens the editor — nothing is animatable yet. To expose the box, we wrap it in a [`<SheetObject>`](/docs/reference/theatre/sheet-object). Its `key` is the name the object gets in the Studio outline. The `children` snippet hands us a `Transform` component, which puts the box's position, rotation and scale under Theatre.js's control:
+On its own, `<Theatre>` only opens the editor — nothing is animatable yet. To expose the box, we wrap it in a [`<SheetObject>`](/docs/reference/theatre/sheet-object). Its `key` is the name the object gets in the [Studio outline](https://www.theatrejs.com/docs/latest/manual/Studio). The `children` snippet hands us a `Transform` component, which puts the box's position, rotation and scale under Theatre.js's control:
 
 ```svelte title="Scene.svelte"
 <script>
@@ -124,11 +122,11 @@ The Theatre.js Studio now overlays the scene, with a **Box** entry in the outlin
   your edits are still there, but they're only visible to you. Press `Alt` + `\` (`Option` + `\` on
   macOS) to hide or show the Studio UI — one of several handy [keyboard
   shortcuts](https://www.theatrejs.com/docs/latest/manual/keyboard-shortcuts). To reset an example
-  to its original state, clear the site's local storage (or use a private window).
+  to its original state, clear the site's local storage.
 </Tip>
 
 <Tip type="info">
-  `<Theatre>` is the convenient all-in-one wrapper. When you need more control — multiple sheets, a custom project name, or showing the studio only in development — reach for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and [`<Studio>`](/docs/reference/theatre/studio) directly — see [Where to go next](#where-to-go-next).
+  `<Theatre>` is the convenient all-in-one wrapper. When you need more control — multiple sheets, a custom project name, or showing the studio only in development — reach for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and [`<Studio>`](/docs/reference/theatre/studio) directly.
 </Tip>
 
 ## Syncing more properties
@@ -161,13 +159,13 @@ Select the **Box** in the Studio and you'll now find a **color** control alongsi
 
 ## Animating on the timeline
 
-With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` in the panel), and Theatre.js records a **keyframe**. Set a few keyframes at different times and you've built an animation — no code required. The Theatre.js manual has a full guide to [adding and removing keyframes](https://www.theatrejs.com/docs/latest/manual/sequences#addingremoving-keyframes).
+With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` in the panel), and Theatre.js records a **keyframe**. [Add keyframes](https://www.theatrejs.com/docs/latest/manual/sequences#addingremoving-keyframes) at different times and you've built an animation.
 
 There's one catch for a website: while you edit, the Studio saves your work to the browser's local storage. That's great for iterating, but it isn't something you can ship. To make an animation part of your app, you [**export**](https://www.theatrejs.com/docs/latest/manual/projects#state) it and load it back in:
 
-1. In the Studio, select the project (top-left) and click **Export** — you get a `state.json` file.
-2. Drop that file next to your components.
-3. Import it and hand it to Theatre.js through the `config` prop.
+- In the Studio, select the project (top-left) and click **Export** — you get a `state.json` file.
+- Drop that file next to your components.
+- Import it and hand it to Theatre.js through the `config` prop.
 
 ```svelte title="App.svelte"
 <script>
@@ -227,3 +225,4 @@ That's the whole workflow: build a scene, expose the parts you care about with `
 - **Drive playback yourself.** `<Sequence>` exposes `bind:playing`, `bind:position`, `play` and `pause`, so you can control the animation from your own UI instead of `autoplay`. See the [`<Sequence>`](/docs/reference/theatre/sequence) reference and the [`useSequence`](/docs/reference/theatre/use-sequence) hook.
 - **Hide the Studio in production.** You usually only want the editor while developing. Swap `<Theatre>` for [`<Project>`](/docs/reference/theatre/project), [`<Sheet>`](/docs/reference/theatre/sheet) and a conditionally-rendered [`<Studio>`](/docs/reference/theatre/studio).
 - **Animate more.** Anything you can wrap in a `<Sync>` can be keyframed — light intensity and colour, camera position, material roughness. Try exposing a few more properties on this scene and animating them.
+- **Adjust the tween** between keyframes. There's some neat options to play with in the [tween editor](https://www.theatrejs.com/docs/latest/manual/sequences#using-the-tween-editor).

--- a/apps/docs/src/content/reference/theatre/your-first-animation.mdx
+++ b/apps/docs/src/content/reference/theatre/your-first-animation.mdx
@@ -1,7 +1,7 @@
 ---
-category: Advanced
-title: Animating with Theatre.js
-order: 2
+order: 0.5
+category: '@threlte/theatre'
+title: 'Your First Animation'
 ---
 
 [Theatre.js](https://www.theatrejs.com/) is an animation library with a visual, keyframe-based editor. The [`@threlte/theatre`](/docs/reference/theatre/getting-started) package connects it to your scene: you pick the properties you want to animate, keyframe them on a timeline in the browser, and play the result back.
@@ -10,9 +10,9 @@ In this tutorial we'll build one small scene and animate it from start to finish
 
 <Tip type="info">
   This guide assumes you're comfortable with the [Your First
-  Scene](/docs/learn/getting-started/your-first-scene) basics. If Theatre.js itself is new to you,
-  the [reference getting started](/docs/reference/theatre/getting-started) page is a good companion
-  — it covers the same components as a quick reference.
+  Scene](/docs/learn/getting-started/your-first-scene) basics. For installation and a quick
+  component-by-component overview of `@threlte/theatre`, see [Getting
+  Started](/docs/reference/theatre/getting-started), directly above this page.
 </Tip>
 
 ## The starting scene

--- a/apps/docs/src/content/reference/theatre/your-first-animation.mdx
+++ b/apps/docs/src/content/reference/theatre/your-first-animation.mdx
@@ -131,7 +131,7 @@ The Theatre.js Studio now overlays the scene, with a **Box** entry in the outlin
 
 ## Syncing more properties
 
-`Transform` covers position, rotation and scale — but we can expose the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sync), which bridges a specific prop of an object to the Studio.
+`Transform` covers position, rotation and scale — but we want to animate the box's **colour** too. For any property that isn't a transform, we use [`<Sync>`](/docs/reference/theatre/sync), which bridges a specific prop of an object to the Studio.
 
 Here we nest `<Sync color />` inside the material, and pull `Sync` out of the same `children` snippet:
 
@@ -159,7 +159,7 @@ Select the **Box** in the Studio and you'll now find a **color** control alongsi
 
 ## Animating on the timeline
 
-With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` in the panel), and Theatre.js records a **keyframe**. [Add keyframes](https://www.theatrejs.com/docs/latest/manual/sequences#addingremoving-keyframes) at different times and you've built an animation.
+With the box's properties exposed, we can author an animation. In the Studio, select the **Box**, then use the timeline at the bottom: move the playhead to a point in time, change a value (drag the box in the viewport, or edit `position` / `rotation` / `color` in the panel), and Theatre.js records a **keyframe**. [Add keyframes](https://www.theatrejs.com/docs/latest/manual/sequences#addingremoving-keyframes) at different times and you've built an animation.
 
 There's one catch for a website: while you edit, the Studio saves your work to the browser's local storage. That's great for iterating, but it isn't something you can ship. To make an animation part of your app, you [**export**](https://www.theatrejs.com/docs/latest/manual/projects#state) it and load it back in:
 

--- a/apps/docs/src/examples/animating-with-theatre/step-1/App.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-1/App.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Canvas } from '@threlte/core'
+  import Scene from './Scene.svelte'
+</script>
+
+<div>
+  <Canvas>
+    <Scene />
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/animating-with-theatre/step-1/Scene.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-1/Scene.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { T } from '@threlte/core'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<T.Mesh position.y={0.5}>
+  <T.BoxGeometry />
+  <T.MeshStandardMaterial color="#ff3e00" />
+</T.Mesh>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>

--- a/apps/docs/src/examples/animating-with-theatre/step-2/App.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-2/App.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+</script>
+
+<div>
+  <Canvas>
+    <Theatre>
+      <Scene />
+    </Theatre>
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/animating-with-theatre/step-2/Scene.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-2/Scene.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { T } from '@threlte/core'
+  import { SheetObject } from '@threlte/theatre'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<SheetObject key="Box">
+  {#snippet children({ Transform })}
+    <Transform>
+      <T.Mesh position.y={0.5}>
+        <T.BoxGeometry />
+        <T.MeshStandardMaterial color="#ff3e00" />
+      </T.Mesh>
+    </Transform>
+  {/snippet}
+</SheetObject>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>

--- a/apps/docs/src/examples/animating-with-theatre/step-3/App.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-3/App.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+</script>
+
+<div>
+  <Canvas>
+    <Theatre>
+      <Scene />
+    </Theatre>
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/animating-with-theatre/step-3/Scene.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-3/Scene.svelte
@@ -1,0 +1,33 @@
+<script>
+  import { T } from '@threlte/core'
+  import { SheetObject } from '@threlte/theatre'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<SheetObject key="Box">
+  {#snippet children({ Transform, Sync })}
+    <Transform>
+      <T.Mesh position.y={0.5}>
+        <T.BoxGeometry />
+        <T.MeshStandardMaterial color="#ff3e00">
+          <Sync color />
+        </T.MeshStandardMaterial>
+      </T.Mesh>
+    </Transform>
+  {/snippet}
+</SheetObject>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>

--- a/apps/docs/src/examples/animating-with-theatre/step-4/App.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-4/App.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+  import state from './state.json'
+</script>
+
+<div>
+  <Canvas>
+    <Theatre config={{ state }}>
+      <Scene />
+    </Theatre>
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/animating-with-theatre/step-4/Scene.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-4/Scene.svelte
@@ -1,0 +1,33 @@
+<script>
+  import { T } from '@threlte/core'
+  import { SheetObject } from '@threlte/theatre'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<SheetObject key="Box">
+  {#snippet children({ Transform, Sync })}
+    <Transform>
+      <T.Mesh position.y={0.5}>
+        <T.BoxGeometry />
+        <T.MeshStandardMaterial color="#ff3e00">
+          <Sync color />
+        </T.MeshStandardMaterial>
+      </T.Mesh>
+    </Transform>
+  {/snippet}
+</SheetObject>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>

--- a/apps/docs/src/examples/animating-with-theatre/step-4/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-4/state.json
@@ -1,0 +1,47 @@
+{
+  "sheetsById": {
+    "default": {
+      "staticOverrides": {
+        "byObject": {
+          "Box": {
+            "color": { "r": 1, "g": 0.243, "b": 0, "a": 1 }
+          }
+        }
+      },
+      "sequence": {
+        "subUnitsPerUnit": 30,
+        "length": 4,
+        "type": "PositionalSequence",
+        "tracksByObject": {
+          "Box": {
+            "trackData": {
+              "rotationY": {
+                "type": "BasicKeyframedTrack",
+                "__debugName": "Box:[\"rotation\",\"y\"]",
+                "keyframes": [
+                  { "id": "kf_rot_0", "position": 0, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 0 },
+                  { "id": "kf_rot_1", "position": 4, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 6.283185307179586 }
+                ]
+              },
+              "positionY": {
+                "type": "BasicKeyframedTrack",
+                "__debugName": "Box:[\"position\",\"y\"]",
+                "keyframes": [
+                  { "id": "kf_pos_0", "position": 0, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 },
+                  { "id": "kf_pos_1", "position": 2, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 1 },
+                  { "id": "kf_pos_2", "position": 4, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 }
+                ]
+              }
+            },
+            "trackIdByPropPath": {
+              "[\"rotation\",\"y\"]": "rotationY",
+              "[\"position\",\"y\"]": "positionY"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitionVersion": "0.4.0",
+  "revisionHistory": ["thob-theatre-tutorial-r1"]
+}

--- a/apps/docs/src/examples/animating-with-theatre/step-4/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-4/state.json
@@ -4,7 +4,12 @@
       "staticOverrides": {
         "byObject": {
           "Box": {
-            "color": { "r": 1, "g": 0.243, "b": 0, "a": 1 }
+            "color": {
+              "r": 1,
+              "g": 0.243,
+              "b": 0,
+              "a": 1
+            }
           }
         }
       },
@@ -66,11 +71,57 @@
                     "value": 0
                   }
                 ]
+              },
+              "V2bfL5vQNa": {
+                "type": "BasicKeyframedTrack",
+                "__debugName": "Box:[\"color\"]",
+                "keyframes": [
+                  {
+                    "id": "TFQuSgEpEP",
+                    "position": 0,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": {
+                      "r": 1,
+                      "g": 0.23921568627450981,
+                      "b": 0,
+                      "a": 1
+                    }
+                  },
+                  {
+                    "id": "Zo94DBRYtK",
+                    "position": 2,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": {
+                      "r": 0.29411764705882354,
+                      "g": 0.27450980392156865,
+                      "b": 1,
+                      "a": 1
+                    }
+                  },
+                  {
+                    "id": "GsjviFU9hx",
+                    "position": 4,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": {
+                      "r": 1,
+                      "g": 0.23921568627450981,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ]
               }
             },
             "trackIdByPropPath": {
               "[\"rotation\",\"y\"]": "rotationY",
-              "[\"position\",\"y\"]": "positionY"
+              "[\"position\",\"y\"]": "positionY",
+              "[\"color\"]": "V2bfL5vQNa"
             }
           }
         }
@@ -78,5 +129,5 @@
     }
   },
   "definitionVersion": "0.4.0",
-  "revisionHistory": ["theatre-tutorial-r1"]
+  "revisionHistory": ["tmMIDB6oCJ16jsqe", "theatre-tutorial-r1"]
 }

--- a/apps/docs/src/examples/animating-with-theatre/step-4/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-4/state.json
@@ -33,7 +33,7 @@
                     "connectedRight": true,
                     "handles": [0.333, 0.333, 0.667, 0.667],
                     "type": "bezier",
-                    "value": 6.283185307179586
+                    "value": 360
                   }
                 ]
               },
@@ -78,5 +78,5 @@
     }
   },
   "definitionVersion": "0.4.0",
-  "revisionHistory": ["thob-theatre-tutorial-r1"]
+  "revisionHistory": ["theatre-tutorial-r1"]
 }

--- a/apps/docs/src/examples/animating-with-theatre/step-4/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-4/state.json
@@ -19,17 +19,52 @@
                 "type": "BasicKeyframedTrack",
                 "__debugName": "Box:[\"rotation\",\"y\"]",
                 "keyframes": [
-                  { "id": "kf_rot_0", "position": 0, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 0 },
-                  { "id": "kf_rot_1", "position": 4, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 6.283185307179586 }
+                  {
+                    "id": "kf_rot_0",
+                    "position": 0,
+                    "connectedRight": true,
+                    "handles": [0.333, 0.333, 0.667, 0.667],
+                    "type": "bezier",
+                    "value": 0
+                  },
+                  {
+                    "id": "kf_rot_1",
+                    "position": 4,
+                    "connectedRight": true,
+                    "handles": [0.333, 0.333, 0.667, 0.667],
+                    "type": "bezier",
+                    "value": 6.283185307179586
+                  }
                 ]
               },
               "positionY": {
                 "type": "BasicKeyframedTrack",
                 "__debugName": "Box:[\"position\",\"y\"]",
                 "keyframes": [
-                  { "id": "kf_pos_0", "position": 0, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 },
-                  { "id": "kf_pos_1", "position": 2, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 1 },
-                  { "id": "kf_pos_2", "position": 4, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 }
+                  {
+                    "id": "kf_pos_0",
+                    "position": 0,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": 0
+                  },
+                  {
+                    "id": "kf_pos_1",
+                    "position": 2,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": 1
+                  },
+                  {
+                    "id": "kf_pos_2",
+                    "position": 4,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": 0
+                  }
                 ]
               }
             },

--- a/apps/docs/src/examples/animating-with-theatre/step-5/App.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-5/App.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { Canvas } from '@threlte/core'
+  import { Sequence, Theatre } from '@threlte/theatre'
+  import Scene from './Scene.svelte'
+  import state from './state.json'
+</script>
+
+<div>
+  <Canvas>
+    <Theatre config={{ state }}>
+      <Sequence
+        autoplay
+        iterationCount={Infinity}
+      >
+        <Scene />
+      </Sequence>
+    </Theatre>
+  </Canvas>
+</div>
+
+<style>
+  div {
+    height: 100%;
+  }
+</style>

--- a/apps/docs/src/examples/animating-with-theatre/step-5/Scene.svelte
+++ b/apps/docs/src/examples/animating-with-theatre/step-5/Scene.svelte
@@ -1,0 +1,33 @@
+<script>
+  import { T } from '@threlte/core'
+  import { SheetObject } from '@threlte/theatre'
+</script>
+
+<T.PerspectiveCamera
+  makeDefault
+  position={[5, 5, 5]}
+  oncreate={(ref) => {
+    ref.lookAt(0, 0, 0)
+  }}
+/>
+
+<T.DirectionalLight position={[3, 10, 7]} />
+<T.AmbientLight intensity={0.4} />
+
+<SheetObject key="Box">
+  {#snippet children({ Transform, Sync })}
+    <Transform>
+      <T.Mesh position.y={0.5}>
+        <T.BoxGeometry />
+        <T.MeshStandardMaterial color="#ff3e00">
+          <Sync color />
+        </T.MeshStandardMaterial>
+      </T.Mesh>
+    </Transform>
+  {/snippet}
+</SheetObject>
+
+<T.Mesh rotation.x={-Math.PI / 2}>
+  <T.CircleGeometry args={[4, 48]} />
+  <T.MeshStandardMaterial color="white" />
+</T.Mesh>

--- a/apps/docs/src/examples/animating-with-theatre/step-5/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-5/state.json
@@ -1,0 +1,47 @@
+{
+  "sheetsById": {
+    "default": {
+      "staticOverrides": {
+        "byObject": {
+          "Box": {
+            "color": { "r": 1, "g": 0.243, "b": 0, "a": 1 }
+          }
+        }
+      },
+      "sequence": {
+        "subUnitsPerUnit": 30,
+        "length": 4,
+        "type": "PositionalSequence",
+        "tracksByObject": {
+          "Box": {
+            "trackData": {
+              "rotationY": {
+                "type": "BasicKeyframedTrack",
+                "__debugName": "Box:[\"rotation\",\"y\"]",
+                "keyframes": [
+                  { "id": "kf_rot_0", "position": 0, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 0 },
+                  { "id": "kf_rot_1", "position": 4, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 6.283185307179586 }
+                ]
+              },
+              "positionY": {
+                "type": "BasicKeyframedTrack",
+                "__debugName": "Box:[\"position\",\"y\"]",
+                "keyframes": [
+                  { "id": "kf_pos_0", "position": 0, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 },
+                  { "id": "kf_pos_1", "position": 2, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 1 },
+                  { "id": "kf_pos_2", "position": 4, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 }
+                ]
+              }
+            },
+            "trackIdByPropPath": {
+              "[\"rotation\",\"y\"]": "rotationY",
+              "[\"position\",\"y\"]": "positionY"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitionVersion": "0.4.0",
+  "revisionHistory": ["thob-theatre-tutorial-r1"]
+}

--- a/apps/docs/src/examples/animating-with-theatre/step-5/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-5/state.json
@@ -4,7 +4,12 @@
       "staticOverrides": {
         "byObject": {
           "Box": {
-            "color": { "r": 1, "g": 0.243, "b": 0, "a": 1 }
+            "color": {
+              "r": 1,
+              "g": 0.243,
+              "b": 0,
+              "a": 1
+            }
           }
         }
       },
@@ -66,11 +71,57 @@
                     "value": 0
                   }
                 ]
+              },
+              "V2bfL5vQNa": {
+                "type": "BasicKeyframedTrack",
+                "__debugName": "Box:[\"color\"]",
+                "keyframes": [
+                  {
+                    "id": "TFQuSgEpEP",
+                    "position": 0,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": {
+                      "r": 1,
+                      "g": 0.23921568627450981,
+                      "b": 0,
+                      "a": 1
+                    }
+                  },
+                  {
+                    "id": "Zo94DBRYtK",
+                    "position": 2,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": {
+                      "r": 0.29411764705882354,
+                      "g": 0.27450980392156865,
+                      "b": 1,
+                      "a": 1
+                    }
+                  },
+                  {
+                    "id": "GsjviFU9hx",
+                    "position": 4,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": {
+                      "r": 1,
+                      "g": 0.23921568627450981,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ]
               }
             },
             "trackIdByPropPath": {
               "[\"rotation\",\"y\"]": "rotationY",
-              "[\"position\",\"y\"]": "positionY"
+              "[\"position\",\"y\"]": "positionY",
+              "[\"color\"]": "V2bfL5vQNa"
             }
           }
         }
@@ -78,5 +129,5 @@
     }
   },
   "definitionVersion": "0.4.0",
-  "revisionHistory": ["theatre-tutorial-r1"]
+  "revisionHistory": ["tmMIDB6oCJ16jsqe", "theatre-tutorial-r1"]
 }

--- a/apps/docs/src/examples/animating-with-theatre/step-5/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-5/state.json
@@ -33,7 +33,7 @@
                     "connectedRight": true,
                     "handles": [0.333, 0.333, 0.667, 0.667],
                     "type": "bezier",
-                    "value": 6.283185307179586
+                    "value": 360
                   }
                 ]
               },
@@ -78,5 +78,5 @@
     }
   },
   "definitionVersion": "0.4.0",
-  "revisionHistory": ["thob-theatre-tutorial-r1"]
+  "revisionHistory": ["theatre-tutorial-r1"]
 }

--- a/apps/docs/src/examples/animating-with-theatre/step-5/state.json
+++ b/apps/docs/src/examples/animating-with-theatre/step-5/state.json
@@ -19,17 +19,52 @@
                 "type": "BasicKeyframedTrack",
                 "__debugName": "Box:[\"rotation\",\"y\"]",
                 "keyframes": [
-                  { "id": "kf_rot_0", "position": 0, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 0 },
-                  { "id": "kf_rot_1", "position": 4, "connectedRight": true, "handles": [0.333, 0.333, 0.667, 0.667], "type": "bezier", "value": 6.283185307179586 }
+                  {
+                    "id": "kf_rot_0",
+                    "position": 0,
+                    "connectedRight": true,
+                    "handles": [0.333, 0.333, 0.667, 0.667],
+                    "type": "bezier",
+                    "value": 0
+                  },
+                  {
+                    "id": "kf_rot_1",
+                    "position": 4,
+                    "connectedRight": true,
+                    "handles": [0.333, 0.333, 0.667, 0.667],
+                    "type": "bezier",
+                    "value": 6.283185307179586
+                  }
                 ]
               },
               "positionY": {
                 "type": "BasicKeyframedTrack",
                 "__debugName": "Box:[\"position\",\"y\"]",
                 "keyframes": [
-                  { "id": "kf_pos_0", "position": 0, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 },
-                  { "id": "kf_pos_1", "position": 2, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 1 },
-                  { "id": "kf_pos_2", "position": 4, "connectedRight": true, "handles": [0.5, 1, 0.5, 0], "type": "bezier", "value": 0 }
+                  {
+                    "id": "kf_pos_0",
+                    "position": 0,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": 0
+                  },
+                  {
+                    "id": "kf_pos_1",
+                    "position": 2,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": 1
+                  },
+                  {
+                    "id": "kf_pos_2",
+                    "position": 4,
+                    "connectedRight": true,
+                    "handles": [0.5, 1, 0.5, 0],
+                    "type": "bezier",
+                    "value": 0
+                  }
                 ]
               }
             },


### PR DESCRIPTION
Adds an introductory tutorial for `@threlte/theatre` under Learn → Advanced
(`/docs/learn/advanced/animating-with-theatre`).

The tutorial builds one small scene and animates it end to end, with a runnable
example embedded at each step:

1. a plain Threlte scene — box on a floor, one light, fixed camera
2. wrapping the app in `<Theatre>` and making the box editable with `<SheetObject>` + `Transform`
3. exposing a non-transform property with `<Sync color />`
4. keyframing in the Studio, then exporting `state.json` and loading it back via `config`
5. playing it back with `<Sequence>` (`autoplay`, looping) — plus pointers for driving playback manually and hiding the Studio in production

It also fixes one link along the way: the `<Sync>` mention in the text now points
at the `<Sync>` reference page instead of the `<SheetObject>` page.

Audio coverage is left for a follow-up, per the issue thread.

Docs-only, no changeset.

Closes #549