### PR TITLE
[threlte/extras] Fix portal insertion order

### DIFF
--- a/.changeset/cozy-results-tap.md
+++ b/.changeset/cozy-results-tap.md
@@ -1,0 +1,5 @@
+---
+"@threlte/extras": patch
+---
+
+Fix portal insertion order

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],

--- a/packages/extras/eslint.config.js
+++ b/packages/extras/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],

--- a/packages/extras/src/lib/components/portals/Portal.svelte
+++ b/packages/extras/src/lib/components/portals/Portal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte'
+  import { untrack, type Snippet } from 'svelte'
   import { usePortalContext } from './usePortalContext.svelte.js'
   import { SvelteSet } from 'svelte/reactivity'
 
@@ -25,13 +25,16 @@
 
     const currentId = id
 
-    if (!portals.has(currentId)) {
-      portals.set(currentId, new SvelteSet())
-    }
+    return untrack(() => {
+      let contents = portals.get(currentId)
 
-    portals.get(currentId)?.add(children)
-    return () => {
-      portals.get(currentId)?.delete(children)
-    }
+      if (contents === undefined) {
+        contents = new SvelteSet()
+        portals.set(currentId, contents)
+      }
+
+      contents.add(children)
+      return () => contents.delete(children)
+    })
   })
 </script>

--- a/packages/extras/src/lib/components/portals/__tests__/__fixtures__/PortalOrder.svelte
+++ b/packages/extras/src/lib/components/portals/__tests__/__fixtures__/PortalOrder.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { T } from '@threlte/core'
+  import Portal from '../../Portal.svelte'
+  import PortalTarget from '../../PortalTarget.svelte'
+</script>
+
+<PortalTarget />
+
+<Portal>
+  <T.Group name="first" />
+</Portal>
+
+<Portal>
+  <T.Group name="second" />
+</Portal>

--- a/packages/extras/src/lib/components/portals/__tests__/portal.spec.ts
+++ b/packages/extras/src/lib/components/portals/__tests__/portal.spec.ts
@@ -1,0 +1,18 @@
+import { render } from '@threlte/test'
+import { tick } from 'svelte'
+import type { Object3D } from 'three'
+import { describe, expect, it } from 'vitest'
+import PortalOrder from './__fixtures__/PortalOrder.svelte'
+
+describe('<Portal>', () => {
+  it('renders portal children in insertion order', async () => {
+    const { scene } = render(PortalOrder)
+
+    await tick()
+
+    expect(scene.children.map((child: Object3D) => child.name).filter(Boolean)).toEqual([
+      'first',
+      'second'
+    ])
+  })
+})

--- a/packages/flex/eslint.config.js
+++ b/packages/flex/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],

--- a/packages/rapier/eslint.config.js
+++ b/packages/rapier/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],

--- a/packages/studio/eslint.config.js
+++ b/packages/studio/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],

--- a/packages/theatre/eslint.config.js
+++ b/packages/theatre/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],

--- a/packages/xr/eslint.config.js
+++ b/packages/xr/eslint.config.js
@@ -20,7 +20,7 @@ export default ts.config(
   },
   {
     name: 'ignores',
-    ignores: ['.svelte-kit']
+    ignores: ['.svelte-kit/**', 'build/**', 'package/**', 'dist/**', 'coverage/**', '.turbo/**']
   },
   {
     files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],


### PR DESCRIPTION
Fixes <Portal> insertion order by untracking portal registry mutations, preventing the first portal child from being re-added after later children. Adds a regression test for multiple portals rendering to the same target in order.