### PR TITLE
docs: correct stale prop shapes in the rapier reference

### DIFF
--- a/apps/docs/src/content/reference/rapier/auto-colliders.mdx
+++ b/apps/docs/src/content/reference/rapier/auto-colliders.mdx
@@ -6,7 +6,7 @@ sourcePath: 'packages/rapier/src/lib/components/Colliders/AutoColliders/AutoColl
 type: 'component'
 componentSignature:
   {
-    pretext: "If a <code>&lt;AutoColliders&gt;</code> component is not a child of a <code>&lt;RigidBody&gt;</code> component, the transform properties are reactive.<br /><br />If you don't provide any of the properties <code>density</code>, <code>mass</code> or <code>massProperties</code>, Rapier will figure that out for you.<br /><br />You can provide either a property <code>density</code>, <code>mass</code> <strong>or</strong> <code>massProperties</code>.",
+    pretext: "If a <code>&lt;AutoColliders&gt;</code> component is not a child of a <code>&lt;RigidBody&gt;</code> component, the transform properties are reactive.<br /><br />If you don't provide any of the properties <code>density</code>, <code>mass</code> or the full mass properties, Rapier will figure that out for you.<br /><br />Provide <code>density</code> on its own, <code>mass</code> on its own, <strong>or</strong> <code>mass</code> together with <code>centerOfMass</code>, <code>principalAngularInertia</code> and <code>angularInertiaLocalFrame</code>.",
     props:
       [
         {
@@ -16,12 +16,9 @@ componentSignature:
         },
         { name: 'density', type: 'number' },
         { name: 'mass', type: 'number' },
-        { name: 'massProperties', type: '{
-            mass: number,
-            centerOfMass: Position,
-            principalAngularInertia: Position,
-            angularInertiaLocalFrame: Rotation,
-            }' },
+        { name: 'centerOfMass', type: '[number, number, number]' },
+        { name: 'principalAngularInertia', type: '[number, number, number]' },
+        { name: 'angularInertiaLocalFrame', type: '[number, number, number]' },
         { name: 'restitution', type: 'number' },
         { name: 'restitutionCombineRule', type: 'CoefficientCombineRule' },
         { name: 'friction', type: 'number' },

--- a/apps/docs/src/content/reference/rapier/collider.mdx
+++ b/apps/docs/src/content/reference/rapier/collider.mdx
@@ -6,7 +6,7 @@ title: '<Collider>'
 type: 'component'
 componentSignature:
   {
-    pretext: "If a <code>&lt;Collider&gt;</code> component is not a child of a <code>&lt;RigidBody&gt;</code> component, the transform properties are reactive.<br /><br />If you don't provide any of the properties <code>density</code>, <code>mass</code> or <code>massProperties</code>, Rapier will figure that out for you.<br /><br />You can provide either a property <code>density</code>, <code>mass</code> <strong>or</strong> <code>massProperties</code>.",
+    pretext: "If a <code>&lt;Collider&gt;</code> component is not a child of a <code>&lt;RigidBody&gt;</code> component, the transform properties are reactive.<br /><br />If you don't provide any of the properties <code>density</code>, <code>mass</code> or the full mass properties, Rapier will figure that out for you.<br /><br />Provide <code>density</code> on its own, <code>mass</code> on its own, <strong>or</strong> <code>mass</code> together with <code>centerOfMass</code>, <code>principalAngularInertia</code> and <code>angularInertiaLocalFrame</code>.",
     props:
       [
         {
@@ -17,12 +17,9 @@ componentSignature:
         { name: 'args', type: 'Parameters<typeof ColliderDesc[Shape]>', required: true },
         { name: 'density',  type: 'number' },
         { name: 'mass',  type: 'number' },
-        { name: 'massProperties',  type: '{
-            mass: number,
-            centerOfMass: Position,
-            principalAngularInertia: Position,
-            angularInertiaLocalFrame: Rotation,
-            }' },
+        { name: 'centerOfMass',  type: '[number, number, number]' },
+        { name: 'principalAngularInertia',  type: '[number, number, number]' },
+        { name: 'angularInertiaLocalFrame',  type: '[number, number, number]' },
         { name: 'restitution',  type: 'number' },
         { name: 'restitutionCombineRule',  type: 'CoefficientCombineRule' },
         { name: 'friction',  type: 'number' },

--- a/apps/docs/src/content/reference/rapier/rigid-body.mdx
+++ b/apps/docs/src/content/reference/rapier/rigid-body.mdx
@@ -14,8 +14,8 @@ componentSignature:
           default: "'dynamic'"
         },
         { name: 'canSleep', type: 'boolean', default: 'true' },
-        { name: 'linearVelocity', type: 'Position', default: '{}' },
-        { name: 'angularVelocity', type: 'Rotation', default: '{}' },
+        { name: 'linearVelocity', type: '[number, number, number]', default: '[0, 0, 0]' },
+        { name: 'angularVelocity', type: '[number, number, number]', default: '[0, 0, 0]' },
         { name: 'gravityScale', type: 'number', default: '1' },
         { name: 'ccd', type: 'boolean', default: 'false' },
         { name: 'lockRotations', type: 'boolean', default: 'false' },

--- a/apps/docs/src/content/reference/rapier/use-fixed-joint.mdx
+++ b/apps/docs/src/content/reference/rapier/use-fixed-joint.mdx
@@ -42,9 +42,9 @@ const {
 	rigidBodyA: Writable<RAPIER.RigidBody>
 	rigidBodyB: Writable<RAPIER.RigidBody>
 } = useFixedJoint(
-	anchorA,  // Position
-  frameA,   // Rotation
-  anchorB,  // Position
-  frameB    // Rotation
+	anchorA,  // [number, number, number]
+  frameA,   // [number, number, number] | Euler
+  anchorB,  // [number, number, number]
+  frameB    // [number, number, number] | Euler
 )
 ```

--- a/apps/docs/src/content/reference/rapier/use-prismatic-joint.mdx
+++ b/apps/docs/src/content/reference/rapier/use-prismatic-joint.mdx
@@ -42,9 +42,9 @@ const {
 	rigidBodyA: Writable<RAPIER.RigidBody>
 	rigidBodyB: Writable<RAPIER.RigidBody>
 } = usePrismaticJoint(
-	anchorA,  // Position
-  anchorB,  // Position
-  axis,     // Rotation
+	anchorA,  // [number, number, number] | Vector3
+  anchorB,  // [number, number, number] | Vector3
+  axis,     // [number, number, number] | Vector3
   limits    // [min, max] | undefined
 )
 ```

--- a/apps/docs/src/content/reference/rapier/use-revolute-joint.mdx
+++ b/apps/docs/src/content/reference/rapier/use-revolute-joint.mdx
@@ -42,9 +42,9 @@ const {
 	rigidBodyA: Writable<RAPIER.RigidBody>
 	rigidBodyB: Writable<RAPIER.RigidBody>
 } = useRevoluteJoint(
-	anchorA,  // Position
-  anchorB,  // Position
-  axis,     // Rotation
+	anchorA,  // [number, number, number] | Vector3
+  anchorB,  // [number, number, number] | Vector3
+  axis,     // [number, number, number] | Vector3
   limits    // [min, max] | undefined
 )
 ```

--- a/apps/docs/src/content/reference/rapier/use-rope-joint.mdx
+++ b/apps/docs/src/content/reference/rapier/use-rope-joint.mdx
@@ -41,8 +41,8 @@ const {
 	rigidBodyA: Writable<RAPIER.RigidBody>
 	rigidBodyB: Writable<RAPIER.RigidBody>
 } = useRopeJoint(
-	anchorA,  // Position
-  anchorB,  // Position
+	anchorA,  // [number, number, number] | Vector3
+  anchorB,  // [number, number, number] | Vector3
 	length    // Length of the rope
 )
 ```

--- a/apps/docs/src/content/reference/rapier/use-spherical-joint.mdx
+++ b/apps/docs/src/content/reference/rapier/use-spherical-joint.mdx
@@ -42,7 +42,7 @@ const {
 	rigidBodyA: Writable<RAPIER.RigidBody>
 	rigidBodyB: Writable<RAPIER.RigidBody>
 } = useSphericalJoint(
-	anchorA,  // Position
-  anchorB,  // Position
+	anchorA,  // [number, number, number] | Vector3
+  anchorB,  // [number, number, number] | Vector3
 )
 ```

--- a/apps/docs/src/content/reference/rapier/world.mdx
+++ b/apps/docs/src/content/reference/rapier/world.mdx
@@ -10,7 +10,7 @@ componentSignature:
       [
         { name: 'framerate', type: "number | 'varying'", default: "'varying'" },
         { name: 'autoStart', type: 'boolean', default: 'true' },
-        { name: 'gravity', type: 'Position', default: '{ y: -9.81 }' },
+        { name: 'gravity', type: '[number, number, number]', default: '[0, -9.81, 0]' },
         {
           name: 'simulationStageOptions',
           type: '{ before?: (Key | Stage) | (Key | Stage)[]; after?: (Key | Stage) | (Key | Stage)[] }'


### PR DESCRIPTION
Closes #1842.

Three commits, one per category of error:

- **Tuple props** — `gravity`, `linearVelocity` and `angularVelocity` are read positionally from an array. The documented `Position` / `Rotation` object shapes stopped working when those types were removed, and passing one yields `undefined` components with nothing logged.
- **`massProperties`** — there is no such prop. `MassDef` exposes `mass`, `centerOfMass`, `principalAngularInertia` and `angularInertiaLocalFrame` as flat, mutually exclusive props on both `<Collider>` and `<AutoColliders>`. The pretext on both pages is corrected to match.
- **Joint hooks** — anchors and frames documented as the tuple-or-instance unions they actually are. This also corrects `axis` on the revolute and prismatic pages, which was labelled `Rotation` but is a direction vector.

Everything was checked against the source rather than inferred. Prettier and the docs build are green.

I have a small A/B example that toggles each prop between its documented and real shape and reads the values back out of Rapier each frame — happy to add it as a docs example or regression aid if that's useful, but I've left it out to keep this PR to the correction itself.
